### PR TITLE
feat(contracts): multi-modal Message content for chat completions (RES-879)

### DIFF
--- a/src/evaluatorq/common/messages.py
+++ b/src/evaluatorq/common/messages.py
@@ -12,17 +12,23 @@ def coerce_content_text(content: Any) -> str:
     ``[{"type": "text", "text": "..."}]``) surfaces the joined text rather than a
     Python ``repr`` of the list. ``None`` becomes ``""``; plain strings (and anything
     else) pass through ``str``.
+
+    Unlike :func:`evaluatorq.contracts.content_to_text`, this best-effort helper
+    does not raise on non-text parts (it is used in report/transcript rendering).
+    Image and file parts are surfaced as a ``[image]`` / ``[file]`` placeholder so
+    they are visibly accounted for rather than silently dropped.
     """
     if isinstance(content, list):
         texts: list[str] = []
         for part in content:
-            if isinstance(part, dict):
-                # Both the chat-completions ("text") and Responses ("input_text")
-                # shapes carry their text under a "text" key.
-                if part.get("type") in ("text", "input_text"):
-                    texts.append(part.get("text", ""))
-            elif getattr(part, "type", None) == "input_text":
-                # An InputTextContent pydantic content part.
-                texts.append(getattr(part, "text", ""))
+            part_type = part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+            # Both the chat-completions ("text") and Responses ("input_text")
+            # shapes carry their text under a "text" key.
+            if part_type in ("text", "input_text"):
+                texts.append(part.get("text", "") if isinstance(part, dict) else getattr(part, "text", ""))
+            elif part_type in ("image_url", "input_image"):
+                texts.append("[image]")
+            elif part_type in ("file", "input_file"):
+                texts.append("[file]")
         return "\n".join(texts)
     return str(content or "")

--- a/src/evaluatorq/common/messages.py
+++ b/src/evaluatorq/common/messages.py
@@ -14,9 +14,15 @@ def coerce_content_text(content: Any) -> str:
     else) pass through ``str``.
     """
     if isinstance(content, list):
-        return "\n".join(
-            part.get("text", "")
-            for part in content
-            if isinstance(part, dict) and part.get("type") == "text"
-        )
+        texts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                # Both the chat-completions ("text") and Responses ("input_text")
+                # shapes carry their text under a "text" key.
+                if part.get("type") in ("text", "input_text"):
+                    texts.append(part.get("text", ""))
+            elif getattr(part, "type", None) == "input_text":
+                # An InputTextContent pydantic content part.
+                texts.append(getattr(part, "text", ""))
+        return "\n".join(texts)
     return str(content or "")

--- a/src/evaluatorq/common/messages.py
+++ b/src/evaluatorq/common/messages.py
@@ -15,8 +15,9 @@ def coerce_content_text(content: Any) -> str:
 
     Unlike :func:`evaluatorq.contracts.content_to_text`, this best-effort helper
     does not raise on non-text parts (it is used in report/transcript rendering).
-    Image and file parts are surfaced as a ``[image]`` / ``[file]`` placeholder so
-    they are visibly accounted for rather than silently dropped.
+    Image and file parts are surfaced as a ``[image]`` / ``[file]`` placeholder,
+    and any other (unknown/future) part type as ``[<type>]``, so every part is
+    visibly accounted for rather than silently dropped.
     """
     if isinstance(content, list):
         texts: list[str] = []
@@ -30,5 +31,9 @@ def coerce_content_text(content: Any) -> str:
                 texts.append("[image]")
             elif part_type in ("file", "input_file"):
                 texts.append("[file]")
+            else:
+                # Unknown/future part shapes (e.g. audio, output_text) are still
+                # surfaced as a placeholder rather than vanishing silently.
+                texts.append(f"[{part_type or 'unknown'}]")
         return "\n".join(texts)
     return str(content or "")

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -35,6 +35,8 @@ def _content_part_to_chat_block(part: ContentPart) -> dict[str, Any]:
             image_url['url'] = part.image_url
         image_url['detail'] = part.detail
         return {'type': 'image_url', 'image_url': image_url}
+    if not isinstance(part, InputFileContent):
+        raise NotImplementedError(f'Unsupported content part: {part.type!r}')
     file_obj: dict[str, Any] = {}
     if part.file_id is not None:
         file_obj['file_id'] = part.file_id

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -11,6 +11,71 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias
 from loguru import logger
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_serializer, model_validator
 
+from evaluatorq.openresponses.convert_models import (
+    InputFileContent,
+    InputImageContent,
+    InputTextContent,
+)
+
+# A single part of multi-modal message content (Responses-API input shapes).
+ContentPart: TypeAlias = InputTextContent | InputImageContent | InputFileContent
+
+
+def _content_part_to_chat_block(part: ContentPart) -> dict[str, Any]:
+    """Render a Responses-style content part as an OpenAI chat-completions block.
+
+    Images and files use the chat-completions shapes (``image_url`` / ``file``),
+    which differ from the Responses ``input_image`` / ``input_file`` wire shapes.
+    """
+    if isinstance(part, InputTextContent):
+        return {'type': 'text', 'text': part.text}
+    if isinstance(part, InputImageContent):
+        image_url: dict[str, Any] = {}
+        if part.image_url is not None:
+            image_url['url'] = part.image_url
+        image_url['detail'] = part.detail
+        return {'type': 'image_url', 'image_url': image_url}
+    file_obj: dict[str, Any] = {}
+    if part.file_id is not None:
+        file_obj['file_id'] = part.file_id
+    if part.file_data is not None:
+        file_obj['file_data'] = part.file_data
+    if part.filename is not None:
+        file_obj['filename'] = part.filename
+    return {'type': 'file', 'file': file_obj}
+
+
+def _render_chat_content(content: str | list[ContentPart] | None) -> str | list[dict[str, Any]]:
+    """Render message content for the chat-completions API: a plain string, or a
+    list of content blocks for multi-modal content."""
+    if isinstance(content, list):
+        return [_content_part_to_chat_block(p) for p in content]
+    return content or ''
+
+
+def content_to_text(content: str | list[ContentPart] | None) -> str:
+    """Flatten message content to plain text.
+
+    For targets that accept only text: a string (or ``None``) passes through; a
+    multi-part list is joined from its text parts, but a non-text part (image or
+    file) raises :class:`NotImplementedError` with a clear message rather than
+    silently dropping content.
+    """
+    if content is None:
+        return ''
+    if isinstance(content, str):
+        return content
+    out: list[str] = []
+    for part in content:
+        if isinstance(part, InputTextContent):
+            out.append(part.text)
+        else:
+            raise NotImplementedError(
+                f'This target accepts only text content; got a {part.type!r} part. '
+                'Use a Responses-API target (OrqResponsesTarget) for image/file content.'
+            )
+    return ''.join(out)
+
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
@@ -138,10 +203,13 @@ class Message(BaseModel):
     - Tool response: ``{"role": "tool", "tool_call_id": "...", "name": "...", "content": "..."}``
     """
 
