### PR TITLE
fix: auto-release on main + PR-based release notes (and widen docs column)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# Controls GitHub's auto-generated release notes (the "What's Changed" + contributor
+# list). The release workflow regenerates each Release body from these categories so
+# notes are PR-based with attributions, complementing the commit-based CHANGELOG.md.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: 🧰 Maintenance
+      labels:
+        - chore
+        - ci
+        - refactor
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,9 @@
 name: Release
 
 on:
-  # Auto-release on merge to main is DISABLED until the PYPI_TOKEN secret is set.
-  # Without it, semantic-release would tag + create a GitHub Release and then fail
-  # at `uv publish`, leaving a release for a version never on PyPI. Re-enable by
-  # uncommenting the push trigger once PYPI_TOKEN exists (see migration tracker).
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -40,11 +36,25 @@ jobs:
         run: uv sync --frozen --all-extras --all-groups
 
       # Bump version in pyproject.toml, commit, tag, and create GitHub Release.
+      # PSR writes a commit-based body; the next step replaces it with PR-based notes.
       - name: Semantic release
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Replace the Release body with GitHub's PR-based auto-notes (What's Changed +
+      # contributor attributions, categorized via .github/release.yml). CHANGELOG.md
+      # stays commit-based; only the GitHub Release body changes.
+      - name: PR-based release notes
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.release.outputs.tag }}"
+          notes=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$tag" --jq '.body')
+          gh release edit "$tag" --notes "$notes"
 
       # Only build and publish when semantic-release actually cut a new version.
       - name: Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,3 +155,16 @@ src/evaluatorq/
 - Linting: ruff
 - Type checking: basedpyright (lenient config — many rules disabled)
 - Logging: `loguru` everywhere (core runtime dependency since 1.3)
+
+### Releases
+
+Releases are fully automated by [python-semantic-release](https://python-semantic-release.readthedocs.io) via `.github/workflows/release.yml` on every push to `main`. **You do not bump the version, edit `CHANGELOG.md`, or tag by hand** — commit messages drive everything.
+
+- **Commits MUST follow [Conventional Commits](https://www.conventionalcommits.org).** The type prefix decides the version bump and the changelog section:
+  - `feat:` → minor bump, "Features" section
+  - `fix:` / `perf:` → patch bump, "Bug Fixes" / "Performance" section
+  - `feat!:` / `fix!:` or a `BREAKING CHANGE:` footer → major bump
+  - `docs:` `chore:` `ci:` `test:` `refactor:` `style:` `build:` `revert:` → no release on their own
+- On a release-worthy push, the pipeline: bumps `[project].version` in `pyproject.toml`, regenerates and commits `CHANGELOG.md` (grouped by type, derived from commits — not a raw git log), tags `vX.Y.Z`, creates the GitHub Release, then builds and publishes to PyPI.
+- The GitHub Release **body** is regenerated from GitHub's PR-based auto-notes (`.github/release.yml` controls the categories) — so it lists merged PRs and contributor attributions, which the commit-based `CHANGELOG.md` does not.
+- Do NOT hand-edit `CHANGELOG.md` — it is overwritten each release. To change what appears, fix the commit subjects.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -88,6 +88,9 @@
   color: var(--orq-teal);
 }
 
+/* Widen the content column (Material default is 61rem). */
+.md-grid { max-width: 70rem; }
+
 /* --- Typography scale -------------------------------------------------
    Material defaults to 125% root, upscaling to 150% on wide screens —
    reads oversized. Pin body to ~16px, gentle wide-screen bump. */


### PR DESCRIPTION
## Summary

Two changes on this branch:

### Release pipeline (main work)
- **Enable auto-release**: re-enable the `push: main` trigger in `release.yml` now that `PYPI_TOKEN` is configured on the repo.
- **PR-based GitHub Release notes**: after `python-semantic-release` cuts the tag/release, a new step regenerates the Release body via GitHub's `generate-notes` API — giving "What's Changed" PR links + contributor attributions. The committed `CHANGELOG.md` stays commit-based; only the GitHub Release body changes.
- **`.github/release.yml`** (new): categorizes the auto-notes (Features / Fixes / Docs / Maintenance / Other), excludes dependabot.
- **`CLAUDE.md`**: document the conventional-commit → version-bump → changelog/publish flow, and that `CHANGELOG.md` / version / tags are never edited by hand.

### Docs
- Widen content column to 70rem (`0be0946`).

## Release flow after merge
Each release-worthy push to `main`:
1. `CHANGELOG.md` committed (commit-based, grouped by type)
2. GitHub Release body (PR-based, with attributions)
3. Publish to PyPI

## Notes
- Auto-notes categories key off **PR labels**; unlabeled PRs land in "Other Changes".
- First real release fires on the next release-worthy merge to main. Can dry-run via `workflow_dispatch` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)