### PR TITLE
fix(redteam): enrich ORQ agent tools with real description + parameter schema

### DIFF
--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -723,6 +723,7 @@ class ToolInfo(BaseModel):
     name: str = Field(description='Tool name/identifier')
     description: str | None = Field(default=None, description='Tool description')
     parameters: dict[str, Any] | None = Field(default=None, description='Tool parameter schema')
+    action_type: str | None = Field(default=None, description='Tool action type (e.g. function, http, mcp)')
 
 
 class MemoryStoreInfo(BaseModel):

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -370,17 +370,8 @@ class ORQAgentTarget(AgentTarget):
             agent_key=self.agent_key,
         )
 
-        tools: list[ToolInfo] = []
         settings = getattr(agent_data, 'settings', None)
-        if settings and hasattr(settings, 'tools') and settings.tools:
-            tools.extend(
-                ToolInfo(
-                    name=getattr(tool, 'key', None) or getattr(tool, 'display_name', None) or tool.id,
-                    description=getattr(tool, 'description', None),
-                    parameters=None,
-                )
-                for tool in settings.tools
-            )
+        raw_tools = list(settings.tools) if settings and getattr(settings, 'tools', None) else []
 
         raw_kb_ids: list[str] = []
         if hasattr(agent_data, 'knowledge_bases') and agent_data.knowledge_bases:
@@ -392,10 +383,12 @@ class ORQAgentTarget(AgentTarget):
 
         enrichment_tasks: list[Any] = [self._enrich_knowledge_base(kb_id) for kb_id in raw_kb_ids]
         enrichment_tasks.extend(self._enrich_memory_store(ms_id) for ms_id in raw_ms_ids)
+        enrichment_tasks.extend(self._enrich_tool(t) for t in raw_tools)
 
         enriched_results = await asyncio.gather(*enrichment_tasks) if enrichment_tasks else []
         knowledge_bases = [r for r in enriched_results if isinstance(r, KnowledgeBaseInfo)]
         memory_stores = [r for r in enriched_results if isinstance(r, MemoryStoreInfo)]
+        tools = [r for r in enriched_results if isinstance(r, ToolInfo)]
 
         model_raw = getattr(agent_data, 'model', None)
         model_id = getattr(model_raw, 'id', None) if model_raw is not None else None
@@ -442,6 +435,41 @@ class ORQAgentTarget(AgentTarget):
         except Exception as e:
             logger.warning(f'Failed to enrich memory store {ms_key}: {e} — attack strategies will use limited context')
             return MemoryStoreInfo(id=ms_key)
+
+    async def _enrich_tool(self, binding: Any) -> ToolInfo:
+        """Resolve an agent tool binding to full ToolInfo (description + parameter schema).
+
+        The agent-retrieve endpoint only returns a tool *binding* (no JSON schema).
+        When a tool_id is present we fetch the underlying tool definition for its
+        real description and parameters; otherwise we fall back to binding fields.
+        """
+        name = (
+            getattr(binding, 'key', None) or getattr(binding, 'display_name', None) or getattr(binding, 'id', 'unknown')
+        )
+        description = getattr(binding, 'description', None)
+        action_type = getattr(binding, 'action_type', None)
+        parameters = None
+        tool_id = getattr(binding, 'tool_id', None)
+        if tool_id:
+            try:
+                rich = await asyncio.to_thread(self.orq_client.tools.retrieve, tool_id=tool_id)
+                fn = getattr(rich, 'function', None)
+                js = getattr(rich, 'json_schema', None)
+                if fn is not None:
+                    description = getattr(fn, 'description', None) or description
+                    raw_params = getattr(fn, 'parameters', None)
+                elif js is not None:
+                    description = getattr(js, 'description', None) or description
+                    raw_params = getattr(js, 'schema_', None)
+                else:
+                    description = getattr(rich, 'description', None) or description
+                    raw_params = None
+                # SDK returns parameters/schema as a Pydantic model; ToolInfo wants a plain dict.
+                if raw_params is not None:
+                    parameters = raw_params.model_dump() if hasattr(raw_params, 'model_dump') else raw_params
+            except Exception as e:
+                logger.warning(f'Failed to enrich tool {tool_id}: {e} — attack strategies will use limited context')
+        return ToolInfo(name=name, description=description, parameters=parameters, action_type=action_type)
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
         """Map an exception to a normalized error code and message tuple."""

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -43,6 +43,7 @@ def _get_orq_server_url() -> str:
     return url.rstrip('/').removesuffix('/v3/router')
 
 
