### PR TITLE
docs(redteam): fix -v → -V vulnerability flag (RES-1005)

### DIFF
--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -301,7 +301,7 @@ STRATEGY_REGISTRY.update(BIAS_STRATEGIES)
 
 Then run:
 ```bash
-eq redteam run -t agent:my-agent -v bias_gender --mode dynamic
+eq redteam run -t agent:my-agent -V bias_gender --mode dynamic
 ```
 
 ## Running with Custom Vulnerabilities
@@ -309,7 +309,7 @@ eq redteam run -t agent:my-agent -v bias_gender --mode dynamic
 ### CLI
 ```bash
 # By vulnerability ID
-eq redteam run -t agent:my-agent -v my_custom_vuln --mode dynamic
+eq redteam run -t agent:my-agent -V my_custom_vuln --mode dynamic
 
 # By category code (if mapped)
 eq redteam run -t agent:my-agent -c MF01 --mode dynamic


### PR DESCRIPTION
## What

`docs/custom-evaluators-and-frameworks.md` showed `eq redteam run -t agent:my-agent -v bias_gender` (and `-v my_custom_vuln`). `-v` is `--verbose` (a count); the vulnerability flag is `-V` (`--vulnerability`, verified in `src/evaluatorq/redteam/cli.py:206-207,321-322`). Those commands silently misparse. Fixed `-v` → `-V` in both spots.

## Scope

Just the wrong-flag bug from RES-1005. The other CLI-accuracy items in that ticket (command-prefix consistency, persistence-flag intro, positional-arg naming, `--sim-model` default check, `eq --version` docs) remain open.

Closes part of [RES-1005](https://linear.app/orqai/issue/RES-1005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)