### PR TITLE
fix(tests): isolate run stores so tests don't pollute the real .evaluatorq

### DIFF
--- a/src/evaluatorq/common/run_store_dir.py
+++ b/src/evaluatorq/common/run_store_dir.py
@@ -1,0 +1,21 @@
+"""Resolve the on-disk store directory for persisted runs.
+
+Both red teaming (``runs/``) and agent simulation (``sim-runs/``) persist
+their reports under ``.evaluatorq/``. The base resolves to ``$EVALUATORQ_DIR``
+when set (tests point this at a tmp dir so runs never leak into the repo
+store), otherwise ``.evaluatorq`` relative to the current working directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+STORE_DIR_NAME = ".evaluatorq"
+
+
+def get_store_dir(subdir: str) -> Path:
+    """Return ``<base>/<subdir>`` where base honors ``EVALUATORQ_DIR``."""
+    base = os.environ.get("EVALUATORQ_DIR")
+    root = Path(base) if base else Path.cwd() / STORE_DIR_NAME
+    return root / subdir

--- a/src/evaluatorq/common/run_store_dir.py
+++ b/src/evaluatorq/common/run_store_dir.py
@@ -4,6 +4,10 @@ Both red teaming (``runs/``) and agent simulation (``sim-runs/``) persist
 their reports under ``.evaluatorq/``. The base resolves to ``$EVALUATORQ_DIR``
 when set (tests point this at a tmp dir so runs never leak into the repo
 store), otherwise ``.evaluatorq`` relative to the current working directory.
+
+``EVALUATORQ_DIR`` must point at the store directory itself (e.g.
+``/tmp/x/.evaluatorq``), not its parent — only the cwd fallback appends
+``.evaluatorq``. An unset or empty value uses the cwd fallback.
 """
 
 from __future__ import annotations
@@ -16,6 +20,6 @@ STORE_DIR_NAME = ".evaluatorq"
 
 def get_store_dir(subdir: str) -> Path:
     """Return ``<base>/<subdir>`` where base honors ``EVALUATORQ_DIR``."""
-    base = os.environ.get("EVALUATORQ_DIR")
+    base = os.environ.get("EVALUATORQ_DIR") or None  # treat "" as unset
     root = Path(base) if base else Path.cwd() / STORE_DIR_NAME
     return root / subdir

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -21,6 +21,7 @@ from evaluatorq import DataPoint, EvaluationResult, job
 from evaluatorq.common.async_utils import await_maybe, warn_if_sync_hooks
 from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.common.messages import coerce_content_text
+from evaluatorq.common.run_store_dir import get_store_dir
 from evaluatorq.common.tracing import set_span_attrs
 from evaluatorq.contracts import AgentTarget, Message
 from evaluatorq.redteam.adaptive.capability_classifier import AgentCapabilities, classify_agent_capabilities
@@ -111,20 +112,9 @@ def _save_report(output_dir: Path | None, filename: str, report: RedTeamReport) 
     logger.debug(f'Saved {filename} to {output_dir}')
 
 
-RUNS_DIR_NAME = Path('.evaluatorq') / 'runs'
-
-
 def get_runs_dir() -> Path:
-    """Return the runs directory.
-
-    Resolves to ``$EVALUATORQ_DIR/runs`` when ``EVALUATORQ_DIR`` is set
-    (tests point this at a tmp dir so runs never leak into the repo store),
-    otherwise ``.evaluatorq/runs`` relative to the current working directory.
-    """
-    base = os.environ.get('EVALUATORQ_DIR')
-    if base:
-        return Path(base) / 'runs'
-    return Path.cwd() / RUNS_DIR_NAME
+    """Return the red team runs directory (``<store>/runs``)."""
+    return get_store_dir('runs')
 
 
 def _auto_save_run(report: RedTeamReport, name: str | None = None) -> Path | None:

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -115,7 +115,15 @@ RUNS_DIR_NAME = Path('.evaluatorq') / 'runs'
 
 
 def get_runs_dir() -> Path:
