### PR TITLE
ci: auto-label PRs from conventional-commit title

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,45 @@
+name: Label PR
+
+# Auto-label a PR from its conventional-commit title prefix so GitHub's
+# auto-generated release notes (.github/release.yml) categorize it. Titles are
+# enforced as conventional commits anyway, so the label derives for free.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // conventional-commit type -> release-notes label
+            const MAP = {
+              feat: 'feature', fix: 'fix', perf: 'fix', revert: 'fix',
+              docs: 'docs',
+              chore: 'chore', ci: 'ci', refactor: 'refactor',
+              build: 'chore', test: 'chore', style: 'chore',
+            };
+            const title = context.payload.pull_request.title || '';
+            const m = title.match(/^(\w+)(\([^)]*\))?!?:/);
+            if (!m) {
+              core.info(`Title not conventional, no label: "${title}"`);
+              return;
+            }
+            const label = MAP[m[1].toLowerCase()];
+            if (!label) {
+              core.info(`No mapping for type "${m[1]}"`);
+              return;
+            }
+            // addLabels creates the label if it does not exist yet.
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });
+            core.info(`Applied label: ${label}`);


### PR DESCRIPTION
GitHub's auto-generated release notes (`.github/release.yml`) categorize by **PR label**, not commit type — so unlabeled PRs all landed under *Other Changes* and *What's Changed* was empty.

This adds a `pull_request_target` workflow that reads the PR title's conventional-commit prefix and applies the matching release-notes label:

| prefix | label |
|---|---|
| `feat` | feature |
| `fix`, `perf`, `revert` | fix |
| `docs` | docs |
| `chore`, `build`, `test`, `style` | chore |
| `ci` | ci |
| `refactor` | refactor |

Inline `actions/github-script` — no third-party action. `addLabels` creates the label if missing. Non-conventional titles get no label (and stay under Other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)