-    role: Literal['user', 'assistant', 'tool', 'system']
-    content: str | None = Field(
+    role: Literal['user', 'assistant', 'tool', 'system', 'developer']
+    content: str | list[ContentPart] | None = Field(
         default=None,
-        description='Message content (required for user/system, optional for assistant with tool_calls)',
+        description=(
+            'Message content. A plain string, or a list of multi-modal content parts '
+            '(text/image/file). Required for user/system, optional for assistant with tool_calls.'
+        ),
     )
 
     # Tool call fields (OpenAI format)
@@ -185,7 +253,7 @@ class Message(BaseModel):
                     for tc in self.tool_calls
                 ],
             }
-        return {'role': self.role, 'content': self.content or ''}
+        return {'role': self.role, 'content': _render_chat_content(self.content)}
 
 
 def _usage_get(usage: Any, key: str, default: Any = None) -> Any:

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -18,7 +18,12 @@ from evaluatorq.openresponses.convert_models import (
 )
 
 # A single part of multi-modal message content (Responses-API input shapes).
-ContentPart: TypeAlias = InputTextContent | InputImageContent | InputFileContent
+# Tagged on ``type`` (mirroring ``OutputMessage``) so Pydantic dispatches on the
+# discriminator rather than try-each-member matching.
+ContentPart: TypeAlias = Annotated[
+    InputTextContent | InputImageContent | InputFileContent,
+    Field(discriminator='type'),
+]
 
 
 def _content_part_to_chat_block(part: ContentPart) -> dict[str, Any]:
@@ -30,13 +35,23 @@ def _content_part_to_chat_block(part: ContentPart) -> dict[str, Any]:
     if isinstance(part, InputTextContent):
         return {'type': 'text', 'text': part.text}
     if isinstance(part, InputImageContent):
-        image_url: dict[str, Any] = {}
-        if part.image_url is not None:
-            image_url['url'] = part.image_url
-        image_url['detail'] = part.detail
-        return {'type': 'image_url', 'image_url': image_url}
+        if part.image_url is None:
+            # A file_id-only image is a Responses-API shape; chat-completions has
+            # no slot for it, so emitting a block without a url would be silently
+            # invalid. Fail loudly instead.
+            raise NotImplementedError(
+                'file_id-backed images are Responses-API only; use OrqResponsesTarget.'
+            )
+        return {'type': 'image_url', 'image_url': {'url': part.image_url, 'detail': part.detail}}
     if not isinstance(part, InputFileContent):
         raise NotImplementedError(f'Unsupported content part: {part.type!r}')
+    if part.file_id is None and part.file_data is None:
+        # file_url/mime_type are intentionally Responses-only — the chat-completions
+        # file block has no slot for them. Without file_id or file_data there is no
+        # representable content, so fail loudly rather than emit an empty block.
+        raise NotImplementedError(
+            'file_url-backed files are Responses-API only; use OrqResponsesTarget.'
+        )
     file_obj: dict[str, Any] = {}
     if part.file_id is not None:
         file_obj['file_id'] = part.file_id
@@ -59,9 +74,9 @@ def content_to_text(content: str | list[ContentPart] | None) -> str:
     """Flatten message content to plain text.
 
     For targets that accept only text: a string (or ``None``) passes through; a
-    multi-part list is joined from its text parts, but a non-text part (image or
-    file) raises :class:`NotImplementedError` with a clear message rather than
-    silently dropping content.
+    multi-part list is concatenated from its text parts (no separator), but a
+    non-text part (image or file) raises :class:`NotImplementedError` with a clear
+    message rather than silently dropping content.
     """
     if content is None:
         return ''
