### PR TITLE
docs: drop 'legacy' framing for Orq deployment targets

### DIFF
--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -3,7 +3,7 @@
 Drive your agent through realistic multi-turn conversations without writing test
 transcripts by hand. Three LLMs are in play:
 
-- **Your agent** — the target under test (a hosted Orq agent, a callback, or a legacy Orq deployment).
+- **Your agent** — the target under test (a hosted Orq agent, a callback, or an Orq deployment).
 - **User simulator** — plays a **persona** pursuing a **scenario** goal, turn by turn.
 - **Judge** — scores whether the goal was met and whether any rules were broken.
 

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -46,15 +46,14 @@ A runnable, narrated walkthrough lives in
 The agent under test is supplied one of these ways (mutually exclusive):
 
 - **`target="agent:<key>"`** (or bare **`target="<key>"`**) — a hosted **orq.ai** agent, invoked through the stateless Responses API target. Requires `ORQ_API_KEY`. The primary path.
-- **`target="deployment:<key>"`** — bridges to a legacy **orq.ai** deployment. Requires `ORQ_API_KEY`.
+- **`target="deployment:<key>"`** — bridges to an **orq.ai** deployment. Requires `ORQ_API_KEY`.
 - **`target=<AgentTarget>`** — an `AgentTarget` instance (e.g. `OrqResponsesTarget`) that speaks `respond(messages)`.
 - **`target_callback=` / `target=<callable>`** — any `async`/sync callable `(list[Message]) -> str`. Great for local mocks and quick checks.
 
 On the CLI, prefer `--target` to mirror red teaming:
 
 - **`--target agent:<key>`** or bare **`--target <key>`** — invokes a hosted Orq agent through the stateless Responses API target.
-- **`--target deployment:<key>`** — uses the legacy deployment callback bridge.
-- **`--agent-key <key>`** — deprecated CLI alias for deployment behavior.
+- **`--target deployment:<key>`** — uses the deployment callback bridge.
 
 ## Personas & scenarios
 
@@ -119,7 +118,7 @@ Examples:
 ```bash
 eq sim run --target agent:refund-agent-fixed
 eq sim generate --target refund-agent-fixed --output dp.jsonl
-eq sim simulate --datapoints dp.jsonl --target deployment:legacy-refund-agent
+eq sim simulate --datapoints dp.jsonl --target deployment:refund-agent
 ```
 
 See [`examples/agent_simulation/README.md`](../../../examples/agent_simulation/README.md)

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -88,7 +88,7 @@ async def simulate(
         target: The agent under test. Takes precedence over ``target_callback``
             when both are supplied. Accepts a ``str`` (``"agent:<key>"`` or bare
             ``"<key>"`` → hosted Orq agent via the Responses router;
-            ``"deployment:<key>"`` → legacy Orq deployment), an ``AgentTarget``
+            ``"deployment:<key>"`` → Orq deployment), an ``AgentTarget``
             instance (routed to the runner's ``target_agent`` path; speaks
             ``respond(messages)``), or a callable (same shape as
             ``target_callback``).

--- a/src/evaluatorq/simulation/cli.py
+++ b/src/evaluatorq/simulation/cli.py
@@ -375,7 +375,7 @@ def simulate(
       (+ optional OPENAI_BASE_URL for vLLM/OpenRouter/local). ORQ wins if both set.
 
     Note: --target agent:<key> invokes a hosted Orq agent through the Responses
-    router. --target deployment:<key> uses the legacy deployment callback path.
+    router. --target deployment:<key> uses the deployment callback path.
     """
     if quiet:
         verbose = -1


### PR DESCRIPTION
Orq deployments are a **supported** simulation target alongside hosted agents — not a legacy path. This removes the "legacy" wording everywhere it described deployments.

## Changes

- `docs/guides/agent-simulation.md` — "a legacy Orq deployment" → "an Orq deployment"
- `src/evaluatorq/simulation/README.md` — drop "legacy" from both the SDK and CLI deployment bullets; remove the stale `--agent-key` deprecated-alias line (flag removed in #25); rename sample key `deployment:legacy-refund-agent` → `deployment:refund-agent`
- `src/evaluatorq/simulation/api.py` / `cli.py` — drop "legacy" from the `target=` / `--target` docstrings

Left untouched: genuinely-legacy mentions (`AgentConfig` conversion, legacy span attribute, legacy dataset export format).

Docs-only / docstring-only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)