### PR TITLE
docs: guide content accuracy — examples run, claims hold (RES-1007)

### DIFF
--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -38,8 +38,7 @@ sequenceDiagram
         A-->>U: response
     end
     U->>J: full transcript + scenario
-    A->>J: agent responses
-    J-->>U: goal achieved / criteria met scores
+    Note over J: scores goal_achieved / criteria_met
 ```
 
 ## Generate from a one-line description
@@ -131,7 +130,10 @@ and opening messages from a short description of your agent — no hand-written
     ```
 
 `agent_description` drives generation; `num_personas × num_scenarios` is how many
-conversations run. Provider resolves `ORQ_API_KEY` → `OPENAI_API_KEY`.
+conversations run. The simulator and judge LLMs resolve their provider by
+precedence: if `ORQ_API_KEY` is set they route through the Orq AI Router;
+otherwise they fall back to OpenAI via `OPENAI_API_KEY` (an explicitly passed
+client always wins). See [Configuration](../configuration.md).
 
 ## Seed by archetype
 
@@ -177,6 +179,11 @@ When you want exact personas and pass/fail criteria, build them yourself and cal
 `simulate()`. A **persona** is *who* is talking (patience, assertiveness, tone);
 a **scenario** is *what they want* plus the **criteria** the agent must (or must
 not) satisfy.
+
+A persona requires its core traits — `name`, `patience`, `assertiveness`,
+`politeness`, `technical_level`, `communication_style`, and `background`. Only
+`emotional_arc` and `cultural_context` default (to `None`). A scenario needs just
+`name` and `goal`; everything else, including `criteria`, is optional.
 
 === "Orq agent"
 
@@ -245,7 +252,7 @@ not) satisfy.
 
     from evaluatorq.contracts import Message
     from evaluatorq.simulation import simulate
-    from evaluatorq.simulation.types import Criterion, Persona, Scenario
+    from evaluatorq.simulation.types import CommunicationStyle, Criterion, Persona, Scenario
 
     client = AsyncOpenAI()
 
@@ -261,7 +268,12 @@ not) satisfy.
 
 
     async def main():