@@ -77,6 +92,7 @@ def content_to_text(content: str | list[ContentPart] | None) -> str:
                 'Use a Responses-API target (OrqResponsesTarget) for image/file content.'
             )
     return ''.join(out)
+
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -993,6 +1009,7 @@ __all__ = [
     'AgentResponse',
     'AgentResponseError',
     'AgentTarget',
+    'ContentPart',
     'FunctionCall',
     'JuryResult',
     'JuryStats',
@@ -1010,4 +1027,5 @@ __all__ = [
     'TokenUsage',
     'ToolCallOutputItem',
     'ToolInfo',
+    'content_to_text',
 ]

--- a/src/evaluatorq/integrations/crewai_integration/target.py
+++ b/src/evaluatorq/integrations/crewai_integration/target.py
@@ -33,6 +33,7 @@ from evaluatorq.contracts import (
     OutputMessage,
     TextOutputItem,
     TokenUsage,
+    content_to_text,
 )
 
 if TYPE_CHECKING:
@@ -174,7 +175,7 @@ def _flatten(messages: list[Message]) -> str:
         # Escape braces: CrewAI fills {input_key} via str.format on the task
         # description, so any literal { } in user content would otherwise raise
         # KeyError or collide with other task variables (template injection).
-        safe = m.content.replace("{", "{{").replace("}", "}}")
+        safe = content_to_text(m.content).replace("{", "{{").replace("}", "}}")
         lines.append(f"{label}: {safe}")
     return "\n".join(lines)
 

--- a/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -24,6 +24,7 @@ from evaluatorq.contracts import (
     TokenUsage,
     ToolCallOutputItem,
     ToolInfo,
+    content_to_text,
 )
 
 if TYPE_CHECKING:
@@ -169,7 +170,7 @@ class LangGraphTarget(AgentTarget):
         """
         if not messages or messages[-1].role != 'user':
             raise ValueError("LangGraphTarget.respond requires messages[-1].role == 'user'")
-        prompt = messages[-1].content or ''
+        prompt = content_to_text(messages[-1].content)
         collector = _TokenUsageCollector()
 
         base_config = self._build_config()

--- a/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -337,4 +337,7 @@ def _message_to_responses_input_items(m: Message) -> list[dict[str, Any]]:
                 fc['id'] = tc.item_id
             items.append(fc)
         return items
+    # Multi-part content passes straight through as Responses-API content parts.
+    if isinstance(m.content, list):
+        return [{'role': m.role, 'content': [p.model_dump(mode='json') for p in m.content]}]
     return [{'role': m.role, 'content': m.content or ''}]

--- a/src/evaluatorq/integrations/pydantic_ai_integration/target.py
+++ b/src/evaluatorq/integrations/pydantic_ai_integration/target.py
@@ -17,6 +17,7 @@ from evaluatorq.contracts import (
     TextOutputItem,
     TokenUsage,
     ToolCallOutputItem,
+    content_to_text,
 )
 
 if TYPE_CHECKING:
@@ -83,7 +84,7 @@ class PydanticAITarget(AgentTarget):
         """Send the latest user turn to the agent; thread history internally."""
         if not messages or messages[-1].role != "user":
             raise ValueError("PydanticAITarget.respond requires messages[-1].role == 'user'")
-        prompt = messages[-1].content or ""
+        prompt = content_to_text(messages[-1].content)
 
         result = await self._agent.run(
             prompt,

--- a/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -27,6 +27,7 @@ from evaluatorq.contracts import (
     OutputMessage,
     TextOutputItem,
     TokenUsage,
+    content_to_text,
 )
 
 AISdkMessageFormat = Literal['v4', 'v5']
@@ -214,7 +215,7 @@ def _message_to_ai_sdk_message(m: Message, *, version: AISdkMessageFormat = 'v5'
     if m.role == 'assistant' and m.tool_calls:
         parts: list[dict[str, Any]] = []
         if m.content:
-            parts.append({'type': 'text', 'text': m.content})
+            parts.append({'type': 'text', 'text': content_to_text(m.content)})
         input_key = 'args' if version == 'v4' else 'input'
         for tc in m.tool_calls:
             try:
@@ -229,7 +230,7 @@ def _message_to_ai_sdk_message(m: Message, *, version: AISdkMessageFormat = 'v5'
                 input_key: tool_input,
             })
         return {'role': 'assistant', 'content': parts}
-    return {'role': m.role, 'content': m.content or ''}
+    return {'role': m.role, 'content': content_to_text(m.content)}
 
 
 def _parse_data_stream(raw: str) -> tuple[str, TokenUsage | None]:

--- a/src/evaluatorq/openresponses/target.py
+++ b/src/evaluatorq/openresponses/target.py
@@ -182,11 +182,15 @@ class OrqResponsesTarget(AgentTarget):
     def _messages_to_input(messages: list[Message]) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
         for m in messages:
+            # Multi-part content (text + image/file) passes straight through to
+            # the Responses API as input content parts.
+            if isinstance(m.content, list):
+                content: Any = [p.model_dump(mode="json") for p in m.content]
             # Assistant messages with tool_calls require content: null per
             # OpenAI's spec; collapsing None to "" produces an invalid payload.
             # For other roles, the API expects a string, so coerce None -> "".
-            if m.role == "assistant":
-                content: Any = m.content
+            elif m.role == "assistant":
+                content = m.content
             else:
                 content = m.content or ""
             d: dict[str, Any] = {"role": m.role, "content": content}

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -43,7 +43,7 @@ def _get_orq_server_url() -> str:
     return url.rstrip('/').removesuffix('/v3/router')
 
 
-from evaluatorq.contracts import AgentTarget, Message
+from evaluatorq.contracts import AgentTarget, Message, content_to_text
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
 from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
@@ -151,7 +151,7 @@ class ORQAgentTarget(AgentTarget):
                 "ORQAgentTarget.respond requires messages[-1].role == 'user'. "
                 'Server-side conversation state is held via task_id.'
             )
-        prompt = messages[-1].content or ''
+        prompt = content_to_text(messages[-1].content)
         accumulated_usage = TokenUsage()
 
         def _accumulate_usage(resp: object) -> None:

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -43,6 +43,7 @@ def _get_orq_server_url() -> str:
     return url.rstrip('/').removesuffix('/v3/router')
 
 
+from evaluatorq.common.tracing import record_token_usage, set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentTarget, Message, content_to_text
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
 from evaluatorq.redteam.backends.base import Backend
@@ -58,7 +59,6 @@ from evaluatorq.redteam.contracts import (
     ToolCallOutputItem,
     ToolInfo,
 )
-from evaluatorq.common.tracing import record_token_usage, set_span_attrs, truncate_for_span
 from evaluatorq.redteam.tracing import with_redteam_span
 
 

--- a/src/evaluatorq/redteam/reports/_utils.py
+++ b/src/evaluatorq/redteam/reports/_utils.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from evaluatorq.common.messages import coerce_content_text
+
 if TYPE_CHECKING:
     from evaluatorq.redteam.contracts import RedTeamResult
 
@@ -12,7 +14,7 @@ def extract_prompt(result: RedTeamResult) -> str:
     """Extract the first user message content as the attack prompt."""
     for msg in result.messages:
         if msg.role == "user" and msg.content:
-            return msg.content
+            return coerce_content_text(msg.content)
     return ""
 
 
@@ -23,5 +25,5 @@ def extract_response(result: RedTeamResult) -> str:
     # Fall back to last assistant message
     for msg in reversed(result.messages):
         if msg.role == "assistant" and msg.content:
-            return msg.content
+            return coerce_content_text(msg.content)
     return ""

--- a/src/evaluatorq/simulation/adapters.py
+++ b/src/evaluatorq/simulation/adapters.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
+from evaluatorq.contracts import content_to_text
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -27,7 +29,7 @@ def from_orq_deployment(
 
         return await invoke(
             agent_key,
-            messages=[{"role": m.role, "content": m.content or ""} for m in messages],
+            messages=[{"role": m.role, "content": content_to_text(m.content)} for m in messages],
         )
 
     return callback
@@ -42,7 +44,7 @@ def from_chat_completions(
     """
 
     async def callback(messages: list[Message]) -> str:
-        result = fn([{"role": m.role, "content": m.content or ""} for m in messages])
+        result = fn([{"role": m.role, "content": content_to_text(m.content)} for m in messages])
         if inspect.isawaitable(result):
             return await result
         return result

--- a/src/evaluatorq/simulation/convert.py
+++ b/src/evaluatorq/simulation/convert.py
@@ -6,6 +6,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from evaluatorq.contracts import content_to_text
 from evaluatorq.openresponses.convert_models import (
     FunctionCall,
     FunctionCallOutput,
@@ -57,7 +58,7 @@ def to_open_responses(
     for msg in result.messages:
         if msg.role in ("user", "system"):
             in_content: _ContentList = [
-                InputTextContent(type="input_text", text=msg.content or "")
+                InputTextContent(type="input_text", text=content_to_text(msg.content))
             ]
             message = Message(
                 type="message",
@@ -74,7 +75,7 @@ def to_open_responses(
             # text message. Mirrors the langchain integration's mapping.
             if msg.content:
                 out_content: _ContentList = [
-                    OutputTextContent(text=msg.content, annotations=[])
+                    OutputTextContent(text=content_to_text(msg.content), annotations=[])
                 ]
                 message = Message(
                     type="message",
@@ -99,7 +100,7 @@ def to_open_responses(
                 type="function_call_output",
                 id=_generate_item_id("fco"),
                 call_id=msg.tool_call_id or "",
-                output=msg.content or "",
+                output=content_to_text(msg.content),
                 status=FunctionCallStatus.completed,
             )
             output_items.append(function_call_output.model_dump(mode="json"))

--- a/src/evaluatorq/simulation/reports/sections.py
+++ b/src/evaluatorq/simulation/reports/sections.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from evaluatorq.common.messages import coerce_content_text
 from evaluatorq.contracts import ReportSection
 from evaluatorq.simulation.types import CriteriaRow, SimulationEntry, TranscriptMessage
 
@@ -384,7 +385,7 @@ def individual_entries(results: list[SimulationResult]) -> list[SimulationEntry]
                 error=_error_message(r),
                 evaluator_scores=_evaluator_scores(r),
                 transcript=[
-                    TranscriptMessage(role=m.role, content=m.content or '')
+                    TranscriptMessage(role=m.role, content=coerce_content_text(m.content))
                     for m in r.messages
                 ],
             )

--- a/tests/common/test_messages.py
+++ b/tests/common/test_messages.py
@@ -27,9 +27,19 @@ def test_list_surfaces_non_text_parts_as_placeholders():
         {"type": "text", "text": "keep"},
         {"type": "image_url", "image_url": {"url": "http://x"}},
         {"type": "input_file", "file_id": "f-1"},
-        "not-a-dict",
     ]
     assert coerce_content_text(content) == "keep\n[image]\n[file]"
+
+
+def test_list_surfaces_unknown_part_types_as_placeholders():
+    """Unknown/future part shapes are surfaced, not silently dropped."""
+    content = [
+        {"type": "text", "text": "keep"},
+        {"type": "input_audio", "input_audio": {}},
+        {"type": "output_text", "text": "ignored-key"},
+        "not-a-dict",
+    ]
+    assert coerce_content_text(content) == "keep\n[input_audio]\n[output_text]\n[unknown]"
 
 
 def test_empty_list_is_empty_string():

--- a/tests/common/test_messages.py
+++ b/tests/common/test_messages.py
@@ -21,13 +21,15 @@ def test_list_content_surfaces_text_parts():
     assert coerce_content_text(content) == "first\nsecond"
 
 
-def test_list_ignores_non_text_parts():
+def test_list_surfaces_non_text_parts_as_placeholders():
+    """Image/file parts are visibly accounted for, not silently dropped."""
     content = [
         {"type": "text", "text": "keep"},
         {"type": "image_url", "image_url": {"url": "http://x"}},
+        {"type": "input_file", "file_id": "f-1"},
         "not-a-dict",
     ]
-    assert coerce_content_text(content) == "keep"
+    assert coerce_content_text(content) == "keep\n[image]\n[file]"
 
 
 def test_empty_list_is_empty_string():

--- a/tests/contracts/test_message_multimodal.py
+++ b/tests/contracts/test_message_multimodal.py
@@ -1,0 +1,88 @@
+"""RES-879: Message supports the developer role and multi-part content."""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.contracts import ContentPart, Message, content_to_text
+from evaluatorq.openresponses.convert_models import InputImageContent, InputTextContent
+
+
+def test_developer_role_accepted() -> None:
+    m = Message(role="developer", content="You are a developer assistant.")
+    assert m.role == "developer"
+
+
+def test_content_accepts_multipart_list() -> None:
+    m = Message(
+        role="user",
+        content=[
+            InputTextContent(type="input_text", text="what is this?"),
+            InputImageContent(type="input_image", image_url="https://x/y.png"),
+        ],
+    )
+    assert isinstance(m.content, list)
+    assert len(m.content) == 2
+    assert isinstance(m.content[1], InputImageContent)
+
+
+def test_text_only_content_still_works() -> None:
+    """No regression: the string shorthand still validates."""
+    m = Message(role="user", content="hello")
+    assert m.content == "hello"
+    assert m.to_chat_completion() == {"role": "user", "content": "hello"}
+
+
+def test_to_chat_completion_renders_multipart() -> None:
+    m = Message(
+        role="user",
+        content=[
+            InputTextContent(type="input_text", text="describe"),
+            InputImageContent(type="input_image", image_url="https://x/y.png", detail="low"),
+        ],
+    )
+    out = m.to_chat_completion()
+    assert out["role"] == "user"
+    assert out["content"] == [
+        {"type": "text", "text": "describe"},
+        {"type": "image_url", "image_url": {"url": "https://x/y.png", "detail": "low"}},
+    ]
+
+
+def test_orq_responses_target_passes_multipart_through() -> None:
+    """The Responses target serializes multi-part content to input content parts."""
+    from evaluatorq.openresponses.target import OrqResponsesTarget
+
+    m = Message(
+        role="user",
+        content=[
+            InputTextContent(type="input_text", text="what is this?"),
+            InputImageContent(type="input_image", image_url="https://x/y.png"),
+        ],
+    )
+    items = OrqResponsesTarget._messages_to_input([m])
+    assert items[0]["role"] == "user"
+    parts = items[0]["content"]
+    assert isinstance(parts, list)
+    assert parts[0]["type"] == "input_text"
+    assert parts[0]["text"] == "what is this?"
+    assert parts[1]["type"] == "input_image"
+    assert parts[1]["image_url"] == "https://x/y.png"
+
+
+def test_content_to_text_raises_on_image_part() -> None:
+    """Text-only targets refuse non-text content rather than silently dropping it."""
+    content: list[ContentPart] = [
+        InputTextContent(type="input_text", text="hi"),
+        InputImageContent(type="input_image", image_url="https://x/y.png"),
+    ]
+    with pytest.raises(NotImplementedError):
+        content_to_text(content)
+
+
+def test_content_to_text_text_only() -> None:
+    content: list[ContentPart] = [
+        InputTextContent(type="input_text", text="a"),
+        InputTextContent(type="input_text", text="b"),
+    ]
+    assert content_to_text(content) == "ab"

--- a/tests/contracts/test_message_multimodal.py
+++ b/tests/contracts/test_message_multimodal.py
@@ -5,22 +5,31 @@ from __future__ import annotations
 import pytest
 
 from evaluatorq.contracts import ContentPart, Message, content_to_text
-from evaluatorq.openresponses.convert_models import InputImageContent, InputTextContent
+from evaluatorq.openresponses.convert_models import (
+    InputFileContent,
+    InputImageContent,
+    InputTextContent,
+)
+
+
+@pytest.fixture
+def text_and_image() -> list[ContentPart]:
+    """A reusable text + image multi-part content list."""
+    return [
+        InputTextContent(type="input_text", text="what is this?"),
+        InputImageContent(type="input_image", image_url="https://x/y.png"),
+    ]
 
 
 def test_developer_role_accepted() -> None:
     m = Message(role="developer", content="You are a developer assistant.")
     assert m.role == "developer"
+    # Round-trips through chat-completions rendering, not just model validation.
+    assert m.to_chat_completion() == {"role": "developer", "content": "You are a developer assistant."}
 
 
-def test_content_accepts_multipart_list() -> None:
-    m = Message(
-        role="user",
-        content=[
-            InputTextContent(type="input_text", text="what is this?"),
-            InputImageContent(type="input_image", image_url="https://x/y.png"),
-        ],
-    )
+def test_content_accepts_multipart_list(text_and_image: list[ContentPart]) -> None:
+    m = Message(role="user", content=text_and_image)
     assert isinstance(m.content, list)
     assert len(m.content) == 2
     assert isinstance(m.content[1], InputImageContent)
@@ -49,17 +58,32 @@ def test_to_chat_completion_renders_multipart() -> None:
     ]
 
 
-def test_orq_responses_target_passes_multipart_through() -> None:
-    """The Responses target serializes multi-part content to input content parts."""
-    from evaluatorq.openresponses.target import OrqResponsesTarget
-
+def test_to_chat_completion_renders_file_part() -> None:
+    """An InputFileContent part serializes to the chat-completions ``file`` block."""
     m = Message(
         role="user",
         content=[
-            InputTextContent(type="input_text", text="what is this?"),
-            InputImageContent(type="input_image", image_url="https://x/y.png"),
+            InputTextContent(type="input_text", text="summarize"),
+            InputFileContent(type="input_file", file_id="file-123", filename="doc.pdf"),
         ],
     )
+    out = m.to_chat_completion()
+    assert out["content"] == [
+        {"type": "text", "text": "summarize"},
+        {"type": "file", "file": {"file_id": "file-123", "filename": "doc.pdf"}},
+    ]
+
+
+def test_orq_responses_target_passes_multipart_through(text_and_image: list[ContentPart]) -> None:
+    """The Responses target serializes multi-part content to input content parts.
+
+    Note: this exercises the private ``_messages_to_input`` directly to assert the
+    serialized wire shape without a live call; it is coupled to that implementation
+    detail by design.
+    """
+    from evaluatorq.openresponses.target import OrqResponsesTarget
+
+    m = Message(role="user", content=text_and_image)
     items = OrqResponsesTarget._messages_to_input([m])
     assert items[0]["role"] == "user"
     parts = items[0]["content"]
@@ -86,3 +110,7 @@ def test_content_to_text_text_only() -> None:
         InputTextContent(type="input_text", text="b"),
     ]
     assert content_to_text(content) == "ab"
+
+
+def test_content_to_text_empty_list() -> None:
+    assert content_to_text([]) == ""

--- a/tests/contracts/test_message_multimodal.py
+++ b/tests/contracts/test_message_multimodal.py
@@ -94,13 +94,43 @@ def test_orq_responses_target_passes_multipart_through(text_and_image: list[Cont
     assert parts[1]["image_url"] == "https://x/y.png"
 
 
+def test_to_chat_completion_raises_on_file_id_only_image() -> None:
+    """A file_id-only image is Responses-only and must not render an invalid block."""
+    m = Message(
+        role="user",
+        content=[InputImageContent(type="input_image", file_id="file-123")],
+    )
+    with pytest.raises(NotImplementedError, match="file_id-backed images"):
+        m.to_chat_completion()
+
+
+def test_to_chat_completion_raises_on_file_url_only_file() -> None:
+    """A file_url-only file has no chat-completions slot and must fail loudly."""
+    m = Message(
+        role="user",
+        content=[InputFileContent(type="input_file", file_url="https://x/y.pdf")],
+    )
+    with pytest.raises(NotImplementedError, match="file_url-backed files"):
+        m.to_chat_completion()
+
+
 def test_content_to_text_raises_on_image_part() -> None:
     """Text-only targets refuse non-text content rather than silently dropping it."""
     content: list[ContentPart] = [
         InputTextContent(type="input_text", text="hi"),
         InputImageContent(type="input_image", image_url="https://x/y.png"),
     ]
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="accepts only text content"):
+        content_to_text(content)
+
+
+def test_content_to_text_raises_on_file_part() -> None:
+    """The raise covers every non-text part, not just images."""
+    content: list[ContentPart] = [
+        InputTextContent(type="input_text", text="hi"),
+        InputFileContent(type="input_file", file_id="file-123"),
+    ]
+    with pytest.raises(NotImplementedError, match="accepts only text content"):
         content_to_text(content)
 
 

--- a/tests/integration/test_callable_integration.py
+++ b/tests/integration/test_callable_integration.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from evaluatorq.contracts import Message
+from evaluatorq.contracts import Message, content_to_text
 from evaluatorq.integrations.callable_integration import CallableTarget
 
 
@@ -18,7 +18,7 @@ class TestCallableIntegration:
         history: list[str] = []
 
         async def stateful_agent(messages: list[Message]) -> str:
-            history.append(messages[-1].content or "")
+            history.append(content_to_text(messages[-1].content))
             return f"You said {len(history)} things so far."
 
         def reset() -> None:

--- a/tests/integration/test_orq_responses_target_integration.py
+++ b/tests/integration/test_orq_responses_target_integration.py
@@ -15,7 +15,16 @@ import os
 import pytest
 
 from evaluatorq.contracts import AgentResponse, LLMCallConfig, Message
+from evaluatorq.openresponses.convert_models import InputImageContent, InputTextContent
 from evaluatorq.openresponses.target import OrqResponsesTarget
+
+# 1x1 red PNG, base64 data URL.
+_RED_PIXEL_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+# A small, stable public image.
+_HTTPS_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png"
 
 
 @pytest.mark.integration
@@ -53,3 +62,52 @@ class TestOrqResponsesTargetIntegration:
         # Usage is reported on the response itself (no instance accumulation).
         assert r2.usage is not None
         assert r2.usage.total_tokens > 0
+
+    @pytest.mark.asyncio
+    async def test_multipart_image_base64_round_trips(self):
+        """RES-879: a base64 image part flows through respond to a vision model."""
+        if not os.environ.get("ORQ_API_KEY"):
+            pytest.skip("ORQ_API_KEY not set")
+
+        config = LLMCallConfig(model="openai/gpt-4o-mini")
+        target = OrqResponsesTarget(config, instructions="Reply tersely.")
+
+        r = await target.respond(
+            [
+                Message(
+                    role="user",
+                    content=[
+                        InputTextContent(
+                            type="input_text",
+                            text="Reply with the single word RED if you can see the image.",
+                        ),
+                        InputImageContent(type="input_image", image_url=_RED_PIXEL_DATA_URL),
+                    ],
+                )
+            ]
+        )
+        assert isinstance(r, AgentResponse)
+        assert r.text
+
+    @pytest.mark.asyncio
+    async def test_multipart_image_https_round_trips(self):
+        """RES-879: an https image part flows through respond to a vision model."""
+        if not os.environ.get("ORQ_API_KEY"):
+            pytest.skip("ORQ_API_KEY not set")
+
+        config = LLMCallConfig(model="openai/gpt-4o-mini")
+        target = OrqResponsesTarget(config, instructions="Reply tersely.")
+
+        r = await target.respond(
+            [
+                Message(
+                    role="user",
+                    content=[
+                        InputTextContent(type="input_text", text="Describe this image in one short sentence."),
+                        InputImageContent(type="input_image", image_url=_HTTPS_IMAGE_URL),
+                    ],
+                )
+            ]
+        )
+        assert isinstance(r, AgentResponse)
+        assert r.text

--- a/tests/integration/test_orq_responses_target_integration.py
+++ b/tests/integration/test_orq_responses_target_integration.py
@@ -18,13 +18,16 @@ from evaluatorq.contracts import AgentResponse, LLMCallConfig, Message
 from evaluatorq.openresponses.convert_models import InputImageContent, InputTextContent
 from evaluatorq.openresponses.target import OrqResponsesTarget
 
-# 1x1 red PNG, base64 data URL.
+# 1x1 solid-color PNGs as base64 data URLs. Self-contained so the tests do not
+# depend on any live external URL (which could rate-limit, move, or change).
 _RED_PIXEL_DATA_URL = (
     "data:image/png;base64,"
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 )
-# A small, stable public image.
-_HTTPS_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png"
+_GREEN_PIXEL_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNg+M8AAAICAQB7CYF4AAAAAElFTkSuQmCC"
+)
 
 
 @pytest.mark.integration
@@ -65,7 +68,11 @@ class TestOrqResponsesTargetIntegration:
 
     @pytest.mark.asyncio
     async def test_multipart_image_base64_round_trips(self):
-        """RES-879: a base64 image part flows through respond to a vision model."""
+        """RES-879: a base64 image part actually reaches the vision model.
+
+        Asserts the model reports the image color, not merely that the HTTP call
+        succeeded -- a truthy ``r.text`` would pass even if the image were dropped.
+        """
         if not os.environ.get("ORQ_API_KEY"):
             pytest.skip("ORQ_API_KEY not set")
 
@@ -79,7 +86,7 @@ class TestOrqResponsesTargetIntegration:
                     content=[
                         InputTextContent(
                             type="input_text",
-                            text="Reply with the single word RED if you can see the image.",
+                            text="What color is this image? Reply with just the color name.",
                         ),
                         InputImageContent(type="input_image", image_url=_RED_PIXEL_DATA_URL),
                     ],
@@ -87,11 +94,15 @@ class TestOrqResponsesTargetIntegration:
             ]
         )
         assert isinstance(r, AgentResponse)
