### PR TITLE
ci: disable auto-release until PYPI_TOKEN set; fix PSR build_command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  # Auto-release on merge to main is DISABLED until the PYPI_TOKEN secret is set.
+  # Without it, semantic-release would tag + create a GitHub Release and then fail
+  # at `uv publish`, leaving a release for a version never on PyPI. Re-enable by
+  # uncommenting the push trigger once PYPI_TOKEN exists (see migration tracker).
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
 
 concurrency:
   group: release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,9 +210,10 @@ dependencies = [
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 commit_parser = "conventional"
-build_command = "uv build"
 # Suppress PSR's own build step (we run `uv build` separately in the workflow)
-# so that the action only handles versioning, changelog, and tagging.
+# so the action only handles versioning, changelog, and tagging. `uv` is not on
+# PATH inside the PSR action container, so a non-empty build_command exits 127.
+build_command = false
 upload_to_vcs_release = true
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
Stops the failing Release workflow on every merge to main.

## Why
PR #2 merged the release scaffolding, but `PYPI_TOKEN` is not configured yet. Two problems surfaced on the first merges:

1. **`build_command = "uv build"` exits 127** — the python-semantic-release action runs in its own container where `uv` is not on PATH. PSR aborted at the build step (which, by luck, prevented a tokenless publish). The workflow already has its own `Build`/`Publish` steps, so PSR should not build. Set `build_command = false` (matches the existing comment's intent).
2. **No `PYPI_TOKEN`** — once the build bug is fixed, the next merge would cut a real release (backlog of feat/fix commits since `v1.3.2`), tag it, create a GitHub Release, then fail at `uv publish` — leaving a release for a version never on PyPI.

## Change
- Comment out the `push` trigger on `release.yml`; keep `workflow_dispatch` for manual testing.
- Fix `build_command`.

## Re-enable
After adding the `PYPI_TOKEN` secret: uncomment the push trigger. The first release will bundle everything since `v1.3.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)