### PR TITLE
fix: semantic-release via CLI to push over SSH deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,27 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras --all-groups
 
-      # Bump version in pyproject.toml, commit, tag, and create GitHub Release.
-      # PSR writes a commit-based body; the next step replaces it with PR-based notes.
+      # Run semantic-release as a CLI (not the docker action) so the version-bump
+      # commit/tag are pushed over the SSH remote from checkout — the deploy key is
+      # on the Protect-main ruleset bypass list. The docker action forces an
+      # HTTPS + GITHUB_TOKEN push, which cannot bypass the ruleset (GH013).
+      # GH_TOKEN is used only for the GitHub Release API call, not the git push.
       - name: Semantic release
         id: release
-        uses: python-semantic-release/python-semantic-release@v10.5.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          before=$(git rev-parse HEAD)
+          uvx --from "python-semantic-release==10.5.3" semantic-release -v version
+          after=$(git rev-parse HEAD)
+          if [ "$before" != "$after" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Replace the Release body with GitHub's PR-based auto-notes (What's Changed +
       # contributor attributions, categorized via .github/release.yml). CHANGELOG.md


### PR DESCRIPTION
The PSR docker action forced an HTTPS+GITHUB_TOKEN push (rejected by the Protect-main ruleset, GH013). Switch to running semantic-release as a CLI after the ssh-key checkout so the version-bump commit/tag push over SSH, where the deploy key bypass applies. Outputs (released/tag) are derived from a HEAD-changed check.