### PR TITLE
docs: LLM-as-a-jury guide + fenced-JSON judge fix (RES-969)

### DIFF
--- a/docs/llm-as-a-jury.md
+++ b/docs/llm-as-a-jury.md
@@ -1,0 +1,216 @@
+# LLM as a Jury
+
+A single judge model is a single point of failure. It can be noisy from one
+call to the next, and it can be biased toward outputs from its own provider
+family. The jury (or panel of judges) replaces that one judge with several,
+runs them together, aggregates their verdicts into one decision, and reports
+how much they agreed.
+
+You can use a jury two ways: as a general evaluator in `evaluatorq()` through
+`llm_jury()`, or inside red teaming through `EvaluatorConfig`. Both share the
+same panel machinery.
+
+## When to use it
+
+- The evaluation is high stakes and you want a verdict that does not rest on
+  one model's opinion.
+- You are judging outputs from the same provider as your usual judge and want
+  to avoid a judge grading its own family.
+- You want a quantitative signal for how much your judges actually agree, so
+  you know when a verdict is solid and when it is contested.
+
+A single judge is cheaper and faster. Reach for a jury when the cost of a
+wrong verdict outweighs the extra calls. A single-judge panel runs with no
+aggregation overhead, so a jury is purely additive.
+
+## Quick start
+
+`llm_jury()` builds an evaluator you drop into the `evaluators=[...]` list of
+`evaluatorq()`. Give it two or more `judges` and it becomes a jury:
+
+```python
+import asyncio
+
+from evaluatorq import DataPoint, evaluatorq, llm_jury
+
+correctness = llm_jury(
+    name="correctness",
+    criteria="The answer is factually correct and directly answers the question.",
+    judges=[
+        "anthropic/claude-sonnet-4-6",
+        "google/gemini-2.5-pro",
+        "mistral/mistral-large-2411",
+    ],
+)
+
+
+async def answer(data: DataPoint, _row: int) -> dict:
+    # Your system under test produces the output to be judged.
+    return {"name": "qa", "output": "Paris is the capital of France."}
+
+
+async def main() -> None:
+    await evaluatorq(
+        "qa-eval",
+        data=[DataPoint(inputs={"question": "What is the capital of France?"})],
+        jobs=[answer],
+        evaluators=[correctness],
+    )
+
+
+asyncio.run(main())
+```
+
+`llm_jury(model="x")` is shorthand for `judges=["x"]` — a single judge, the
+classic LLM-as-a-judge. Pass `judges=[...]` with two or more models to turn it
+into a jury.
+
+!!! tip "Keep the panel odd and mixed-provider"
+    An odd number of judges (3, 5) makes ties rare. A mix of provider families
+    gives you the independence a jury is meant to provide; three judges from the
+    same provider tend to be correlated and add little over one.
+
+## Verdict modes
+
+`verdict_kind` (with `labels`) decides what each judge returns and how `passed`
+is set. It is not inferred from `labels` — pick the mode explicitly.
+
+| Mode | Configure it with | Judge returns | `passed` is |
+| --- | --- | --- | --- |
+| **Boolean** (default) | `verdict_kind="categorical"`, no `labels` | `true` / `false` | the boolean itself |
+| **Labeled** | `verdict_kind="categorical"`, `labels=[...]` | one of `labels` | `verdict in passing_labels` (`None` if `passing_labels` omitted) |
+| **Numeric** | `verdict_kind="numeric"` | a float in `score_range` | `score >= threshold` |
+
+```python
+# Labeled: a fixed rubric, only some labels pass
+tone = llm_jury(
+    name="tone",
+    criteria="Rate the tone of the reply.",
+    judges=["anthropic/claude-sonnet-4-6", "google/gemini-2.5-pro"],
+    labels=["rude", "neutral", "friendly"],
+    passing_labels=["neutral", "friendly"],
+)
+
+# Numeric: a 0-1 score with a pass threshold
+helpfulness = llm_jury(
+    name="helpfulness",
+    criteria="Score how helpful the answer is, 0 to 1.",
+    judges=["anthropic/claude-sonnet-4-6", "google/gemini-2.5-pro"],
+    verdict_kind="numeric",
+    threshold=0.7,
+)
+```
+
+`labels`/`passing_labels` are valid only for `categorical`; passing them with
+`numeric` raises `ValueError`. In labeled mode `passing_labels` must be a subset
+of `labels`; omit it and the verdict is still recorded but `passed` is `None`.
+
+## Panel configuration
+
+| Argument | Default | What it does |
+| --- | --- | --- |
+| `judges` | — | Judge model IDs. Two or more makes it a jury. Mutually exclusive with `model`. |
+| `model` | — | Single-judge shorthand for `judges=[model]`. |
+| `repetitions` | `1` | How many times each judge is asked. The judge takes its own majority before the panel votes, which smooths per-call noise. |
+| `replacement_judges` | `None` | Stand-in models called only when a configured judge fails mechanically. |
+| `min_successful_judges` | `1` | Minimum decisive judges required, otherwise the verdict is **inconclusive**. Must not exceed the panel size. |
+| `threshold` | `0.5` | Numeric mode: `passed` when `score >= threshold`. |
+| `structured_output` | `True` | Use the provider's structured-output API; falls back to a schema-injected `json_object` call for models that reject it. |
+
+## How the verdict is decided
+
+1. **Each judge votes.** With `repetitions > 1` a judge is asked several times
+   and reduces its own passes to one vote first (plurality for categorical,
+   mean or median for numeric).
+2. **Failures pull in replacements.** For every configured judge that fails
+   mechanically, one model from `replacement_judges` stands in, up to the number
+   of failures.
+3. **The panel aggregates.** Categorical verdicts are decided by plurality vote;
+   numeric verdicts by mean or median.
+4. **Thresholds and ties apply.** If fewer than `min_successful_judges` return a
+   usable verdict, the result is **inconclusive**.
+
+A judge can also **abstain**: it returns cleanly but declines to choose. An
+abstention is not a failure and does not trigger a replacement, but it is
+excluded from the decisive tally.
+
+## Reading the output
+
+`llm_jury()` returns a standard evaluator, so each result carries the aggregated
+verdict in `value`, the pass/fail in `passed`, and a human-readable panel
+breakdown (who voted what, how close it was) appended to `explanation`:
+
+```python
+results = await evaluatorq(..., evaluators=[correctness])
+for r in results:
+    for job in r.job_results:
+        for score in job.evaluator_scores:
+            print(score.evaluator_name, score.score.value, score.score.pass_)
+            print(score.score.explanation)  # includes the per-judge jury summary
+```
+
+## In red teaming
+
+Red teaming reaches the same panel through `EvaluatorConfig`, where the verdict
+is the categorical RESISTANT/VULNERABLE case (`passed=True` means RESISTANT):
+
+```python
+from evaluatorq.redteam import EvaluatorConfig, LLMConfig, OpenAIModelTarget, red_team
+
+report = await red_team(
+    OpenAIModelTarget("gpt-4o"),
+    llm_config=LLMConfig(
+        evaluator=EvaluatorConfig(
+            judges=[
+                "anthropic/claude-sonnet-4-6",
+                "google/gemini-2.5-pro",
+                "mistral/mistral-large-2411",
+            ],
+            min_successful_judges=2,
+            strict_panel=True,  # refuse a judge that shares the target's family
+        ),
+    ),
+    mode="dynamic",
+    categories=["LLM01"],
+    max_dynamic_datapoints=3,
+)
+```
+
+`EvaluatorConfig` adds `strict_panel` (turn panel-composition warnings into hard
+errors) and surfaces a per-attack `jury` breakdown plus a run-level reliability
+statistic:
+
+```python
+for result in report.results:
+    jury = result.evaluation.jury if result.evaluation else None
+    if jury is None:
+        continue
+    print(f"{jury.judges_succeeded}/{jury.judges_configured} judges, agreement {jury.raw_agreement}")
+    for vote in jury.votes:
+        print(vote.model, vote.value, vote.abstained, vote.error)
+
+reliability = report.summary.jury_reliability
+if reliability:
+    print(reliability.krippendorff_alpha)  # 1.0 = perfect, ~0 = chance, <0 = systematic disagreement
+```
+
+## Reliability, in short
+
+For red-team runs, `raw_agreement` tells you how lopsided one vote was, and
+Krippendorff's alpha on the run tells you whether your judges agree more than
+they would by chance:
+
+- `1.0` is perfect agreement.
+- around `0` is chance level, so the panel is not adding signal.
+- below `0` is systematic disagreement, which usually means the judges are
+  reading the rubric differently and the prompt or panel needs another look.
+
+It is `None` when undefined, for example a single-judge run or fewer than two
+multi-judge samples.
+
+## Full example
+
+A complete red-teaming script covering repetitions, replacements, the
+`min_successful_judges` threshold, `strict_panel`, and reading the per-result
+and run-level output lives at
+[`examples/redteam/16_llm_as_a_jury.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/redteam/16_llm_as_a_jury.py).

--- a/examples/redteam/16_llm_as_a_jury.py
+++ b/examples/redteam/16_llm_as_a_jury.py
@@ -1,0 +1,108 @@
+"""LLM-as-a-jury: evaluate with a panel of judges instead of one.
+
+A single judge model can be noisy or biased toward its own provider family.
+Configure ``EvaluatorConfig`` with several judges and the runner aggregates
+their verdicts by plurality vote, falls back to replacement judges when one
+fails, and reports how much the judges agreed.
+
+For red teaming the verdict is categorical: ``passed=True`` means RESISTANT
+(the attack failed) and ``passed=False`` means VULNERABLE (the attack
+succeeded).
+
+Prerequisites:
+    - ORQ_API_KEY (routes the panel through the ORQ model router), or
+      OPENAI_API_KEY for an OpenAI-only panel
+
+Usage:
+    ORQ_API_KEY=orq-... python 16_llm_as_a_jury.py
+"""
+
+import asyncio
+
+from evaluatorq.redteam import EvaluatorConfig, LLMConfig, OpenAIModelTarget, red_team
+
+
+async def main() -> None:
+    target = OpenAIModelTarget(
+        "gpt-4o",
+        system_prompt="You are a helpful customer support assistant for Acme Corp.",
+    )
+
+    # A mixed-provider panel of three judges. judges[0] is the primary model;
+    # the remaining judges turn the evaluation into a jury. Keep the panel odd
+    # and spread across providers so a tie is rare and no single provider can
+    # swing every verdict. The target is OpenAI, so no judge is OpenAI — under
+    # strict_panel a judge sharing the target's family is refused (a model should
+    # not grade its own family).
+    config = LLMConfig(
+        evaluator=EvaluatorConfig(
+            judges=[
+                "anthropic/claude-sonnet-4-6",
+                "google/gemini-2.5-pro",
+                "mistral/mistral-large-2411",
+            ],
+            # Ask each judge twice and take its own majority before the panel
+            # votes. Smooths out per-call noise from a single judge.
+            repetitions=2,
+            # Stand-ins called only when a configured judge fails mechanically.
+            replacement_judges=["anthropic/claude-haiku-4-5-20251001"],
+            # Treat the run as inconclusive unless at least two judges return a
+            # usable verdict. Guards against a verdict resting on one survivor.
+            min_successful_judges=2,
+            # Refuse a judge that shares the target's provider family.
+            strict_panel=True,
+            temperature=0.0,
+        ),
+    )
+
+    report = await red_team(
+        target,
+        llm_config=config,
+        mode="dynamic",
+        categories=["LLM01"],
+        max_dynamic_datapoints=3,
+        max_turns=2,
+        generate_strategies=False,
+    )
+
+    print(f"Resistance rate: {report.summary.resistance_rate:.0%}")
+
+    # Run-level, chance-corrected agreement across every multi-judge sample.
+    # None for single-judge runs.
+    reliability = report.summary.jury_reliability
+    if reliability and reliability.krippendorff_alpha is not None:
+        print(
+            f"Inter-judge reliability (Krippendorff alpha): "
+            f"{reliability.krippendorff_alpha:.2f} over {reliability.samples} samples"
+        )
+
+    # Per-result jury breakdown: who voted what, and how close it was.
+    for result in report.results:
+        jury = result.evaluation.jury if result.evaluation else None
+        if jury is None:
+            continue
+        rate = f"{jury.raw_agreement:.0%}" if jury.raw_agreement is not None else "n/a"
+        flags = []
+        if jury.tie:
+            flags.append("TIE")
+        if jury.inconclusive:
+            flags.append("INCONCLUSIVE")
+        suffix = f" [{', '.join(flags)}]" if flags else ""
+        print(
+            f"\n{result.attack.vulnerability}: "
+            f"{jury.judges_succeeded}/{jury.judges_configured} judges, "
+            f"agreement {rate}{suffix}"
+        )
+        for vote in jury.votes:
+            if not vote.success:
+                verdict = f"FAILED ({vote.error})"
+            elif vote.abstained:
+                verdict = "abstained"
+            else:
+                verdict = "RESISTANT" if vote.value else "VULNERABLE"
+            tag = " (replacement)" if vote.replacement else ""
+            print(f"  - {vote.model}{tag}: {verdict}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - Red Teaming:
           - guides/red-teaming.md
           - Custom Evaluators & Frameworks: custom-evaluators-and-frameworks.md
+      - LLM as a Jury: llm-as-a-jury.md
       - Dashboard: dashboard.md
   - Reference:
       - Configuration: configuration.md

--- a/src/evaluatorq/common/judge.py
+++ b/src/evaluatorq/common/judge.py
@@ -154,6 +154,28 @@ def build_eval_replacements(
     return {**flat, **nested}
 
 
+def _strip_code_fences(text: str) -> str:
+    """Unwrap a markdown-fenced JSON block to its inner content.
+
+    Some providers ignore ``response_format=json_object`` when reached through
+    the Orq router (notably Anthropic and Gemini) and wrap an otherwise-valid
+    verdict in a ```` ```json ```` block. Returns the text unchanged when there
+    is no leading fence, so bare JSON is untouched.
+    """
+    stripped = text.strip()
+    if not stripped.startswith('```'):
+        return text
+    newline = stripped.find('\n')
+    if newline == -1:
+        return text
+    inner = stripped[newline + 1 :]
+    # Drop only a closing fence that sits on its own line. Anchoring on the
+    # newline avoids matching a ``` inside the JSON content (e.g. inside an
+    # explanation string), which a bare rfind('```') would truncate at.
+    inner = inner.rsplit('\n```', 1)[0]
+    return inner.strip()
+
+
 def _classify(exc: Exception) -> JudgeError:
     if isinstance(exc, APIConnectionError):
         return JudgeError.API_CONNECTION
@@ -194,12 +216,15 @@ async def _json_object_judge(
         extra_kwargs=cfg.extra_kwargs or None,
     )
     raw = response.choices[0].message.content or '{}'
+    # Routed Anthropic/Gemini sometimes ignore json_object and wrap the verdict in
+    # a ```json fence; strip it before parsing (raw stays original for the trace).
+    cleaned = _strip_code_fences(raw)
     if inject_model is not None:
         # Enforce the dynamic verdict schema (e.g. a categorical Literal label set)
         # on the fallback path too, so an out-of-set value raises ValidationError
         # (-> JudgeError.PARSE) instead of slipping through the loose payload model.
-        inject_model.model_validate_json(raw)
-    return EvaluatorResponsePayload.model_validate_json(raw), usage, raw
+        inject_model.model_validate_json(cleaned)
+    return EvaluatorResponsePayload.model_validate_json(cleaned), usage, raw
 
 
 async def run_judge(
@@ -326,7 +351,7 @@ async def run_judge(
                 extra_kwargs=cfg.extra_kwargs or None,
             )
             raw_content = response.choices[0].message.content or '{}'
-            payload = EvaluatorResponsePayload.model_validate_json(raw_content)
+            payload = EvaluatorResponsePayload.model_validate_json(_strip_code_fences(raw_content))
             return JudgeOutcome(payload=payload, token_usage=usage, raw_content=raw_content)
     except (asyncio.TimeoutError, APITimeoutError):
         logger.error('Judge [{}] timed out after {}ms', model, cfg.timeout_ms)

--- a/tests/redteam/test_judge.py
+++ b/tests/redteam/test_judge.py
@@ -77,6 +77,61 @@ async def test_fenced_json_is_unwrapped(monkeypatch: pytest.MonkeyPatch, content
 
 
 @pytest.mark.asyncio
+async def test_fenced_json_empty_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty fenced block yields '' which fails JSON parse -> PARSE."""
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_json_response('```json\n```'))
+    outcome = await run_judge(
+        client=client,
+        model='m',
+        cfg=LLMCallConfig(),
+        prompt_template='x',
+        replacements={},
+    )
+    assert outcome.error_kind is JudgeError.PARSE
+
+
+@pytest.mark.asyncio
+async def test_fenced_json_no_leading_triple_backticks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Text that starts with two backticks is not treated as fenced."""
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_json_response('``{"value": true}'))
+    outcome = await run_judge(
+        client=client,
+        model='m',
+        cfg=LLMCallConfig(),
+        prompt_template='x',
+        replacements={},
+    )
+    assert outcome.error_kind is JudgeError.PARSE
+
+
+@pytest.mark.asyncio
+async def test_fenced_json_inner_triple_backticks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the explanation inside a fenced block contains ' ``` ', rfind may
+    match the wrong fence. The _strip_code_fences function should still
+    handle the common case; this test documents that edge behaviour."""
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    # Inner ``` inside the JSON content — rfind matches the inner one first
+    client.chat.completions.create = AsyncMock(
+        return_value=_json_response('```json\n{"value": true, "explanation": "use ``` for code"}\n```')
+    )
+    outcome = await run_judge(
+        client=client,
+        model='m',
+        cfg=LLMCallConfig(),
+        prompt_template='x',
+        replacements={},
+    )
+    # The inner ``` causes rfind to truncate; payload may fail or be partial
+    # The important thing is the function doesn't crash.
+    assert outcome.raw_content == '```json\n{"value": true, "explanation": "use ``` for code"}\n```'
+
+
+@pytest.mark.asyncio
 async def test_timeout_captured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
     client = MagicMock()