-    """Return the runs directory resolved relative to the current working directory."""
+    """Return the runs directory.
+
+    Resolves to ``$EVALUATORQ_DIR/runs`` when ``EVALUATORQ_DIR`` is set
+    (tests point this at a tmp dir so runs never leak into the repo store),
+    otherwise ``.evaluatorq/runs`` relative to the current working directory.
+    """
+    base = os.environ.get('EVALUATORQ_DIR')
+    if base:
+        return Path(base) / 'runs'
     return Path.cwd() / RUNS_DIR_NAME
 
 

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -13,6 +13,7 @@ Saved runs land in ``.evaluatorq/sim-runs/`` under collision-free
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +35,9 @@ def sanitise_run_name(name: str) -> str:
 
 
 def get_sim_runs_dir() -> Path:
+    base = os.environ.get("EVALUATORQ_DIR")
+    if base:
+        return Path(base) / "sim-runs"
     return Path.cwd() / SIM_RUNS_DIR_NAME
 
 

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -13,12 +13,12 @@ Saved runs land in ``.evaluatorq/sim-runs/`` under collision-free
 from __future__ import annotations
 
 import logging
-import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from evaluatorq.common.run_store_dir import get_store_dir
 from evaluatorq.simulation.types import SimulationRun
 
 logger = logging.getLogger(__name__)
@@ -35,10 +35,8 @@ def sanitise_run_name(name: str) -> str:
 
 
 def get_sim_runs_dir() -> Path:
-    base = os.environ.get("EVALUATORQ_DIR")
-    if base:
-        return Path(base) / "sim-runs"
-    return Path.cwd() / SIM_RUNS_DIR_NAME
+    """Return the agent sim runs directory (``<store>/sim-runs``)."""
+    return get_store_dir("sim-runs")
 
 
 def build_simulation_run(

--- a/tests/common/test_run_store_dir.py
+++ b/tests/common/test_run_store_dir.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evaluatorq.common.run_store_dir import get_store_dir
+
+
+def test_env_var_override_is_used_verbatim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EVALUATORQ_DIR", str(tmp_path / "store"))
+    assert get_store_dir("runs") == tmp_path / "store" / "runs"
+
+
+def test_falls_back_to_cwd_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EVALUATORQ_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert get_store_dir("sim-runs") == tmp_path / ".evaluatorq" / "sim-runs"
+
+
+def test_empty_env_var_treated_as_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EVALUATORQ_DIR", "")
+    monkeypatch.chdir(tmp_path)
+    assert get_store_dir("runs") == tmp_path / ".evaluatorq" / "runs"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,14 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _isolate_run_stores(tmp_path, monkeypatch):
+    """Point the redteam/sim run stores at a tmp dir so tests never write
+    runs into the repo's real ``.evaluatorq/`` store."""
+    monkeypatch.setenv("EVALUATORQ_DIR", str(tmp_path / ".evaluatorq"))
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _clear_span_max_text_chars_cache():
     """Clear lru_cache between tests so EVALUATORQ_SPAN_MAX_TEXT_CHARS env changes propagate."""
     from evaluatorq.common.tracing import _default_span_max_text_chars

--- a/tests/simulation/test_run_store.py
+++ b/tests/simulation/test_run_store.py
@@ -333,6 +333,8 @@ def test_write_report_full_run_json(tmp_path: Path) -> None:
 def test_get_sim_runs_dir_returns_cwd_relative_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # Drop the autouse EVALUATORQ_DIR override so the cwd fallback is exercised.
+    monkeypatch.delenv("EVALUATORQ_DIR", raising=False)
     monkeypatch.chdir(tmp_path)
     result = get_sim_runs_dir()
     expected = tmp_path / SIM_RUNS_DIR_NAME


### PR DESCRIPTION
## Problem

`red_team()` and the sim runner auto-save every run to `Path.cwd()/.evaluatorq/{runs,sim-runs}`. Running the test suite therefore wrote throwaway runs (`description: "Test report"`, `tested_agents: ["agent:test"]`, 0 attacks) into the developer's **real** store — which then showed up as junk entries in the combined dashboard.

## Fix

- `get_runs_dir()` / `get_sim_runs_dir()` now honor an `EVALUATORQ_DIR` env override (fall back to cwd as before).
- Autouse fixture `_isolate_run_stores` in `tests/conftest.py` points `EVALUATORQ_DIR` at a per-test `tmp_path`, so **no test can write into the repo store**.

No dashboard behavior change — empty runs still display. This only stops tests leaking into the store.

## Verification

- Ran full `tests/redteam` suite: repo store count unchanged (0 leak; previously it grew each run).
- `uv run pytest -m 'not integration'` → all pass.

Stacked on `aminaakhmedova/res-974-add-evaluatorq-combined-dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)