### PR TITLE
docs: widen content column to 70rem

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -88,6 +88,9 @@
   color: var(--orq-teal);
 }
 
+/* Widen the content column (Material default is 61rem). */
+.md-grid { max-width: 70rem; }
+
 /* --- Typography scale -------------------------------------------------
    Material defaults to 125% root, upscaling to 150% on wide screens —
    reads oversized. Pin body to ~16px, gentle wide-screen bump. */


### PR DESCRIPTION
## What

Bump `.md-grid` max-width from Material's default 61rem to 70rem so the docs article column uses more of the available width on large screens.

```css
.md-grid { max-width: 70rem; }
```

## Why

Material for MkDocs centers `.md-grid` with auto margins and caps it at 61rem, leaving wide empty gutters on big monitors. 70rem reclaims ~9rem of that. Below 61rem viewport width nothing changes (viewport is the constraint).

## Validation

`mkdocs serve` builds clean; served CSS confirmed to carry the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)