--- a/tests/redteam/test_judge.py
+++ b/tests/redteam/test_judge.py
@@ -56,6 +56,10 @@ async def test_success_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:
         '   ```json\n{"value": true, "explanation": "resisted"}\n```   ',
         # Opening fence but no closing fence — must still unwrap and parse.
         '```json\n{"value": true, "explanation": "resisted"}',
+        # Inner ``` in the explanation with no closing fence: the newline-anchored
+        # close must not truncate at the inner backticks (regression for the
+        # rfind('```') edge case).
+        '```json\n{"value": true, "explanation": "use ``` for code"}',
     ],
 )
 async def test_fenced_json_is_unwrapped(monkeypatch: pytest.MonkeyPatch, content: str) -> None:

--- a/tests/redteam/test_judge.py
+++ b/tests/redteam/test_judge.py
@@ -48,6 +48,35 @@ async def test_success_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'content',
+    [
+        '```json\n{"value": true, "explanation": "resisted"}\n```',
+        '```\n{"value": true, "explanation": "resisted"}\n```',
+        '   ```json\n{"value": true, "explanation": "resisted"}\n```   ',
+        # Opening fence but no closing fence — must still unwrap and parse.
+        '```json\n{"value": true, "explanation": "resisted"}',
+    ],
+)
+async def test_fenced_json_is_unwrapped(monkeypatch: pytest.MonkeyPatch, content: str) -> None:
+    """Providers that ignore json_object (routed Anthropic/Gemini) wrap valid
+    JSON in a markdown code fence; the verdict must still parse, not drop."""
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_json_response(content))
+    outcome = await run_judge(
+        client=client,
+        model='m',
+        cfg=LLMCallConfig(),
+        prompt_template='x',
+        replacements={},
+    )
+    assert outcome.error_kind is None
+    assert isinstance(outcome.payload, EvaluatorResponsePayload)
+    assert outcome.payload.value is True
+
+
+@pytest.mark.asyncio
 async def test_timeout_captured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
     client = MagicMock()


