### PR TITLE
feat(evaluatorq): no-inference mode — replay pre-recorded responses (RES-993)

### DIFF
--- a/src/evaluatorq/evaluatorq.py
+++ b/src/evaluatorq/evaluatorq.py
@@ -7,6 +7,9 @@ from datetime import datetime, timezone
 from itertools import starmap
 from typing import Any, cast
 
+from loguru import logger
+
+from .common.messages import coerce_content_text
 from .fetch_data import fetch_dataset_batches, setup_orq_client
 from .processings import process_data_point
 from .progress import Phase, ProgressService, with_progress
@@ -51,6 +54,43 @@ def check_pass_failures(results: EvaluatorqResult) -> bool:
     return False
 
 
+def extract_recorded_response(messages: Any) -> str:
+    """Return the last recorded assistant response from a row's ``messages`` column.
+
+    Used by the no-inference path: the pre-recorded conversation already contains the
+    response we want to score, so we surface the last assistant message's text rather
+    than generating a new one.
+
+    Raises:
+        ValueError: if ``messages`` is empty or holds no assistant message with text.
+    """
+    if not messages:
+        raise ValueError(
+            "inference=False requires a recorded response in the 'messages' column, "
+            "but this row has no messages."
+        )
+    for message in reversed(list(messages)):
+        role = message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
+        if role != "assistant":
+            continue
+        content = (
+            message.get("content") if isinstance(message, dict) else getattr(message, "content", None)
+        )
+        text = coerce_content_text(content)
+        if text.strip():
+            return text
+    raise ValueError(
+        "inference=False requires a recorded response in the 'messages' column, "
+        "but this row has no assistant message with text content."
+    )
+
+
+async def _replay_recorded_response(data_point: DataPoint, _row_index: int) -> dict[str, Any]:
+    """Synthetic job for the no-inference path: replays the pre-recorded response."""
+    response = extract_recorded_response(data_point.inputs.get("messages"))
+    return {"name": "recorded", "output": response}
+
+
 async def evaluatorq(
     name: str,
     params: EvaluatorParams | dict[str, Any] | None = None,
@@ -62,6 +102,7 @@ async def evaluatorq(
     print_results: bool = True,
     description: str | None = None,
     path: str | None = None,
+    inference: bool = True,
     _exit_on_failure: bool = True,
     _send_results: bool = True,
     _base_url: str | None = None,
@@ -93,6 +134,9 @@ async def evaluatorq(
         description: Optional description for the evaluation run.
         path: Optional path (e.g. "MyProject/MyFolder") to place the experiment
               in a specific project and folder on the Orq platform.
+        inference: When True (default) jobs run to generate responses. When False,
+              generation is skipped and evaluators score the pre-recorded response in
+              each row's ``messages`` column; ``jobs`` is then optional and ignored.
 
     Returns:
         List of DataPointResult objects
@@ -105,8 +149,8 @@ async def evaluatorq(
     if params is not None:
         # Validate params if passed as dict
         validated = EvaluatorParams.model_validate(params) if isinstance(params, dict) else params
-    elif data is not None and jobs is not None:
-        # Use kwargs
+    elif data is not None and (jobs is not None or not inference):
+        # Use kwargs ('jobs' is optional when inference=False — responses are replayed).
         validated = EvaluatorParams(
             data=data,
             jobs=jobs,
@@ -115,15 +159,24 @@ async def evaluatorq(
             print_results=print_results,
             description=description,
             path=path,
+            inference=inference,
         )
     else:
         raise ValueError(
-            "Either 'params' or both 'data' and 'jobs' keyword arguments are required"
+            "Either 'params' or both 'data' and 'jobs' keyword arguments are required "
+            "(omit 'jobs' only when inference=False)"
         )
 
     # Extract validated values
     data = validated.data
-    jobs = validated.jobs
+    inference = validated.inference
+    if inference:
+        jobs = validated.jobs or []
+    else:
+        # No-inference mode: skip generation and replay each row's recorded response.
+        if validated.jobs:
+            logger.warning("inference=False: ignoring the provided 'jobs'; responses are replayed from the 'messages' column.")
+        jobs = [_replay_recorded_response]
     evaluators_list = validated.evaluators or []
     parallelism = validated.parallelism
     print_results = validated.print_results
@@ -164,7 +217,9 @@ async def evaluatorq(
                 "ORQ_API_KEY environment variable must be set to fetch datapoints from Orq platform."
             )
         dataset_id = data.dataset_id
-        include_messages = data.include_messages
+        # No-inference mode needs the recorded responses, which arrive in the
+        # 'messages' column only when include_messages is enabled.
+        include_messages = data.include_messages or not inference
 
         # Stream fetch and process batches concurrently
         async def run_streaming_evaluation() -> EvaluatorqResult:

--- a/src/evaluatorq/evaluatorq.py
+++ b/src/evaluatorq/evaluatorq.py
@@ -34,19 +34,29 @@ from .types import (
 )
 
 
-def check_pass_failures(results: EvaluatorqResult) -> bool:
+def check_pass_failures(
+    results: EvaluatorqResult, *, treat_errors_as_failure: bool = False
+) -> bool:
     """
     Check if any evaluator returned pass_=False.
 
     Args:
         results: The evaluation results to check
+        treat_errors_as_failure: When True, a row whose job errored (e.g. a missing
+            recorded response in no-inference mode) also counts as a failure. Without
+            this, an errored job has no evaluator scores and would be invisible here,
+            letting a run with no usable responses exit successfully.
 
     Returns:
         True if any evaluator failed (pass_=False), False otherwise
     """
     for data_point_result in results:
+        if treat_errors_as_failure and data_point_result.error:
+            return True
         if data_point_result.job_results:
             for job_result in data_point_result.job_results:
+                if treat_errors_as_failure and job_result.error:
+                    return True
                 if job_result.evaluator_scores:
                     for evaluator_score in job_result.evaluator_scores:
                         if evaluator_score.score.pass_ is False:
@@ -85,7 +95,9 @@ def extract_recorded_response(messages: Any) -> str:
     )
 
 
-async def _replay_recorded_response(data_point: DataPoint, _row_index: int) -> dict[str, Any]:
+# Must be async to satisfy the Job protocol (an Awaitable-returning callable), even
+# though replaying a recorded response involves no awaiting.
+async def _replay_recorded_response(data_point: DataPoint, _row_index: int) -> dict[str, Any]:  # noqa: RUF029
     """Synthetic job for the no-inference path: replays the pre-recorded response."""
     response = extract_recorded_response(data_point.inputs.get("messages"))
     return {"name": "recorded", "output": response}
@@ -150,7 +162,7 @@ async def evaluatorq(
         # Validate params if passed as dict
         validated = EvaluatorParams.model_validate(params) if isinstance(params, dict) else params
     elif data is not None and (jobs is not None or not inference):
-        # Use kwargs ('jobs' is optional when inference=False — responses are replayed).
+        # Use kwargs ('jobs' is optional when inference=False, since responses are replayed).
         validated = EvaluatorParams(
             data=data,
             jobs=jobs,
@@ -171,7 +183,8 @@ async def evaluatorq(
     data = validated.data
     inference = validated.inference
     if inference:
-        jobs = validated.jobs or []
+        # The validator guarantees jobs is non-empty whenever inference=True.
+        jobs = cast("list[Job]", validated.jobs)
     else:
         # No-inference mode: skip generation and replay each row's recorded response.
         if validated.jobs:
@@ -220,6 +233,8 @@ async def evaluatorq(
         # No-inference mode needs the recorded responses, which arrive in the
         # 'messages' column only when include_messages is enabled.
         include_messages = data.include_messages or not inference
+        if include_messages and not data.include_messages:
+            logger.debug("inference=False: enabling include_messages to load recorded responses despite include_messages=False on the dataset input.")
 
         # Stream fetch and process batches concurrently
         async def run_streaming_evaluation() -> EvaluatorqResult:
@@ -381,8 +396,10 @@ async def evaluatorq(
         await asyncio.sleep(2)  # Give additional time for network operations
         await shutdown_tracing()
 
-    # Check for pass failures and exit if any
-    has_failures = check_pass_failures(results)
+    # Check for pass failures and exit if any. In no-inference mode a row that has no
+    # usable recorded response surfaces as a job error rather than an evaluator score,
+    # so count those errors as failures too (the mode must fail loudly, not exit 0).
+    has_failures = check_pass_failures(results, treat_errors_as_failure=not inference)
     if has_failures and _exit_on_failure:
         sys.exit(1)
 

--- a/src/evaluatorq/types.py
+++ b/src/evaluatorq/types.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 from typing_extensions import TypedDict
 
 from evaluatorq.contracts import TokenUsage
@@ -185,9 +185,18 @@ class EvaluatorParams(BaseModel):
     }
 
     data: DatasetIdInput | Sequence[Awaitable[DataPoint] | DataPointInput]
-    jobs: list[Job]
+    jobs: list[Job] | None = None
     evaluators: list[Evaluator] | None = None
     parallelism: int = Field(default=1, ge=1)
     print_results: bool = Field(default=True, validation_alias="print")
     description: str | None = None
     path: str | None = None
+    inference: bool = True
+    """When False, skip generation and evaluate the pre-recorded response in each
+    row's ``messages`` column instead of running ``jobs``."""
+
+    @model_validator(mode="after")
+    def _require_jobs_when_inferring(self) -> "EvaluatorParams":
+        if self.inference and not self.jobs:
+            raise ValueError("'jobs' is required unless inference=False")
+        return self

--- a/tests/unit/test_no_inference.py
+++ b/tests/unit/test_no_inference.py
@@ -1,0 +1,137 @@
+"""RES-993: no-inference mode replays pre-recorded responses to the evaluators."""
+
+import pytest
+
+from evaluatorq import evaluatorq
+from evaluatorq.evaluatorq import extract_recorded_response
+from evaluatorq.types import DataPoint, EvaluationResult, ScorerParameter
+
+
+def _row(response: str | None, *, with_assistant: bool = True) -> DataPoint:
+    messages: list[dict[str, object]] = [{"role": "user", "content": "hi"}]
+    if with_assistant:
+        messages.append({"role": "assistant", "content": response})
+    return DataPoint(inputs={"messages": messages})
+
+
+async def _capturing_scorer(seen: list[object]):
+    async def scorer(params: ScorerParameter) -> EvaluationResult:
+        seen.append(params["output"])
+        return EvaluationResult(value=1)
+
+    return scorer
+
+
+# --- extract_recorded_response -------------------------------------------------
+
+
+def test_extract_returns_last_assistant_message():
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "first"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "second"},
+    ]
+    assert extract_recorded_response(messages) == "second"
+
+
+def test_extract_flattens_multipart_content():
+    messages = [
+        {"role": "assistant", "content": [{"type": "text", "text": "hello there"}]},
+    ]
+    assert extract_recorded_response(messages) == "hello there"
+
+
+def test_extract_raises_on_empty_messages():
+    with pytest.raises(ValueError, match="no messages"):
+        extract_recorded_response([])
+
+
+def test_extract_raises_when_no_assistant_message():
+    with pytest.raises(ValueError, match="no assistant message"):
+        extract_recorded_response([{"role": "user", "content": "only user"}])
+
+
+def test_extract_raises_when_assistant_content_blank():
+    with pytest.raises(ValueError, match="no assistant message"):
+        extract_recorded_response([{"role": "assistant", "content": "   "}])
+
+
+# --- evaluatorq(inference=False) ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_inference_feeds_recorded_response_to_evaluators():
+    seen: list[object] = []
+    results = await evaluatorq(
+        "test-no-inference",
+        data=[_row("the recorded answer")],
+        evaluators=[{"name": "capture", "scorer": await _capturing_scorer(seen)}],
+        inference=False,
+        print_results=False,
+        _send_results=False,
+        _exit_on_failure=False,
+    )
+
+    assert seen == ["the recorded answer"]
+    assert len(results) == 1
+    assert results[0].job_results is not None
+    assert results[0].job_results[0].output == "the recorded answer"
+    assert results[0].job_results[0].error is None
+
+
+@pytest.mark.asyncio
+async def test_no_inference_does_not_run_provided_jobs():
+    ran = False
+
+    async def should_not_run(_data: DataPoint, _row: int):
+        nonlocal ran
+        ran = True
+        return {"name": "nope", "output": "generated"}
+
+    results = await evaluatorq(
+        "test-jobs-ignored",
+        data=[_row("recorded")],
+        jobs=[should_not_run],
+        inference=False,
+        print_results=False,
+        _send_results=False,
+        _exit_on_failure=False,
+    )
+
+    assert ran is False
+    assert results[0].job_results is not None
+    assert results[0].job_results[0].output == "recorded"
+
+
+@pytest.mark.asyncio
+async def test_no_inference_missing_response_errors_clearly():
+    results = await evaluatorq(
+        "test-missing-response",
+        data=[_row(None, with_assistant=False)],
+        evaluators=[],
+        inference=False,
+        print_results=False,
+        _send_results=False,
+        _exit_on_failure=False,
+    )
+
+    assert len(results) == 1
+    assert results[0].job_results is not None
+    job_result = results[0].job_results[0]
+    assert job_result.output is None
+    assert job_result.error is not None
+    assert "messages" in job_result.error
+
+
+@pytest.mark.asyncio
+async def test_inference_true_without_jobs_raises():
+    with pytest.raises(ValueError, match="jobs"):
+        await evaluatorq(
+            "test-needs-jobs",
+            data=[DataPoint(inputs={"text": "x"})],
+            evaluators=[],
+            print_results=False,
+            _send_results=False,
+            _exit_on_failure=False,
+        )

--- a/tests/unit/test_no_inference.py
+++ b/tests/unit/test_no_inference.py
@@ -3,7 +3,7 @@
 import pytest
 
 from evaluatorq import evaluatorq
-from evaluatorq.evaluatorq import extract_recorded_response
+from evaluatorq.evaluatorq import check_pass_failures, extract_recorded_response
 from evaluatorq.types import DataPoint, EvaluationResult, ScorerParameter
 
 
@@ -122,6 +122,11 @@ async def test_no_inference_missing_response_errors_clearly():
     assert job_result.output is None
     assert job_result.error is not None
     assert "messages" in job_result.error
+
+    # Fail-loud at the run level: a missing recorded response leaves no evaluator
+    # score, so only treat_errors_as_failure surfaces it (the run must not exit 0).
+    assert check_pass_failures(results) is False
+    assert check_pass_failures(results, treat_errors_as_failure=True) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Adds an `inference=False` mode to `evaluatorq()` so evaluators run against pre-recorded responses (already in the dataset's `messages` column) without triggering a generation step. Lets you fix the responses and iterate on evaluators alone (the RES-994 alignment workflow).

Closes RES-993.

## How

- `EvaluatorParams.inference: bool = True`; `jobs` is now optional, with a validator that still requires it when `inference=True`.
- When `inference=False`, jobs are replaced by a synthetic replay job that extracts the recorded response from `inputs["messages"]` and feeds it through the existing evaluator pipeline unchanged.
- Dataset sources force `include_messages` on so the column actually loads.
- A provided `jobs` list is ignored in this mode (loguru warning).

## The recorded "response"

Defined as the **last `assistant` message's text content** (multipart content flattened via `coerce_content_text`). If the alignment consumer needs a different shape (full response dict, whole transcript), easy to adjust.

## Fail-loud semantics

A row with no usable recorded response gets a clear error on its `JobResult` and no evaluator scores, rather than aborting the whole run. This matches how job failures already surface and keeps the streaming dataset path intact.

## Tests

`tests/unit/test_no_inference.py` — response extraction (last assistant, multipart flatten, empty / no-assistant / blank-content errors) and the end-to-end path (replays to evaluators, does not run provided jobs, missing-response errors clearly, `inference=True` without jobs raises).

Full unit suite green (2580 passed, 2 skipped); basedpyright 0 errors.

## DoD

- [x] `inference=False` runs evaluators on `messages`-column responses with zero generation calls
- [x] Default behavior (`inference=True`) unchanged
- [x] Missing/invalid response with `inference=False` errors clearly
- [x] Tests cover the no-inference path (incl. missing-response case)
- [ ] PR merged

## Out of scope (follow-ups)

- Loading responses from an orq experiment (RES-1016)
- Auto-detection of a response column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