-        assert r.text
+        assert "red" in r.text.lower()
 
     @pytest.mark.asyncio
-    async def test_multipart_image_https_round_trips(self):
-        """RES-879: an https image part flows through respond to a vision model."""
+    async def test_multipart_second_image_round_trips(self):
+        """RES-879: a second, distinct image part also reaches the vision model.
+
+        Uses a different color so a stale/cached/dropped image would fail the
+        assertion. Base64 data URL keeps the test free of any live dependency.
+        """
         if not os.environ.get("ORQ_API_KEY"):
             pytest.skip("ORQ_API_KEY not set")
 
@@ -103,11 +114,14 @@ class TestOrqResponsesTargetIntegration:
                 Message(
                     role="user",
                     content=[
-                        InputTextContent(type="input_text", text="Describe this image in one short sentence."),
-                        InputImageContent(type="input_image", image_url=_HTTPS_IMAGE_URL),
+                        InputTextContent(
+                            type="input_text",
+                            text="What color is this image? Reply with just the color name.",
+                        ),
+                        InputImageContent(type="input_image", image_url=_GREEN_PIXEL_DATA_URL),
                     ],
                 )
             ]
         )
         assert isinstance(r, AgentResponse)
-        assert r.text
+        assert "green" in r.text.lower()

--- a/tests/integrations/test_respond_smoke.py
+++ b/tests/integrations/test_respond_smoke.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from evaluatorq.contracts import AgentResponse, AgentTarget, Message
+from evaluatorq.contracts import AgentResponse, AgentTarget, Message, content_to_text
 
 
 def _msgs(content: str = "hi") -> list[Message]:
@@ -36,7 +36,7 @@ async def test_callable_target_respond_accepts_non_user_last():
     """CallableTarget forwards the whole transcript; it imposes no last-turn-role guard."""
     from evaluatorq.integrations.callable_integration import CallableTarget
 
-    target = CallableTarget(lambda messages: messages[-1].content or "")
+    target = CallableTarget(lambda messages: content_to_text(messages[-1].content))
     result = await target.respond([Message(role="assistant", content="x")])
     assert result.text == "x"
 

--- a/tests/redteam/e2e/conftest.py
+++ b/tests/redteam/e2e/conftest.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from evaluatorq.contracts import AgentTarget, Message
+from evaluatorq.contracts import AgentTarget, Message, content_to_text
 from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
     AgentContext,
@@ -138,7 +138,7 @@ class MockAgentTarget(AgentTarget):
         self._conversation: list[dict[str, str]] = []
 
     async def respond(self, messages: list[Message]) -> AgentResponse:
-        prompt = messages[-1].content or "" if messages else ""
+        prompt = content_to_text(messages[-1].content) if messages else ""
         lower = prompt.lower()
         if "ignore previous instructions" in lower or "system prompt" in lower or "hidden instructions" in lower:
             return AgentResponse(text="SYSTEM_PROMPT: internal guardrails. SUPER_SECRET_TOKEN=abc123")

