### PR TITLE
fix: PSR build_command must be empty string, not bool (v10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,8 @@ commit_parser = "conventional"
 # Suppress PSR's own build step (we run `uv build` separately in the workflow)
 # so the action only handles versioning, changelog, and tagging. `uv` is not on
 # PATH inside the PSR action container, so a non-empty build_command exits 127.
-build_command = false
+# Must be an empty string, not `false` — PSR v10's config schema rejects a bool.
+build_command = ""
 upload_to_vcs_release = true
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
## Problem
The first auto-release run (after #44) failed at the **Semantic release** step:

```
1 validation error for RawConfig
build_command
  Input should be a valid string [type=string_type, input_value=False]
```

python-semantic-release v10.5.3 validates `build_command` as a string. The prior `build_command = false` (valid in older PSR) is now rejected, aborting before any tag/release/publish. **No phantom release was created** — clean failure.

## Fix
`build_command = ""` — the documented value to skip PSR's own build (we build with `uv build` in a later workflow step).

## Effect
Merging this re-runs Release over all unreleased commits since v1.3.2 (including the #44 `fix:`), cutting the first real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)