### PR TITLE
feat(simulation): decouple framework targets from redteam and expose them (RES-907)

### DIFF
--- a/src/evaluatorq/integrations/__init__.py
+++ b/src/evaluatorq/integrations/__init__.py
@@ -2,12 +2,12 @@
 
 Available integrations:
 - langchain_integration: LangChain agent wrapper for OpenResponses format
-- langgraph_integration: LangGraph red teaming target
-- openai_agents_integration: OpenAI Agents SDK red teaming target
+- langgraph_integration: LangGraph agent target
+- openai_agents_integration: OpenAI Agents SDK agent target
 - pydantic_ai_integration: Pydantic AI agent target
 - crewai_integration: CrewAI crew target
-- vercel_ai_sdk_integration: Vercel AI SDK red teaming target (HTTP)
-- callable_integration: Custom callable red teaming target
+- vercel_ai_sdk_integration: Vercel AI SDK agent target (HTTP)
+- callable_integration: Custom callable agent target
 
 Integrations with optional dependencies (langgraph, openai-agents, pydantic-ai,
 crewai) use lazy imports so that importing this package does not fail when those

--- a/src/evaluatorq/integrations/callable_integration/__init__.py
+++ b/src/evaluatorq/integrations/callable_integration/__init__.py
@@ -1,6 +1,6 @@
-"""Custom callable integration for evaluatorq red teaming.
+"""Custom callable integration for evaluatorq simulation and red teaming.
 
-Provides a wrapper to use any sync or async function as a red teaming target.
+Provides a wrapper to use any sync or async function as an AgentTarget.
 """
 
 from .target import CallableTarget

--- a/src/evaluatorq/integrations/callable_integration/target.py
+++ b/src/evaluatorq/integrations/callable_integration/target.py
@@ -1,4 +1,4 @@
-"""Red teaming target wrapper for arbitrary callables."""
+"""AgentTarget wrapper for arbitrary callables."""
 
 from __future__ import annotations
 
@@ -8,8 +8,15 @@ from typing import Any
 
 from loguru import logger
 
-from evaluatorq.contracts import AgentTarget, Message
-from evaluatorq.redteam.contracts import AgentContext, AgentResponse, OutputMessage, TextOutputItem, TokenUsage
+from evaluatorq.contracts import (
+    AgentContext,
+    AgentResponse,
+    AgentTarget,
+    Message,
+    OutputMessage,
+    TextOutputItem,
+    TokenUsage,
+)
 
 # Accepted callable signatures — receive the conversation as a list of typed
 # :class:`~evaluatorq.contracts.Message` objects. The list holds one message for
@@ -36,7 +43,7 @@ def _is_async_callable(fn: object) -> bool:
 
 
 class CallableTarget(AgentTarget):
-    """Wraps any sync or async function as a red teaming target.
+    """Wraps any sync or async function as an AgentTarget.
 
     Use this as an escape hatch for frameworks that don't have a dedicated
     integration. You provide a function that takes the conversation (a list of
@@ -71,7 +78,7 @@ class CallableTarget(AgentTarget):
 
         target = CallableTarget(my_agent, usage_fn=get_usage)
 
-        # Pass to red teaming
+        # Pass to simulation or red teaming
         config = DynamicRunConfig(targets=[target])
     """
 
@@ -83,7 +90,7 @@ class CallableTarget(AgentTarget):
         usage_fn: UsageFn | None = None,
         agent_context: AgentContext | None = None,
     ) -> None:
-        """Create a callable red teaming target.
+        """Create a callable agent target.
 
         Args:
             fn: A sync or async function taking the conversation as a

--- a/src/evaluatorq/integrations/crewai_integration/target.py
+++ b/src/evaluatorq/integrations/crewai_integration/target.py
@@ -1,4 +1,4 @@
-"""Simulation/red-teaming target wrapper for CrewAI crews.
+"""Simulation/AgentTarget wrapper for CrewAI crews.
 
 CrewAI is the biggest format divergence among the supported frameworks, which
 makes it a good generality stress test for the unified ``AgentTarget`` protocol.