--- a/tests/redteam/test_orchestrator_coverage.py
+++ b/tests/redteam/test_orchestrator_coverage.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from evaluatorq.contracts import AgentResponse
+from evaluatorq.contracts import AgentResponse, content_to_text
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AttackStrategy,
@@ -839,7 +839,8 @@ class TestRunAttack:
         # Turn 1 recorded an error message placeholder in the conversation
         turn1_assistant = result.chat_completions[1]
         assert turn1_assistant.content is not None
-        assert "ERROR" in turn1_assistant.content or "timed out" in turn1_assistant.content.lower()
+        _turn1_text = content_to_text(turn1_assistant.content)
+        assert "ERROR" in _turn1_text or "timed out" in _turn1_text.lower()
 
     @pytest.mark.asyncio
     @patch(_PATCH_RECORD_LLM)

--- a/tests/unit/test_redteam_targets.py
+++ b/tests/unit/test_redteam_targets.py
@@ -8,14 +8,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from evaluatorq.contracts import Message
+from evaluatorq.contracts import Message, content_to_text
 from evaluatorq.integrations.callable_integration import CallableTarget
 from evaluatorq.redteam.contracts import AgentResponse, OutputMessage, TextOutputItem, TokenUsage, ToolCallOutputItem
 
 
 def _last(messages: list[Message]) -> str:
     """Read the last turn's content off a Message list."""