+from evaluatorq.common.tracing import record_token_usage, set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentTarget, Message
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
 from evaluatorq.redteam.backends.base import Backend
@@ -58,7 +59,6 @@ from evaluatorq.redteam.contracts import (
     ToolCallOutputItem,
     ToolInfo,
 )
-from evaluatorq.common.tracing import record_token_usage, set_span_attrs, truncate_for_span
 from evaluatorq.redteam.tracing import with_redteam_span
 
 
@@ -456,12 +456,14 @@ class ORQAgentTarget(AgentTarget):
                 fn = getattr(rich, 'function', None)
                 js = getattr(rich, 'json_schema', None)
                 if fn is not None:
-                    description = getattr(fn, 'description', None) or description
+                    description = getattr(fn, 'description', None) or getattr(rich, 'description', None) or description
                     raw_params = getattr(fn, 'parameters', None)
                 elif js is not None:
-                    description = getattr(js, 'description', None) or description
+                    description = getattr(js, 'description', None) or getattr(rich, 'description', None) or description
                     raw_params = getattr(js, 'schema_', None)
                 else:
+                    # http, mcp, and code tools do not expose parameter schemas in
+                    # the retrieved tool definition; we return description only.
                     description = getattr(rich, 'description', None) or description
                     raw_params = None
                 # SDK returns parameters/schema as a Pydantic model; ToolInfo wants a plain dict.

