### PR TITLE
fix: release pushes via SSH deploy key for protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'chore(release):')"
 
     steps:
+      # SSH deploy key (in the Protect-main ruleset bypass) lets semantic-release
+      # push its version-bump commit back to the PR-protected main branch.
+      # GITHUB_TOKEN cannot bypass the ruleset; the deploy key can.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Lets semantic-release push its version-bump + CHANGELOG commit back to the PR-protected main branch via an SSH deploy key on the ruleset bypass list. GITHUB_TOKEN cannot bypass the ruleset (GH013); the deploy key can. Prereq: run setup_deploy_key.sh first.