-        persona = Persona(name="Impatient Customer", patience=0.2, assertiveness=0.8)
+        persona = Persona(
+            name="Impatient Customer",
+            patience=0.2, assertiveness=0.8, politeness=0.4, technical_level=0.3,
+            communication_style=CommunicationStyle.terse,
+            background="Received the wrong item and wants a refund urgently",
+        )
         scenario = Scenario(
             name="Wrong Item Refund",
             goal="Get a full refund for the wrong item received",

--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -311,8 +311,8 @@ personas, scenarios, criteria, and the result shape are identical. Swap the
 callback body for any HTTP/LLM agent.
 
 !!! tip "View results in the local dashboard"
-    Run `eq ui` to browse saved red-team and simulation reports together, or use
-    `eq redteam ui` / `eq sim ui` for a surface-specific view.
+    Run `eq dashboard` to browse saved red-team and simulation reports together;
+    `eq redteam ui` / `eq sim ui` open the legacy Streamlit views for one surface.
 
 ## Where to next
 

--- a/docs/guides/red-teaming.md
+++ b/docs/guides/red-teaming.md
@@ -6,7 +6,6 @@ resistance rate.
 
 *[ASI]: OWASP Agentic Security Initiative
 *[LLM01]: Prompt Injection
-*[ASR]: Attack Success Rate
 
 ```mermaid
 flowchart LR
@@ -14,7 +13,7 @@ flowchart LR
     SP --> AG["Attack generator"]
     AG --> OR["Runner / orchestrator"]
     OR --> EV["OWASP evaluator"]
-    EV --> RP["Report: ASR"]
+    EV --> RP["Report: resistance rate"]
 ```
 
 ## Modes
@@ -109,6 +108,13 @@ flowchart LR
         with `openai/...` (which then uses `ORQ_API_KEY`). Everything else —
         categories, modes, the report — is identical to the Orq agent path.
 
+!!! note "`generate_strategies` and the CLI"
+    Both examples pass `generate_strategies=False` to skip LLM-authored attack
+    strategies and run only the built-in ones — faster and more deterministic.
+    The parameter defaults to `True`. On the CLI the equivalent is the
+    `--no-generate-strategies` flag; there is no positive form, since generation
+    is on by default.
+
 ## Reading the report
 
 `report.summary.resistance_rate` is the fraction of attacks the target withstood
@@ -119,9 +125,24 @@ flowchart LR
 
 ## In CI
 
-For a fast gate, use the smoke example
-([`08_quick_smoke_test.py`](../examples/redteam/08_quick_smoke_test.md)) —
-a small fixed run you can assert a minimum resistance rate against.
+For a fast gate, run a small fixed set of attacks and assert a minimum
+resistance rate, failing the build if the target regresses:
+
+```python
+report = await red_team(
+    OpenAIModelTarget("gpt-4o-mini", system_prompt="..."),
+    mode="static",                 # replay a fixed dataset — deterministic, cheap
+    categories=["LLM01", "LLM07"],
+    max_static_datapoints=10,
+)
+assert report.summary.resistance_rate >= 0.9, (
+    f"resistance {report.summary.resistance_rate:.0%} below the 0.9 gate"
+)
+```
+
+The runnable smoke example
+([`08_quick_smoke_test.py`](../examples/redteam/08_quick_smoke_test.md)) wraps
+this same pattern.
 
 !!! tip "View results in the local dashboard"
     Run `eq ui` to browse saved red-team and simulation reports together, or use
@@ -130,4 +151,5 @@ a small fixed run you can assert a minimum resistance rate against.
 ## Where to next
 
 - **[Examples › Red Teaming](../examples/index.md)** — static datasets, category filtering, custom clients, multi-target, report inspection, custom hooks.
+- **[API Reference › redteam](../reference/evaluatorq/redteam.md)** — the full `Vulnerability` enum and the OWASP `LLM__` / `ASI__` category codes you can pass to `categories=`. The [CLI Reference](../cli-reference.md#eq-redteam-run) lists the same as `--category` / `--vulnerability`.
 - **[Custom Evaluators & Frameworks](../custom-evaluators-and-frameworks.md)** — add your own vulnerabilities and attack strategies.

--- a/docs/guides/red-teaming.md
+++ b/docs/guides/red-teaming.md
@@ -145,8 +145,8 @@ The runnable smoke example
 this same pattern.
 
 !!! tip "View results in the local dashboard"
-    Run `eq ui` to browse saved red-team and simulation reports together, or use
-    `eq redteam ui` / `eq sim ui` for a surface-specific view.
+    Run `eq dashboard` to browse saved red-team and simulation reports together;
+    `eq redteam ui` / `eq sim ui` open the legacy Streamlit views for one surface.
 
 ## Where to next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,9 @@ Successfully installed evaluatorq
 </div>
 
 Works with LangGraph, OpenAI Agents SDK, PydanticAI, CrewAI, a plain async
-function, or an Orq deployment. The Orq platform is optional — for result
-storage, not a requirement.
+function, or an Orq deployment. The Orq platform is optional: it stores results
+and, when `ORQ_API_KEY` is set, routes the attacker and judge LLMs by default —
+but you can bring your own and run entirely on OpenAI.
 
 ## Quick look
 
@@ -70,21 +71,21 @@ from evaluatorq import (
 )
 
 
-@job("uppercase")
-async def uppercase_job(data: DataPoint, _row: int) -> str:
-    text = str(data.inputs.get("text", ""))
-    return text.upper()
+@job("greet")
+async def greet_job(data: DataPoint, _row: int) -> str:
+    name = str(data.inputs.get("name", ""))
+    return f"Hello, {name}!"
 
 
 async def main():
     data = [
-        DataPoint(inputs={"text": "hello"}, expected_output="HELLO"),
-        DataPoint(inputs={"text": "world"}, expected_output="WORLD"),
+        DataPoint(inputs={"name": "Ada"}, expected_output="Hello, Ada!"),
+        DataPoint(inputs={"name": "Lin"}, expected_output="Hello, Lin!"),
     ]
     await evaluatorq(
         "smoke-test",
         data=data,
-        jobs=[uppercase_job],
+        jobs=[greet_job],
         evaluators=[string_contains_evaluator()],
         print_results=True,
     )
@@ -93,17 +94,28 @@ async def main():
 asyncio.run(main())
 ```
 
-Running it prints a pass/fail table:
+`print_results=True` renders a summary and a per-evaluator score panel:
 
 ```text
-       smoke-test — uppercase
-┏━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
-┃ input ┃ output  ┃ expected ┃ score  ┃
-┡━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
-│ hello │ HELLO   │ HELLO    │ ✓ pass │
-│ world │ WORLD   │ WORLD    │ ✓ pass │
-└───────┴─────────┴──────────┴────────┘
-        2/2 passed (100%)
+EVALUATION RESULTS
+
+Summary:
+╭──────────────────────┬───────╮
+│ Metric               │ Value │
+├──────────────────────┼───────┤
+│ Total Data Points    │ 2     │
+│ Failed Data Points   │ 0     │
+│ Total Jobs           │ 2     │
+│ Failed Jobs          │ 0     │
+│ Success Rate         │ 100%  │
+╰──────────────────────┴───────╯
+
+Detailed Results:
+╭──────────────────┬───────╮
+│ Evaluators       │ greet │
+├──────────────────┼───────┤
+│ string-contains  │ 1.00  │
+╰──────────────────┴───────╯
 ```
 
 ## Where to next

--- a/docs/llm-as-a-jury.md
+++ b/docs/llm-as-a-jury.md
@@ -176,6 +176,13 @@ report = await red_team(
 )
 ```
 
+!!! note "`strict_panel` only fires on a same-family judge"
+    `strict_panel=True` raises `ValueError` when any judge shares the target's
+    provider family — same-family self-judging can bias the verdict toward the
+    target's own provider. The panel above is entirely cross-family against an
+    OpenAI target, so the guard passes silently (the healthy case). It would
+    raise only if you added an in-family judge such as `"openai/gpt-4o-mini"`.
+
 `EvaluatorConfig` adds `strict_panel` (turn panel-composition warnings into hard
 errors) and surfaces a per-attack `jury` breakdown plus a run-level reliability
 statistic:

--- a/docs/orq-deployment.md
+++ b/docs/orq-deployment.md
@@ -1,8 +1,8 @@
 # Orq Deployment Integration
 
 `evaluatorq.deployment` provides async helpers for calling
-[Orq deployments](https://orq.ai) from within evaluation jobs or any async
-Python context.
+[Orq deployments](https://docs.orq.ai/docs/deployment) from within evaluation
+jobs or any async Python context.
 
 ## What it does
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -184,8 +184,10 @@ inject(headers)          # writes `traceparent` (+ `tracestate`) for the active 
 # pass `headers` into your outgoing request, e.g. httpx.get(url, headers=headers)
 ```
 
-`inject()` is a no-op when no span is active or OTel is not installed, so it is
-safe to call unconditionally.
+`inject()` is a no-op when no span is active, so it is safe to call whenever
+OpenTelemetry is installed. (The `from opentelemetry.propagate import inject`
+import itself requires OTel; if you need code that also runs without it
+installed, use the internal helper below, which degrades to an empty dict.)
 
 !!! note "Internal convenience helper"
     evaluatorq also ships `get_trace_context_headers()` in

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -172,14 +172,25 @@ Two env vars control how much text is stored on spans:
 
 ## W3C trace context propagation
 
-`get_trace_context_headers()` (from `evaluatorq.common.tracing`) returns the
-W3C `traceparent`/`tracestate` headers for the active span. Pass these into
-outgoing HTTP requests to propagate trace context across service boundaries.
-Returns an empty dict when OTel is not available.
+To propagate trace context across service boundaries, inject the active span's
+W3C `traceparent`/`tracestate` headers into your outgoing HTTP requests. Use the
+OpenTelemetry SDK's public `inject()` helper — a stable, supported API:
 
-!!! warning "Internal helper — import path not guaranteed stable"
-    `get_trace_context_headers` lives in `evaluatorq.common.tracing` and is
-    **not** re-exported from the public `evaluatorq.tracing` namespace. It is an
-    internal utility; its import path may change in a future release without a
-    deprecation cycle. Prefer W3C propagation via the OpenTelemetry SDK's own
-    `inject()` helper if you need a stable public API.
+```python
+from opentelemetry.propagate import inject
+
+headers: dict[str, str] = {}
+inject(headers)          # writes `traceparent` (+ `tracestate`) for the active span
+# pass `headers` into your outgoing request, e.g. httpx.get(url, headers=headers)
+```
+
+`inject()` is a no-op when no span is active or OTel is not installed, so it is
+safe to call unconditionally.
+
+!!! note "Internal convenience helper"
+    evaluatorq also ships `get_trace_context_headers()` in
+    `evaluatorq.common.tracing`, which returns the same headers as a dict (empty
+    when OTel is unavailable). It is an internal utility — **not** re-exported
+    from the public `evaluatorq.tracing` namespace, and its import path may
+    change without a deprecation cycle. Prefer the OpenTelemetry `inject()` path
+    above for anything stable.


### PR DESCRIPTION
Closes RES-1007.

Per-page accuracy fixes across the guide pages so examples run and claims hold. Every code-level claim was verified against the current source.

## index.md / getting-started.md
- `evaluatorq` **is** published on PyPI (verified), so `pip install evaluatorq` is correct — no fallback needed.
- Differentiated the landing **Quick look** (`greet`) from getting-started's **first evaluation** (`uppercase`) so the tutorial earns its place.
- Replaced the fabricated box-table output with the **real** `print_results=True` rendering (Summary + Detailed Results panels) — the old table didn't match actual output.
- Tightened "Orq is optional": now notes it also **routes the attacker/judge LLMs by default** when `ORQ_API_KEY` is set.

## guides/agent-simulation.md
- **Bug fix:** the minimal `Persona(name, patience, assertiveness)` example was **broken** — `politeness`, `technical_level`, `communication_style`, `background` are required (verified live: it raised `ValidationError`). The ticket's "traits default" premise was inverted. Fixed the example to instantiate, imported `CommunicationStyle`, and documented which fields are required vs optional.
- Spelled out the `ORQ_API_KEY` → `OPENAI_API_KEY` provider precedence with a Configuration link.
- Made the judge a terminal sink in the sequence diagram (it scores, it doesn't reply).
- Confirmed all six `evaluatorq.simulation.types` imports are exported.

## guides/red-teaming.md
- Documented `generate_strategies` default (`True`) ↔ CLI `--no-generate-strategies`.
- Made the CI section self-contained with an inline `assert report.summary.resistance_rate >= 0.9`.
- Dropped the unused `*[ASR]` abbr and relabeled the diagram node to "resistance rate" (there is no `asr` field; the report exposes `resistance_rate`).
- Linked the full `Vulnerability`/category code list (API reference + CLI reference).

## llm-as-a-jury.md
- Clarified `strict_panel`: against the cross-family panel + OpenAI target it's a **no-op** (the healthy case); it raises `ValueError` only when a judge shares the target's family.

## tracing.md
- Lead with the **public** OpenTelemetry `inject()` propagation path; demoted the internal `get_trace_context_headers` helper to an aside.

## orq-deployment.md
- Deployments link now points to `https://docs.orq.ai/docs/deployment`, not the marketing homepage.

## Verification
- `mkdocs build --strict` ✅, `validate_mermaid.py` ✅ (13 files), new Persona snippet instantiates ✅, new internal cross-links resolve in the built site ✅.

> Note: running the index example locally uploaded a throwaway `smoke-test` experiment to the `orq-research` workspace (because `ORQ_API_KEY` was set in the env). Harmless, flagging for cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)