### PR TITLE
feat(results): upload to the base_url used for inference (RES-912)

### DIFF
--- a/src/evaluatorq/common/llm_client.py
+++ b/src/evaluatorq/common/llm_client.py
@@ -64,6 +64,27 @@ def client_routes_through_orq(client: AsyncOpenAI | None) -> bool:
     return str(base_url).rstrip("/").endswith(ORQ_ROUTER_SUFFIX)
 
 
+def resolve_results_base_url(
+    client: AsyncOpenAI | None = None,
+    *,
+    default_orq_host: str = ORQ_DEFAULT_HOST,
+) -> str:
+    """Resolve the Orq host that results should be uploaded to.
+
+    Prefers the host of the client actually used for inference when it routes
+    through the Orq router — so a staging/custom Orq endpoint receives both the
+    inference traffic and the results — stripping the ``/v3/router`` suffix to
+    get the bare host. A non-Orq client (e.g. direct OpenAI) is ignored: uploads
+    always go to Orq, never to the inference provider. Falls back to
+    ``ORQ_BASE_URL`` / ``default_orq_host`` when no Orq-routed client is given,
+    preserving the original env-based behaviour.
+    """
+    if client_routes_through_orq(client):
+        host = str(client.base_url).rstrip("/")  # pyright: ignore[reportOptionalMemberAccess]
+        return host[: -len(ORQ_ROUTER_SUFFIX)].rstrip("/")
+    return os.environ.get("ORQ_BASE_URL", default_orq_host).rstrip("/")
+
+
 def resolve_llm_client(
     config_client: AsyncOpenAI | None = None,
     *,
@@ -145,4 +166,5 @@ __all__ = [
     "ResolvedClient",
     "client_routes_through_orq",
     "resolve_llm_client",
+    "resolve_results_base_url",
 ]

--- a/src/evaluatorq/common/llm_client.py
+++ b/src/evaluatorq/common/llm_client.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, NamedTuple
 
+from loguru import logger
+
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
@@ -81,8 +83,12 @@ def resolve_results_base_url(
     """
     if client_routes_through_orq(client):
         host = str(client.base_url).rstrip("/")  # pyright: ignore[reportOptionalMemberAccess]
-        return host[: -len(ORQ_ROUTER_SUFFIX)].rstrip("/")
-    return os.environ.get("ORQ_BASE_URL", default_orq_host).rstrip("/")
+        resolved = host[: -len(ORQ_ROUTER_SUFFIX)].rstrip("/")
+        logger.debug("Results upload host resolved from inference client: {}", resolved)
+        return resolved
+    resolved = os.environ.get("ORQ_BASE_URL", default_orq_host).rstrip("/")
+    logger.debug("Results upload host resolved from env/default: {}", resolved)
+    return resolved
 
 
 def resolve_llm_client(

--- a/src/evaluatorq/evaluatorq.py
+++ b/src/evaluatorq/evaluatorq.py
@@ -64,6 +64,7 @@ async def evaluatorq(
     path: str | None = None,
     _exit_on_failure: bool = True,
     _send_results: bool = True,
+    _base_url: str | None = None,
     _trace_type: str = "evaluatorq",
 ) -> EvaluatorqResult:
     """
@@ -316,6 +317,7 @@ async def evaluatorq(
             start_time,
             datetime.now(timezone.utc),
             path=path,
+            base_url=_base_url,
         )
 
     # Shutdown tracing gracefully

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -19,6 +19,7 @@ from loguru import logger
 
 from evaluatorq import DataPoint, EvaluationResult, job
 from evaluatorq.common.async_utils import await_maybe, warn_if_sync_hooks
+from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.common.messages import coerce_content_text
 from evaluatorq.common.tracing import set_span_attrs
 from evaluatorq.contracts import AgentTarget, Message
@@ -162,7 +163,6 @@ async def _send_cleaned_results(
     used (RES-912). Falls back to ``ORQ_BASE_URL`` / the default when it is not
     an Orq-routed client.
     """
-    from evaluatorq.common.llm_client import resolve_results_base_url
     api_key = os.environ.get('ORQ_API_KEY')
     if not api_key:
         logger.debug('Skipping result upload to Orq platform: ORQ_API_KEY not set')
@@ -186,6 +186,9 @@ async def _send_cleaned_results(
         return
 
     logger.debug(f'Sending {len(cleaned)} cleaned results to Orq platform (stripped from {len(results)} raw)')
+    # Resolve the upload host before the try, so a resolution failure surfaces on
+    # its own rather than being caught below and mislabelled as an upload failure.
+    upload_base_url = resolve_results_base_url(inference_client)
     try:
         experiment_url = await send_results_to_orq(
             api_key=api_key,
@@ -195,7 +198,7 @@ async def _send_cleaned_results(
             results=cleaned,
             start_time=start_time,
             end_time=datetime.now(tz=timezone.utc),
-            base_url=resolve_results_base_url(inference_client),
+            base_url=upload_base_url,
         )
         if report is not None and experiment_url:
             report.experiment_url = experiment_url
@@ -2286,8 +2289,9 @@ async def _run_dynamic_or_hybrid(
                 description=description or f'{mode.capitalize()} red teaming ({len(all_target_labels)} targets)',
                 start_time=pipeline_start,
                 report=merged,
-                # All targets share one resolved attacker/inference client, so the
-                # first prepared target is representative of the Orq host to upload to.
+                # The attacker LLM client — the same Orq host that owns the
+                # ORQ_API_KEY used for this run, shared across all prepared
+                # targets, so the first one is representative of the upload host.
                 inference_client=prepared_targets[0].resolved_llm_client if prepared_targets else None,
             )
         finally:

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -2286,6 +2286,8 @@ async def _run_dynamic_or_hybrid(
                 description=description or f'{mode.capitalize()} red teaming ({len(all_target_labels)} targets)',
                 start_time=pipeline_start,
                 report=merged,
+                # All targets share one resolved attacker/inference client, so the
+                # first prepared target is representative of the Orq host to upload to.
                 inference_client=prepared_targets[0].resolved_llm_client if prepared_targets else None,
             )
         finally:

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -144,6 +144,7 @@ async def _send_cleaned_results(
     description: str,
     start_time: datetime,
     report: RedTeamReport | None = None,
+    inference_client: AsyncOpenAI | None = None,
 ) -> None:
     """Strip skipped job results and upload to the Orq platform.
 
@@ -155,7 +156,13 @@ async def _send_cleaned_results(
 
     If *report* is provided, ``report.experiment_url`` is set to the URL
     returned by the platform on a successful upload.
+
+    ``inference_client`` is the client used for inference; its Orq host is
+    resolved once and forwarded so results upload to the same server inference
+    used (RES-912). Falls back to ``ORQ_BASE_URL`` / the default when it is not
+    an Orq-routed client.
     """
+    from evaluatorq.common.llm_client import resolve_results_base_url
     api_key = os.environ.get('ORQ_API_KEY')
     if not api_key:
         logger.debug('Skipping result upload to Orq platform: ORQ_API_KEY not set')
@@ -188,6 +195,7 @@ async def _send_cleaned_results(
             results=cleaned,
             start_time=start_time,
             end_time=datetime.now(tz=timezone.utc),
+            base_url=resolve_results_base_url(inference_client),
         )
         if report is not None and experiment_url:
             report.experiment_url = experiment_url
@@ -2278,6 +2286,7 @@ async def _run_dynamic_or_hybrid(
                 description=description or f'{mode.capitalize()} red teaming ({len(all_target_labels)} targets)',
                 start_time=pipeline_start,
                 report=merged,
+                inference_client=prepared_targets[0].resolved_llm_client if prepared_targets else None,
             )
         finally:
             _save_report(output_dir, '03_summary_report.json', merged)
@@ -2616,6 +2625,7 @@ async def _run_static(
             description=description or f'Static red teaming ({len(all_target_labels)} targets)',
             start_time=pipeline_start,
             report=merged,
+            inference_client=llm_client,
         )
     finally:
         _save_report(output_dir, '03_summary_report.json', merged)

--- a/src/evaluatorq/send_results.py
+++ b/src/evaluatorq/send_results.py
@@ -7,6 +7,7 @@ import httpx
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from .common.llm_client import ORQ_DEFAULT_HOST
 from .types import DataPointResult, EvaluatorqResult
 
 
@@ -92,9 +93,7 @@ async def send_results_to_orq(
             results=results,
         )
 
-        # Prefer an explicit base_url (e.g. the host used for inference); fall
-        # back to the environment or the default host.
-        resolved_base_url = (base_url or os.getenv("ORQ_BASE_URL", "https://my.orq.ai")).rstrip("/")
+        resolved_base_url = (base_url or os.getenv("ORQ_BASE_URL", ORQ_DEFAULT_HOST)).rstrip("/")
 
         # Serialize with aliases, stripping None on optional fields (the API
         # rejects null for ``error``, ``explanation``, etc.) but keeping

--- a/src/evaluatorq/send_results.py
+++ b/src/evaluatorq/send_results.py
@@ -50,6 +50,7 @@ async def send_results_to_orq(
     end_time: datetime,
     *,
     path: str | None = None,
+    base_url: str | None = None,
     raise_on_error: bool = False,
 ) -> str | None:
     """
@@ -65,6 +66,10 @@ async def send_results_to_orq(
         end_time: When the evaluation ended
         path: Optional path (e.g. "MyProject/MyFolder") to place the experiment
               in a specific project and folder on the Orq platform.
+        base_url: Optional Orq host to upload to (e.g. a staging server). When
+              omitted, falls back to the ``ORQ_BASE_URL`` env var, then to
+              ``https://my.orq.ai``. Lets callers route results to the same
+              server used for inference.
         raise_on_error: Raise upload errors instead of treating upload as best-effort.
 
     Returns:
@@ -87,8 +92,9 @@ async def send_results_to_orq(
             results=results,
         )
 
-        # Get base URL from environment or use default.
-        base_url = os.getenv("ORQ_BASE_URL", "https://my.orq.ai").rstrip("/")
+        # Prefer an explicit base_url (e.g. the host used for inference); fall
+        # back to the environment or the default host.
+        resolved_base_url = (base_url or os.getenv("ORQ_BASE_URL", "https://my.orq.ai")).rstrip("/")
 
         # Serialize with aliases, stripping None on optional fields (the API
         # rejects null for ``error``, ``explanation``, etc.) but keeping
@@ -116,7 +122,7 @@ async def send_results_to_orq(
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
-                f"{base_url}/v2/spreadsheets/evaluations/receive",
+                f"{resolved_base_url}/v2/spreadsheets/evaluations/receive",
                 headers={
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {api_key}",

--- a/src/evaluatorq/send_results.py
+++ b/src/evaluatorq/send_results.py
@@ -94,6 +94,7 @@ async def send_results_to_orq(
         )
 
         resolved_base_url = (base_url or os.getenv("ORQ_BASE_URL", ORQ_DEFAULT_HOST)).rstrip("/")
+        logger.debug("Uploading results to {}", resolved_base_url)
 
         # Serialize with aliases, stripping None on optional fields (the API
         # rejects null for ``error``, ``explanation``, etc.) but keeping

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -17,6 +17,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, DEFAULT_MODEL
 from evaluatorq.simulation.utils.run_store import auto_save_run, build_simulation_run, write_report
 
@@ -912,8 +913,6 @@ async def _simulate_via_evaluatorq(
 
     # Resolve the Orq host once from the inference client so results upload to
     # the same server used for inference (RES-912); falls back to env.
-    from evaluatorq.common.llm_client import resolve_results_base_url
-
     upload_base_url = resolve_results_base_url(generation_client)
 
     try:

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -910,6 +910,12 @@ async def _simulate_via_evaluatorq(
     start = datetime.now(tz=timezone.utc)
     run_name = evaluation_name or f'simulation-{start.strftime("%Y%m%d-%H%M%S")}-{uuid.uuid4().hex[:8]}'
 
+    # Resolve the Orq host once from the inference client so results upload to
+    # the same server used for inference (RES-912); falls back to env.
+    from evaluatorq.common.llm_client import resolve_results_base_url
+
+    upload_base_url = resolve_results_base_url(generation_client)
+
     try:
         eq_results = await evaluatorq(
             run_name,
@@ -921,6 +927,7 @@ async def _simulate_via_evaluatorq(
             path=orq_results_path,
             _send_results=upload_results,
             _exit_on_failure=exit_on_failure,
+            _base_url=upload_base_url,
         )
     finally:
         # Close the runner, then any target that owns resources (e.g.

--- a/tests/common/test_llm_client.py
+++ b/tests/common/test_llm_client.py
@@ -4,23 +4,30 @@ from __future__ import annotations
 
 import os
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 from evaluatorq.common.llm_client import ORQ_DEFAULT_HOST, resolve_results_base_url
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+
+def _client(base_url: str) -> AsyncOpenAI:
+    """A duck-typed stand-in: resolve_results_base_url only reads ``.base_url``."""
+    return cast("AsyncOpenAI", cast(object, SimpleNamespace(base_url=base_url)))
 
 
 def test_prefers_orq_routed_client_host_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """An Orq-routed inference client wins over ORQ_BASE_URL so results land on
     the same server inference used, even when the env points elsewhere."""
     monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai")
-    client = SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router")
-    assert resolve_results_base_url(client) == "https://my.staging.orq.ai"
+    assert resolve_results_base_url(_client("https://my.staging.orq.ai/v3/router")) == "https://my.staging.orq.ai"
 
 
 def test_strips_router_suffix_with_trailing_slash() -> None:
-    client = SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router/")
-    assert resolve_results_base_url(client) == "https://my.staging.orq.ai"
+    assert resolve_results_base_url(_client("https://my.staging.orq.ai/v3/router/")) == "https://my.staging.orq.ai"
 
 
 def test_falls_back_to_env_when_no_client(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,5 +44,4 @@ def test_non_orq_client_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> No
     """A direct-OpenAI inference client must not redirect uploads at OpenAI;
     uploads always go to Orq, resolved from env."""
     monkeypatch.setenv("ORQ_BASE_URL", "https://my.staging.orq.ai")
-    client = SimpleNamespace(base_url="https://api.openai.com/v1")
-    assert resolve_results_base_url(client) == "https://my.staging.orq.ai"
+    assert resolve_results_base_url(_client("https://api.openai.com/v1")) == "https://my.staging.orq.ai"

--- a/tests/common/test_llm_client.py
+++ b/tests/common/test_llm_client.py
@@ -1,0 +1,41 @@
+"""Tests for resolve_results_base_url — the upload host resolver (RES-912)."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from evaluatorq.common.llm_client import ORQ_DEFAULT_HOST, resolve_results_base_url
+
+
+def test_prefers_orq_routed_client_host_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An Orq-routed inference client wins over ORQ_BASE_URL so results land on
+    the same server inference used, even when the env points elsewhere."""
+    monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai")
+    client = SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router")
+    assert resolve_results_base_url(client) == "https://my.staging.orq.ai"
+
+
+def test_strips_router_suffix_with_trailing_slash() -> None:
+    client = SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router/")
+    assert resolve_results_base_url(client) == "https://my.staging.orq.ai"
+
+
+def test_falls_back_to_env_when_no_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORQ_BASE_URL", "https://my.staging.orq.ai")
+    assert resolve_results_base_url(None) == "https://my.staging.orq.ai"
+
+
+def test_falls_back_to_default_when_no_client_and_no_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ORQ_BASE_URL", raising=False)
+    assert resolve_results_base_url(None) == ORQ_DEFAULT_HOST
+
+
+def test_non_orq_client_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A direct-OpenAI inference client must not redirect uploads at OpenAI;
+    uploads always go to Orq, resolved from env."""
+    monkeypatch.setenv("ORQ_BASE_URL", "https://my.staging.orq.ai")
+    client = SimpleNamespace(base_url="https://api.openai.com/v1")
+    assert resolve_results_base_url(client) == "https://my.staging.orq.ai"

--- a/tests/redteam/test_send_cleaned_results.py
+++ b/tests/redteam/test_send_cleaned_results.py
@@ -112,3 +112,45 @@ async def test_upload_exception_does_not_break_report() -> None:
             report=report,
         )
     assert report.experiment_url is None
+
+
+@pytest.mark.asyncio
+async def test_forwards_inference_client_base_url() -> None:
+    """RES-912: the Orq host used for inference is forwarded to the upload so
+    results land on the same server (e.g. staging)."""
+    from types import SimpleNamespace
+
+    report = _make_report()
+    spy = AsyncMock(return_value=None)
+    client = SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router")
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch("evaluatorq.redteam.runner.send_results_to_orq", spy),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+            inference_client=client,  # type: ignore[arg-type]
+        )
+    assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"
+
+
+@pytest.mark.asyncio
+async def test_base_url_falls_back_to_env_without_client() -> None:
+    report = _make_report()
+    spy = AsyncMock(return_value=None)
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test", "ORQ_BASE_URL": "https://my.staging.orq.ai"}),
+        patch("evaluatorq.redteam.runner.send_results_to_orq", spy),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"

--- a/tests/redteam/test_send_cleaned_results.py
+++ b/tests/redteam/test_send_cleaned_results.py
@@ -6,11 +6,16 @@ import os
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from evaluatorq.redteam.contracts import Pipeline, RedTeamReport, ReportSummary
 from evaluatorq.redteam.runner import _send_cleaned_results
 from evaluatorq.types import DataPoint, DataPointResult, JobResult
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
 
 
 def _make_report() -> RedTeamReport:
@@ -119,10 +124,11 @@ async def test_forwards_inference_client_base_url() -> None:
     """RES-912: the Orq host used for inference is forwarded to the upload so
     results land on the same server (e.g. staging)."""
     from types import SimpleNamespace
+    from typing import cast
 
     report = _make_report()
     spy = AsyncMock(return_value=None)
-    client = SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router")
+    client = cast("AsyncOpenAI", cast(object, SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router")))
     with (
         patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
         patch("evaluatorq.redteam.runner.send_results_to_orq", spy),
@@ -133,8 +139,9 @@ async def test_forwards_inference_client_base_url() -> None:
             description="d",
             start_time=datetime.now(tz=timezone.utc),
             report=report,
-            inference_client=client,  # type: ignore[arg-type]
+            inference_client=client,
         )
+    assert spy.await_args is not None
     assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"
 
 
@@ -153,4 +160,5 @@ async def test_base_url_falls_back_to_env_without_client() -> None:
             start_time=datetime.now(tz=timezone.utc),
             report=report,
         )
+    assert spy.await_args is not None
     assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"

--- a/tests/simulation/test_upload_base_url.py
+++ b/tests/simulation/test_upload_base_url.py
@@ -55,4 +55,5 @@ async def test_sim_forwards_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -
             exit_on_failure=False,
         )
 
+    assert spy.await_args is not None
     assert spy.await_args.kwargs["_base_url"] == "https://my.staging.orq.ai"

--- a/tests/simulation/test_upload_base_url.py
+++ b/tests/simulation/test_upload_base_url.py
@@ -1,0 +1,58 @@
+"""RES-912: agent sim forwards the inference base_url to the results upload."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from evaluatorq.simulation.types import (
+    CommunicationStyle,
+    Datapoint,
+    Message,
+    Persona,
+    Scenario,
+)
+
+
+def _make_datapoint() -> Datapoint:
+    return Datapoint(
+        id="dp-001",
+        persona=Persona(
+            name="P",
+            patience=0.5,
+            assertiveness=0.5,
+            politeness=0.5,
+            technical_level=0.5,
+            communication_style=CommunicationStyle.casual,
+            background="b",
+        ),
+        scenario=Scenario(name="S", goal="g"),
+        user_system_prompt="system",
+        first_message="hi",
+    )
+
+
+async def _target(messages: list[Message]) -> str:
+    return "ok"
+
+
+@pytest.mark.asyncio
+async def test_sim_forwards_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORQ_API_KEY", "test")
+    monkeypatch.setenv("ORQ_BASE_URL", "https://my.staging.orq.ai")
+
+    from evaluatorq.simulation.api import simulate
+
+    spy = AsyncMock(return_value=[])
+    with patch("evaluatorq.evaluatorq.evaluatorq", spy):
+        await simulate(
+            target=_target,
+            datapoints=[_make_datapoint()],
+            sim_model="test",
+            max_turns=1,
+            exit_on_failure=False,
+        )
+
+    assert spy.await_args.kwargs["_base_url"] == "https://my.staging.orq.ai"

--- a/tests/simulation/test_upload_base_url.py
+++ b/tests/simulation/test_upload_base_url.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any
+import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+import evaluatorq.evaluatorq  # noqa: F401  populate sys.modules; the package attr is shadowed by the function
+
+# evaluatorq.evaluatorq resolves to the re-exported function, not the submodule,
+# so patch the module object directly (3.10's mock can't resolve the shadowed path).
+_EQ_MOD = sys.modules["evaluatorq.evaluatorq"]
 
 from evaluatorq.simulation.types import (
     CommunicationStyle,
@@ -46,7 +52,7 @@ async def test_sim_forwards_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -
     from evaluatorq.simulation.api import simulate
 
     spy = AsyncMock(return_value=[])
-    with patch("evaluatorq.evaluatorq.evaluatorq", spy):
+    with patch.object(_EQ_MOD, "evaluatorq", spy):
         await simulate(
             target=_target,
             datapoints=[_make_datapoint()],

--- a/tests/simulation/test_upload_base_url.py
+++ b/tests/simulation/test_upload_base_url.py
@@ -63,3 +63,32 @@ async def test_sim_forwards_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -
 
     assert spy.await_args is not None
     assert spy.await_args.kwargs["_base_url"] == "https://my.staging.orq.ai"
+
+
+@pytest.mark.asyncio
+async def test_sim_forwards_base_url_from_injected_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An injected Orq-routed generation_client wins over ORQ_BASE_URL — results
+    upload to the host the injected inference client actually uses."""
+    from types import SimpleNamespace
+    from typing import Any, cast
+
+    monkeypatch.setenv("ORQ_API_KEY", "test")
+    monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai")  # env points at prod
+
+    from evaluatorq.simulation.api import simulate
+
+    client = cast("Any", SimpleNamespace(base_url="https://my.staging.orq.ai/v3/router"))
+    spy = AsyncMock(return_value=[])
+    with patch.object(_EQ_MOD, "evaluatorq", spy):
+        await simulate(
+            target=_target,
+            datapoints=[_make_datapoint()],
+            sim_model="test",
+            max_turns=1,
+            exit_on_failure=False,
+            generation_client=client,
+        )
+
+    assert spy.await_args is not None
+    # client host wins over the prod env var
+    assert spy.await_args.kwargs["_base_url"] == "https://my.staging.orq.ai"

--- a/tests/test_evaluatorq_base_url.py
+++ b/tests/test_evaluatorq_base_url.py
@@ -29,6 +29,7 @@ async def test_forwards_base_url_to_upload() -> None:
             print_results=False,
             _base_url="https://my.staging.orq.ai",
         )
+    assert spy.await_args is not None
     assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"
 
 
@@ -46,4 +47,5 @@ async def test_base_url_defaults_to_none() -> None:
             jobs=[_job],
             print_results=False,
         )
+    assert spy.await_args is not None
     assert spy.await_args.kwargs.get("base_url") is None

--- a/tests/test_evaluatorq_base_url.py
+++ b/tests/test_evaluatorq_base_url.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import evaluatorq.evaluatorq  # noqa: F401  populate sys.modules; the package attr is shadowed by the function
 from evaluatorq import DataPoint, evaluatorq
+
+# evaluatorq.evaluatorq resolves to the re-exported function, not the submodule,
+# so patch the module object directly (3.10's mock can't resolve the shadowed path).
+_EQ_MOD = sys.modules["evaluatorq.evaluatorq"]
 
 
 async def _job(data: DataPoint, _row: int) -> dict[str, Any]:
@@ -20,7 +26,7 @@ async def test_forwards_base_url_to_upload() -> None:
     spy = AsyncMock(return_value=None)
     with (
         patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
-        patch("evaluatorq.evaluatorq.send_results_to_orq", spy),
+        patch.object(_EQ_MOD, "send_results_to_orq", spy),
     ):
         await evaluatorq(
             "run",
@@ -39,7 +45,7 @@ async def test_base_url_defaults_to_none() -> None:
     spy = AsyncMock(return_value=None)
     with (
         patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
-        patch("evaluatorq.evaluatorq.send_results_to_orq", spy),
+        patch.object(_EQ_MOD, "send_results_to_orq", spy),
     ):
         await evaluatorq(
             "run",

--- a/tests/test_evaluatorq_base_url.py
+++ b/tests/test_evaluatorq_base_url.py
@@ -1,0 +1,49 @@
+"""RES-912: evaluatorq() forwards _base_url to send_results_to_orq."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from evaluatorq import DataPoint, evaluatorq
+
+
+async def _job(data: DataPoint, _row: int) -> dict[str, Any]:
+    return {"name": "j", "output": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_forwards_base_url_to_upload() -> None:
+    spy = AsyncMock(return_value=None)
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch("evaluatorq.evaluatorq.send_results_to_orq", spy),
+    ):
+        await evaluatorq(
+            "run",
+            data=[DataPoint(inputs={"x": 1})],
+            jobs=[_job],
+            print_results=False,
+            _base_url="https://my.staging.orq.ai",
+        )
+    assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"
+
+
+@pytest.mark.asyncio
+async def test_base_url_defaults_to_none() -> None:
+    """Without _base_url, send_results_to_orq receives None and reads env itself."""
+    spy = AsyncMock(return_value=None)
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch("evaluatorq.evaluatorq.send_results_to_orq", spy),
+    ):
+        await evaluatorq(
+            "run",
+            data=[DataPoint(inputs={"x": 1})],
+            jobs=[_job],
+            print_results=False,
+        )
+    assert spy.await_args.kwargs.get("base_url") is None

--- a/tests/test_send_results.py
+++ b/tests/test_send_results.py
@@ -483,3 +483,84 @@ class TestSendResultsUploadFailures:
             raise_on_error=False,
         )
         assert result is None
+
+
+class TestSendResultsBaseUrl:
+    """RES-912: results upload to the same server used for inference."""
+
+    @staticmethod
+    def _ok_post(captured: dict[str, Any]):
+        async def fake_post(self: httpx.AsyncClient, url: str, *args: Any, **kwargs: Any) -> httpx.Response:
+            captured["url"] = url
+            request = httpx.Request("POST", url)
+            return httpx.Response(
+                200,
+                request=request,
+                json={"sheet_id": "s1", "manifest_id": "m1", "experiment_name": "eval", "rows_created": 1},
+            )
+
+        return fake_post
+
+    @pytest.mark.asyncio
+    async def test_base_url_kwarg_overrides_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai")
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._ok_post(captured))
+
+        await send_results_to_orq(
+            api_key="key",
+            evaluation_name="eval",
+            evaluation_description=None,
+            dataset_id=None,
+            results=build_results(0.5),
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            base_url="https://my.staging.orq.ai",
+        )
+        assert captured["url"] == "https://my.staging.orq.ai/v2/spreadsheets/evaluations/receive"
+
+    @pytest.mark.asyncio
+    async def test_base_url_trailing_slash_normalized(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._ok_post(captured))
+
+        await send_results_to_orq(
+            api_key="key",
+            evaluation_name="eval",
+            evaluation_description=None,
+            dataset_id=None,
+            results=build_results(0.5),
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            base_url="https://my.staging.orq.ai/",
+        )
+        assert captured["url"] == "https://my.staging.orq.ai/v2/spreadsheets/evaluations/receive"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_env_when_base_url_not_supplied(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        monkeypatch.setenv("ORQ_BASE_URL", "https://my.staging.orq.ai")
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._ok_post(captured))
+
+        await send_results_to_orq(
+            api_key="key",
+            evaluation_name="eval",
+            evaluation_description=None,
+            dataset_id=None,
+            results=build_results(0.5),
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        )
+        assert captured["url"] == "https://my.staging.orq.ai/v2/spreadsheets/evaluations/receive"


### PR DESCRIPTION
## Problem

`send_results_to_orq` (used by both the red team runner and agent sim) read `ORQ_BASE_URL` from the environment at call time and ignored the `base_url` actually used for inference. Pointing inference at a non-default server (e.g. staging `my.staging.orq.ai`) still uploaded results to `my.orq.ai` unless `ORQ_BASE_URL` was also set separately.

Closes RES-912.

## Change

Results now upload to the same Orq host used for inference.

- `send_results_to_orq` gains an optional `base_url` kwarg; falls back to `ORQ_BASE_URL` env / `https://my.orq.ai` when not supplied (behaviour unchanged when absent).
- New `resolve_results_base_url()` helper in `common/llm_client.py`: prefers the inference client's Orq host (stripping `/v3/router`), ignores non-Orq clients (uploads always go to Orq), falls back to env.
- Red team `_send_cleaned_results` resolves `base_url` once from the inference client and forwards it (both dynamic/hybrid and static call sites).
- `evaluatorq()` core gains a private `_base_url`, forwarded to the upload.
- Agent sim resolves `base_url` from the inference client and threads it through.

## Acceptance criteria

- [x] `send_results_to_orq` accepts an optional `base_url` kwarg
- [x] Red team upload resolves `base_url` once (same logic as inference) and forwards it
- [x] Agent sim upload path does the same
- [x] Fallback behaviour unchanged when `base_url` is not supplied (reads env)

## Tests

New unit tests at every seam: helper resolution, `send_results` override + env fallback, red team runner forwarding, `evaluatorq()` core forwarding, agent sim forwarding. Full suite: 2090 passed, 2 skipped. `basedpyright` clean on changed files; no new `ruff` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)