### PR DESCRIPTION
## What

Adds public documentation for the **LLM-as-a-jury** (panel-of-judges) evaluator, which shipped with no docs (RES-969). While testing the docs against the live ORQ router, found and fixed a real bug that was silently dropping jury votes.

## Changes

**Docs (RES-969)**
- `docs/llm-as-a-jury.md` — when to use a jury, quick start, the full `EvaluatorConfig` field table (`judges`, `repetitions`, `replacement_judges`, `min_successful_judges`, `strict_panel`), aggregation / tie / abstention semantics, and how to read the per-result `jury` breakdown and run-level Krippendorff-alpha reliability.
- `examples/redteam/16_llm_as_a_jury.py` — runnable example covering a mixed-provider panel, repetitions, replacements, the threshold, `strict_panel`, and reading the output.
- `mkdocs.yml` — nav entry.

**Fix**
- `src/evaluatorq/common/judge.py` — providers that ignore `response_format=json_object` through the ORQ router (Anthropic, Gemini) wrap valid verdicts in a ```` ```json ```` fence. That failed `model_validate_json` and recorded a `PARSE` failure, silently shrinking the panel and biasing verdicts toward bare-JSON providers. Strip code fences before parsing; bare JSON is untouched.

## Verification

- Model IDs in the docs/example verified live via the ORQ model list.
- Live jury runs against the router: 3-provider unanimous, replacement-on-failure, and inconclusive (`min_successful_judges`) paths all behave as documented.
- Tie path (fail-closed to VULNERABLE) verified via existing unit coverage in `tests/redteam/test_panel_of_judges.py` — could not force a genuine split with live models.
- Fence fix: TDD (3 parametrized cases in `tests/redteam/test_judge.py`, red → green) and re-ran the exact live scenario that previously dropped the Anthropic vote (`succeeded=1` → `succeeded=2`).
- ruff clean, basedpyright 0 errors, full unit suite: 2080 passed / 2 skipped. `mkdocs build --strict` exits 0; examples compile 81/81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)