-    return messages[-1].content or ""
+    return content_to_text(messages[-1].content)
 
 
 class TestCallableTarget:
@@ -252,7 +252,7 @@ class TestCallableTargetUsage:
         captured: dict[str, list[str]] = {}
 
         def usage_fn(messages: list[Message], response: str) -> TokenUsage:
-            captured["contents"] = [m.content or "" for m in messages]
+            captured["contents"] = [content_to_text(m.content) for m in messages]
             return TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2, calls=1)
 
         target = CallableTarget(lambda messages: "response", usage_fn=usage_fn)


### PR DESCRIPTION
## What

Extends `contracts.Message` so chat-completion messages can carry multi-modal input.

- `content` is now `str | list[ContentPart] | None`, where `ContentPart` is the Responses-API `InputTextContent | InputImageContent | InputFileContent`. The string shorthand still validates and round-trips unchanged.
- Adds the `developer` role.
- `to_chat_completion()` renders a multi-part list into Chat-Completions content blocks (`text` / `image_url`).

## Targets, by capability

- **Responses targets** (`OrqResponsesTarget`, `OpenAIAgentTarget`) pass multi-part content straight through as Responses input content parts.
- **Chat/string targets** (`LangGraph`, `Vercel`, `ORQAgent`) flatten via `content_to_text`, which raises `NotImplementedError` on image/file parts instead of silently dropping them.
- Report/transcript paths coerce best-effort via `coerce_content_text`.

## Tests

- Contract tests: developer role, multipart validation, `to_chat_completion` rendering, `OrqResponsesTarget` pass-through serialization, convert-or-raise.
- Live vision integration tests (base64 + https image) gated on `ORQ_API_KEY` — currently credit-blocked in the workspace, so they ship but are skipped in the default run.

## Notes

Stacked on #17 (BOPS-839). Review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)