@@ -25,10 +25,11 @@ import re
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from evaluatorq.contracts import AgentTarget, Message
-from evaluatorq.redteam.contracts import (
+from evaluatorq.contracts import (
     AgentContext,
     AgentResponse,
+    AgentTarget,
+    Message,
     OutputMessage,
     TextOutputItem,
     TokenUsage,

--- a/src/evaluatorq/integrations/langgraph_integration/__init__.py
+++ b/src/evaluatorq/integrations/langgraph_integration/__init__.py
@@ -1,6 +1,6 @@
-"""LangGraph integration for evaluatorq red teaming.
+"""LangGraph integration for evaluatorq simulation and red teaming.
 
-Provides a wrapper to use any LangGraph compiled graph as a red teaming target.
+Provides a wrapper to use any LangGraph compiled graph as an AgentTarget.
 """
 
 from .target import LangGraphTarget

--- a/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -1,4 +1,4 @@
-"""Red teaming target wrapper for LangGraph agents."""
+"""AgentTarget wrapper for LangGraph agents."""
 
 from __future__ import annotations
 
@@ -13,11 +13,12 @@ from langchain_core.messages import AIMessage
 from langchain_core.outputs import LLMResult
 from langchain_core.runnables import RunnableConfig
 
-from evaluatorq.contracts import AgentTarget, Message
-from evaluatorq.redteam.contracts import (
+from evaluatorq.contracts import (
     AgentContext,
     AgentResponse,
+    AgentTarget,
     MemoryStoreInfo,
+    Message,
     OutputMessage,
     TextOutputItem,
     TokenUsage,
@@ -90,7 +91,7 @@ class _TokenUsageCollector(BaseCallbackHandler):
 
 
 class LangGraphTarget(AgentTarget):
-    """Wraps a LangGraph CompiledStateGraph as a red teaming target.
+    """Wraps a LangGraph CompiledStateGraph as an AgentTarget.
 
     Each instance generates its own ``memory_entity_id`` used as the LangGraph
     ``thread_id`` — this is the checkpointer's isolation key, so parallel
@@ -109,7 +110,7 @@ class LangGraphTarget(AgentTarget):
         graph = create_react_agent(model, tools=[...])
         target = LangGraphTarget(graph)
 
-        # Pass to red teaming
+        # Pass to simulation or red teaming
         config = DynamicRunConfig(targets=[target])
     """
 
@@ -120,7 +121,7 @@ class LangGraphTarget(AgentTarget):
         config: dict[str, Any] | None = None,
         agent_context: AgentContext | None = None,
     ) -> None:
-        """Create a LangGraph red teaming target.
+        """Create a LangGraph agent target.
 
         Args:
             graph: A compiled LangGraph state graph.
@@ -321,7 +322,7 @@ class LangGraphTarget(AgentTarget):
         )
 
     def new(self) -> LangGraphTarget:
-        """Return an independent instance for parallel red teaming jobs.
+        """Return an independent instance for parallel simulation/red-team jobs.
 
         Each call gets a fresh ``memory_entity_id`` (and thus a fresh LangGraph
         thread), so parallel workers never share checkpointer state.

--- a/src/evaluatorq/integrations/openai_agents_integration/__init__.py
+++ b/src/evaluatorq/integrations/openai_agents_integration/__init__.py
@@ -1,6 +1,6 @@
-"""OpenAI Agents SDK integration for evaluatorq red teaming.
+"""OpenAI Agents SDK integration for evaluatorq simulation and red teaming.
 
-Provides a wrapper to use any OpenAI Agents SDK agent as a red teaming target.
+Provides a wrapper to use any OpenAI Agents SDK agent as an AgentTarget.
 """
 
 from .target import OpenAIAgentTarget

--- a/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -1,4 +1,4 @@
-"""Red teaming target wrapper for OpenAI Agents SDK."""
+"""AgentTarget wrapper for OpenAI Agents SDK."""
 
 from __future__ import annotations
 
@@ -9,10 +9,11 @@ from typing import Any
 from agents import Agent, Runner
 from loguru import logger
 
-from evaluatorq.contracts import AgentTarget, Message
-from evaluatorq.redteam.contracts import (
+from evaluatorq.contracts import (
     AgentContext,
     AgentResponse,
+    AgentTarget,
+    Message,
     OutputMessage,
     TextOutputItem,
     TokenUsage,
@@ -22,7 +23,7 @@ from evaluatorq.redteam.contracts import (
 
 
 class OpenAIAgentTarget(AgentTarget):
-    """Wraps an OpenAI Agents SDK Agent as a red teaming target.
+    """Wraps an OpenAI Agents SDK Agent as an AgentTarget.
 
     Usage::
 
@@ -32,12 +33,12 @@ class OpenAIAgentTarget(AgentTarget):
         agent = Agent(name="my-agent", instructions="You are a helpful assistant.")
         target = OpenAIAgentTarget(agent)
 
-        # Pass to red teaming
+        # Pass to simulation or red teaming
         config = DynamicRunConfig(targets=[target])
     """
 
     def __init__(self, agent: Agent, *, run_kwargs: dict[str, Any] | None = None) -> None:
-        """Create an OpenAI Agents SDK red teaming target.
+        """Create an OpenAI Agents SDK agent target.
 
         Args:
             agent: An OpenAI Agents SDK Agent instance.
@@ -238,7 +239,7 @@ class OpenAIAgentTarget(AgentTarget):
         return OpenAIAgentTarget(self._agent, run_kwargs=dict(self._run_kwargs))
 
     def new(self) -> OpenAIAgentTarget:
-        """Return an independent instance for parallel red teaming jobs."""
+        """Return an independent instance for parallel simulation/red-team jobs."""
         return self.clone()
 
 

--- a/src/evaluatorq/integrations/pydantic_ai_integration/target.py
+++ b/src/evaluatorq/integrations/pydantic_ai_integration/target.py
@@ -1,4 +1,4 @@
-"""Simulation/red-teaming target wrapper for Pydantic AI agents."""
+"""Simulation/AgentTarget wrapper for Pydantic AI agents."""
 
 from __future__ import annotations
 
@@ -8,10 +8,11 @@ import re
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from evaluatorq.contracts import AgentTarget, Message
-from evaluatorq.redteam.contracts import (
+from evaluatorq.contracts import (
     AgentContext,
     AgentResponse,
+    AgentTarget,
+    Message,
     OutputMessage,
     TextOutputItem,
     TokenUsage,

--- a/src/evaluatorq/integrations/vercel_ai_sdk_integration/__init__.py
+++ b/src/evaluatorq/integrations/vercel_ai_sdk_integration/__init__.py
@@ -1,7 +1,7 @@
-"""Vercel AI SDK integration for evaluatorq red teaming.
+"""Vercel AI SDK integration for evaluatorq simulation and red teaming.
 
 Provides a wrapper to use any Vercel AI SDK agent (served over HTTP)
-as a red teaming target.
+as an AgentTarget (usable in simulation and red teaming).
 """
 
 from .target import VercelAISdkTarget

--- a/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -1,4 +1,4 @@
-"""Red teaming target wrapper for Vercel AI SDK agents served over HTTP.
+"""AgentTarget wrapper for Vercel AI SDK agents served over HTTP.
 
 The Vercel AI SDK is a TypeScript library, so Python integration works by
 calling an HTTP endpoint that serves the agent (e.g. a Next.js route handler).
@@ -19,8 +19,15 @@ from urllib.parse import urlparse
 
 import httpx
 
-from evaluatorq.contracts import AgentTarget, Message
-from evaluatorq.redteam.contracts import AgentContext, AgentResponse, OutputMessage, TextOutputItem, TokenUsage
+from evaluatorq.contracts import (
+    AgentContext,
+    AgentResponse,
+    AgentTarget,
+    Message,
+    OutputMessage,
+    TextOutputItem,
+    TokenUsage,
+)
 
 AISdkMessageFormat = Literal['v4', 'v5']
 """AI SDK tool-message wire format. v5 (current) vs v4 (legacy) differ on tool
@@ -28,7 +35,7 @@ field names — see :func:`_message_to_ai_sdk_message`."""
 
 
 class VercelAISdkTarget(AgentTarget):
-    """Wraps a Vercel AI SDK HTTP endpoint as a red teaming target.
+    """Wraps a Vercel AI SDK HTTP endpoint as an AgentTarget.
 
     The endpoint must accept POST requests with a JSON body containing
     ``messages`` in the standard chat format and return a response using
@@ -47,7 +54,7 @@ class VercelAISdkTarget(AgentTarget):
             headers={"Authorization": "Bearer sk-..."},
         )
 
-        # Pass to red teaming
+        # Pass to simulation or red teaming
         config = DynamicRunConfig(targets=[target])
     """
 
@@ -61,7 +68,7 @@ class VercelAISdkTarget(AgentTarget):
         agent_context: AgentContext | None = None,
         message_format: AISdkMessageFormat = 'v5',
     ) -> None:
-        """Create a Vercel AI SDK red teaming target.
+        """Create a Vercel AI SDK agent target.
 
         Args:
             url: The HTTP endpoint URL serving the AI SDK agent.
@@ -135,7 +142,7 @@ class VercelAISdkTarget(AgentTarget):
         return AgentContext(key=safe_key, description='opaque Vercel AI SDK HTTP target')
 
     def new(self) -> VercelAISdkTarget:
-        """Return an independent instance for parallel red teaming jobs."""
+        """Return an independent instance for parallel simulation/red-team jobs."""
         return VercelAISdkTarget(
             self._url,
             headers=dict(self._headers),

--- a/src/evaluatorq/simulation/__init__.py
+++ b/src/evaluatorq/simulation/__init__.py
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)  # noqa: RUF067
 
 if TYPE_CHECKING:
     from evaluatorq.contracts import AgentTarget, LLMCallConfig, TokenUsage
+    from evaluatorq.integrations.callable_integration import CallableTarget
+    from evaluatorq.integrations.langgraph_integration import LangGraphTarget
+    from evaluatorq.integrations.openai_agents_integration import OpenAIAgentTarget
+    from evaluatorq.integrations.vercel_ai_sdk_integration import VercelAISdkTarget
     from evaluatorq.openresponses.target import OrqResponsesTarget
     from evaluatorq.simulation.adapters import (
         from_chat_completions,
@@ -177,6 +181,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {  # noqa: RUF067
         'SimulationCancelledError',
     ),
     'AgentTarget': ('evaluatorq.contracts', 'AgentTarget'),
+    'CallableTarget': ('evaluatorq.integrations.callable_integration', 'CallableTarget'),
+    'LangGraphTarget': ('evaluatorq.integrations.langgraph_integration', 'LangGraphTarget'),
+    'OpenAIAgentTarget': ('evaluatorq.integrations.openai_agents_integration', 'OpenAIAgentTarget'),
+    'VercelAISdkTarget': ('evaluatorq.integrations.vercel_ai_sdk_integration', 'VercelAISdkTarget'),
     'DEFAULT_MODEL': ('evaluatorq.simulation.types', 'DEFAULT_MODEL'),
     'CommunicationStyle': ('evaluatorq.simulation.types', 'CommunicationStyle'),
     'ConversationStrategy': (
@@ -257,6 +265,7 @@ __all__ = [
     'AgentConfig',
     'AgentTarget',
     'BaseAgent',
+    'CallableTarget',
     'CommunicationStyle',
     'ConversationStrategy',
     'Criterion',
@@ -273,8 +282,10 @@ __all__ = [
     'Judgment',
     # Config (re-exported for user convenience)
     'LLMCallConfig',
+    'LangGraphTarget',
     'Message',
     # Target implementations
+    'OpenAIAgentTarget',
     'OrqResponsesTarget',
     'Persona',
     'PersonaGenerator',
@@ -299,6 +310,7 @@ __all__ = [
     'TokenUsage',
     'TurnMetrics',
     'UserSimulatorAgent',
+    'VercelAISdkTarget',
     'apply_perturbation',
     'apply_perturbations_batch',
     'apply_random_perturbation',

--- a/src/evaluatorq/simulation/__init__.py
+++ b/src/evaluatorq/simulation/__init__.py
@@ -244,12 +244,30 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {  # noqa: RUF067
 }
 
 
+# Framework targets that pull an optional dependency at import time, so a
+# missing extra surfaces as an actionable message instead of a bare ImportError
+# about the third-party package. (Callable/Vercel need no extra.)
+_OPTIONAL_TARGET_EXTRAS: dict[str, str] = {
+    'LangGraphTarget': 'langgraph',
+    'OpenAIAgentTarget': 'openai-agents',
+}
+
+
 def __getattr__(name: str) -> Any:
     if name not in _LAZY_IMPORTS:
         raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
     module_name, attr_name = _LAZY_IMPORTS[name]
-    value = getattr(importlib.import_module(module_name), attr_name)
+    try:
+        value = getattr(importlib.import_module(module_name), attr_name)
+    except ModuleNotFoundError as exc:
+        extra = _OPTIONAL_TARGET_EXTRAS.get(name)
+        if extra is not None:
+            raise ImportError(
+                f"{name} requires the optional '{extra}' dependency. "
+                f"Install it with: pip install 'evaluatorq[{extra}]'"
+            ) from exc
+        raise
     globals()[name] = value
     return value
 

--- a/tests/simulation/test_framework_targets_exposed.py
+++ b/tests/simulation/test_framework_targets_exposed.py
@@ -1,0 +1,109 @@
+"""RES-907: framework integration targets are decoupled from redteam and
+exposed via evaluatorq.simulation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+def test_importing_callable_target_does_not_import_redteam() -> None:
+    """An integration target must not drag in the whole redteam package."""
+    code = (
+        "import evaluatorq.integrations.callable_integration.target\n"
+        "import sys\n"
+        "leaked = sorted(m for m in sys.modules if m.startswith('evaluatorq.redteam'))\n"
+        "assert not leaked, leaked\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["OpenAIAgentTarget", "LangGraphTarget", "VercelAISdkTarget", "CallableTarget"],
+)
+def test_framework_target_exposed_from_simulation(name: str) -> None:
+    import evaluatorq.simulation as sim
+
+    assert hasattr(sim, name), f"{name} not exposed from evaluatorq.simulation"
+    assert name in sim.__all__
+
+
+@pytest.mark.asyncio
+async def test_integration_target_reports_token_usage() -> None:
+    """A simulation driven by an integration target (the target_agent path, not
+    the str-callback path) aggregates the target's token usage into the result."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from evaluatorq.contracts import Message as ContractMessage
+    from evaluatorq.contracts import TokenUsage
+    from evaluatorq.integrations.callable_integration import CallableTarget
+    from evaluatorq.simulation.runner.simulation import SimulationRunner
+    from evaluatorq.simulation.types import (
+        CommunicationStyle,
+        Datapoint,
+        Persona,
+        Scenario,
+    )
+
+    def agent(messages: list[ContractMessage]) -> str:
+        return "agent reply"
+
+    def usage_fn(messages: list[ContractMessage], response: str) -> TokenUsage:
+        return TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15, calls=1)
+
+    target = CallableTarget(agent, usage_fn=usage_fn)
+
+    # User-simulator and judge contribute zero usage, so any non-zero total comes
+    # from the integration target — proving the target_agent path is exercised.
+    sim = MagicMock()
+    sim.generate_first_message = AsyncMock(return_value="hello")
+    sim.respond_async = AsyncMock(return_value="thanks")
+    sim.get_usage = MagicMock(return_value=TokenUsage())
+
+    judgment = MagicMock()
+    judgment.should_terminate = True
+    judgment.goal_achieved = True
+    judgment.goal_completion_score = 1.0
+    judgment.rules_broken = []
+    judgment.reason = "done"
+    judgment.response_quality = 0.9
+    judgment.hallucination_risk = 0.1
+    judgment.tone_appropriateness = 0.9
+    judgment.factual_accuracy = 0.9
+    judge = MagicMock()
+    judge.evaluate = AsyncMock(return_value=judgment)
+    judge.get_usage = MagicMock(return_value=TokenUsage())
+
+    runner = SimulationRunner(
+        target_agent=target,
+        model="test",
+        max_turns=1,
+        user_simulator=sim,
+        judge=judge,
+    )
+    dp = Datapoint(
+        id="dp-1",
+        persona=Persona(
+            name="P",
+            patience=0.5,
+            assertiveness=0.5,
+            politeness=0.5,
+            technical_level=0.5,
+            communication_style=CommunicationStyle.casual,
+            background="b",
+        ),
+        scenario=Scenario(name="S", goal="g"),
+        user_system_prompt="sys",
+        first_message="hi",
+    )
+    result = await runner.run(datapoint=dp)
+
+    assert result.token_usage.total_tokens >= 15

--- a/tests/simulation/test_framework_targets_exposed.py
+++ b/tests/simulation/test_framework_targets_exposed.py
@@ -9,10 +9,24 @@ import sys
 import pytest
 
 
-def test_importing_callable_target_does_not_import_redteam() -> None:
-    """An integration target must not drag in the whole redteam package."""
+@pytest.mark.parametrize(
+    "module",
+    [
+        "evaluatorq.integrations.callable_integration.target",
+        "evaluatorq.integrations.langgraph_integration.target",
+        "evaluatorq.integrations.openai_agents_integration.target",
+        "evaluatorq.integrations.vercel_ai_sdk_integration.target",
+    ],
+)
+def test_importing_integration_target_does_not_import_redteam(module: str) -> None:
+    """No exposed integration target may drag in the whole redteam package.
+
+    Checked per-module because each target has its own independent import block —
+    a redteam import re-added to any one of them must fail the suite, not just
+    the one that happens to be exercised.
+    """
     code = (
-        "import evaluatorq.integrations.callable_integration.target\n"
+        f"import {module}\n"
         "import sys\n"
         "leaked = sorted(m for m in sys.modules if m.startswith('evaluatorq.redteam'))\n"
         "assert not leaked, leaked\n"

--- a/tests/simulation/test_framework_targets_exposed.py
+++ b/tests/simulation/test_framework_targets_exposed.py
@@ -50,6 +50,25 @@ def test_framework_target_exposed_from_simulation(name: str) -> None:
     assert name in sim.__all__
 
 
+@pytest.mark.parametrize(
+    ("name", "extra"),
+    [("LangGraphTarget", "langgraph"), ("OpenAIAgentTarget", "openai-agents")],
+)
+def test_missing_optional_dep_gives_actionable_error(
+    name: str, extra: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing integration extra surfaces as an install hint, not a raw
+    ImportError about the third-party package."""
+    import evaluatorq.simulation as sim
+
+    def _boom(_module: str) -> object:
+        raise ModuleNotFoundError(f"No module named '{extra}'")
+
+    monkeypatch.setattr(sim.importlib, "import_module", _boom)
+    with pytest.raises(ImportError, match=rf"evaluatorq\[{extra}\]"):
+        sim.__getattr__(name)
+
+
 @pytest.mark.asyncio
 async def test_integration_target_reports_token_usage() -> None:
     """A simulation driven by an integration target (the target_agent path, not


### PR DESCRIPTION
## Problem

The four framework integration targets (`OpenAIAgentTarget`, `LangGraphTarget`, `VercelAISdkTarget`, `CallableTarget`) already work with `SimulationRunner`, but:

1. **Not exposed** — they weren't importable from `evaluatorq.simulation` nor reachable from the `eq sim` CLI.
2. **Coupled to redteam** — each `integrations/*/target.py` imported its contracts from `evaluatorq.redteam.contracts`, so importing any integration target dragged in the whole `redteam` package — wrong for a simulation-only user.

Closes [RES-907](https://linear.app/orqai/issue/RES-907/expose-framework-integration-targets-openai-agents-langgraph-vercel-ai).

## Change

* **Decouple:** repoint all 6 `integrations/*/target.py` imports from `evaluatorq.redteam.contracts` → `evaluatorq.contracts` (every name already lives there; verified). Importing an integration target no longer imports `evaluatorq.redteam`.
* **Reword** the "red teaming target" docstrings — these are generic `AgentTarget`s.
* **Expose** the four targets from `evaluatorq.simulation` (lazy import map + `__all__`).
* **CLI:** `eq sim run` already selects a framework target via `--vercel-url` (→ `VercelAISdkTarget`).

## Acceptance criteria

- [X] `from evaluatorq.simulation import OpenAIAgentTarget` (and the other three) resolves
- [X] Importing an integration target does **not** import `evaluatorq.redteam` (asserted in a subprocess test)
- [X] A simulation run driven by an integration target reports non-zero token usage (proves the `target_agent` path)
- [X] `eq sim run` can select a framework target via a flag (`--vercel-url`)

## Tests

New `test_framework_targets_exposed.py`: redteam-isolation (subprocess), exposure of all four targets, and a `CallableTarget` simulation run that aggregates non-zero token usage. Full unit suite green (2083 passed); whole-repo `basedpyright` clean; `ruff` clean on changed files.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)