--- a/tests/redteam/test_orq_tool_enrichment.py
+++ b/tests/redteam/test_orq_tool_enrichment.py
@@ -1,0 +1,104 @@
+"""Tests for ORQAgentTarget tool enrichment (tool_id -> full schema)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from evaluatorq.redteam.backends.orq import ORQAgentTarget
+
+
+def _target_with_tools(bindings: list[object], retrieve_return: object = None) -> ORQAgentTarget:
+    client = MagicMock()
+    client.agents.retrieve.return_value = SimpleNamespace(
+        settings=SimpleNamespace(tools=bindings),
+        knowledge_bases=None,
+        memory_stores=None,
+        model=None,
+        display_name='a',
+        description=None,
+        system_prompt=None,
+        instructions=None,
+    )
+    if retrieve_return is not None:
+        client.tools.retrieve.return_value = retrieve_return
+    return ORQAgentTarget(agent_key='a', orq_client=client)
+
+
+@pytest.mark.asyncio
+async def test_enrich_function_tool_pulls_description_and_parameters():
+    params = SimpleNamespace(model_dump=lambda: {'type': 'object', 'properties': {'q': {'type': 'string'}}})
+    rich = SimpleNamespace(
+        function=SimpleNamespace(description='Search the web', parameters=params),
+        json_schema=None,
+    )
+    binding = SimpleNamespace(
+        key=None, display_name='Web Search', id='t1', description=None, action_type='function', tool_id='tool_123'
+    )
+    target = _target_with_tools([binding], retrieve_return=rich)
+
+    ctx = await target.get_agent_context()
+
+    assert len(ctx.tools) == 1
+    tool = ctx.tools[0]
+    assert tool.name == 'Web Search'
+    assert tool.description == 'Search the web'
+    assert tool.parameters == {'type': 'object', 'properties': {'q': {'type': 'string'}}}
+    assert tool.action_type == 'function'
+
+
+@pytest.mark.asyncio
+async def test_enrich_json_schema_tool_uses_schema_field():
+    schema = SimpleNamespace(model_dump=lambda: {'type': 'object'})
+    rich = SimpleNamespace(function=None, json_schema=SimpleNamespace(description='JS tool', schema_=schema))
+    binding = SimpleNamespace(
+        key='js_key', display_name=None, id='t2', description=None, action_type='json_schema', tool_id='tool_456'
+    )
+    target = _target_with_tools([binding], retrieve_return=rich)
+
+    ctx = await target.get_agent_context()
+
+    assert ctx.tools[0].name == 'js_key'
+    assert ctx.tools[0].description == 'JS tool'
+    assert ctx.tools[0].parameters == {'type': 'object'}
+
+
+@pytest.mark.asyncio
+async def test_binding_without_tool_id_degrades_to_binding_fields():
+    # Built-in tool (e.g. "Current Date & Time"): no tool_id, no description, no params.
+    binding = SimpleNamespace(
+        key=None,
+        display_name='Current Date & Time',
+        id='builtin',
+        description=None,
+        action_type='datetime',
+        tool_id=None,
+    )
+    target = _target_with_tools([binding])
+
+    ctx = await target.get_agent_context()
+
+    tool = ctx.tools[0]
+    assert tool.name == 'Current Date & Time'
+    assert tool.description is None
+    assert tool.parameters is None
+    assert tool.action_type == 'datetime'
+    target.orq_client.tools.retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enrich_failure_degrades_gracefully():
+    binding = SimpleNamespace(
+        key='k', display_name=None, id='t3', description='binding desc', action_type='http', tool_id='tool_err'
+    )
+    target = _target_with_tools([binding])
+    target.orq_client.tools.retrieve.side_effect = RuntimeError('boom')
+
+    ctx = await target.get_agent_context()
+
+    tool = ctx.tools[0]
+    assert tool.name == 'k'
+    assert tool.description == 'binding desc'  # falls back to binding description
+    assert tool.parameters is None

--- a/tests/simulation/test_upload_base_url.py
+++ b/tests/simulation/test_upload_base_url.py
@@ -15,15 +15,15 @@ _EQ_MOD = sys.modules["evaluatorq.evaluatorq"]
 
 from evaluatorq.simulation.types import (
     CommunicationStyle,
-    Datapoint,
+    SimulationDatapoint,
     Message,
     Persona,
     Scenario,
 )
 
 
-def _make_datapoint() -> Datapoint:
-    return Datapoint(
+def _make_datapoint() -> SimulationDatapoint:
+    return SimulationDatapoint(
         id="dp-001",
         persona=Persona(
             name="P",


### PR DESCRIPTION
## Problem

Red team output showed tool entries like `{"name":"Current Date & Time","description":null,"parameters":null}`. The agent-retrieve endpoint (`RetrieveAgentRequestTools`) only returns a tool **binding** — `id, key, display_name, description, action_type, tool_id` — with **no JSON schema field at all**, and binding-level descriptions are null for built-in tools. The old code in `ORQAgentTarget.get_agent_context` hardcoded `parameters=None` and read only the binding description, so schema was never captured for any tool.

## Fix

- New `_enrich_tool(binding)` resolves each binding's `tool_id` via `tools.retrieve` to pull the underlying tool definition's real `description` and parameter schema (`function.parameters` or `json_schema.schema_`, coerced to `dict` via `model_dump()`).
- Bindings without a `tool_id` (built-ins like *Current Date & Time*) degrade to binding fields — that data genuinely isn't available on that endpoint.
- Runs inside the existing `asyncio.gather` enrichment block (alongside knowledge-base / memory-store enrichment) and fails gracefully with a warning.
- Adds `action_type` to `ToolInfo`.

## Tests

`tests/redteam/test_orq_tool_enrichment.py` — function tool, json_schema tool, no-`tool_id` degrade, and retrieve-failure degrade. All pass; full suite 1429 passing, basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)