### PR TITLE
docs: add mkdocs-material skill

### DIFF
--- a/.claude/skills/mkdocs-material/SKILL.md
+++ b/.claude/skills/mkdocs-material/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: mkdocs-material
+description: Use when creating, configuring, fixing, or deploying MkDocs / Material for MkDocs documentation sites - especially when task-list checkboxes render as literal "[ ]" text, bare URLs are not clickable, tables overflow the page width, Mermaid diagrams show as plain code blocks, mkdocs gh-deploy succeeds but GitHub Pages shows errors or a 404, or an internal/private repo's Pages URL is unclear. Covers mkdocs.yml configuration, pymdownx extensions, navigation, strict builds, and GitHub Pages deployment.
+license: MIT
+metadata:
+  author: forcewake
+  version: "1.0"
+---
+
+# Material for MkDocs
+
+## Overview
+
+Material for MkDocs renders only what its Markdown extensions enable. Most "broken page" reports are a missing one-line entry in `mkdocs.yml`, not broken content. Configure the known extension set up front, verify the **built HTML** (not the Markdown), and validate every change with `mkdocs build --strict` before deploying.
+
+Full config template: [references/mkdocs.yml.template](references/mkdocs.yml.template). Deployment recipes: [references/github-pages.md](references/github-pages.md).
+
+## Quick Start
+
+```bash
+pip install mkdocs-material        # use a venv; pin in requirements.txt
+mkdocs serve                       # live preview at 127.0.0.1:8000
+mkdocs build --strict              # fails on broken links/nav — run before every deploy
+mkdocs gh-deploy --force           # build + force-push to gh-pages branch
+```
+
+Content lives in `docs/`, with `docs/index.md` as the home page. Cross-page links are relative Markdown paths to `.md` files (`[text](../checklists/cutover.md)`) — `--strict` validates them.
+
+## Rendering Failure Modes (symptom → fix)
+
+These all produce a successful build with a broken-looking page. Check this table before debugging anything else.
+
+| Symptom on the rendered page | Root cause | Fix in `mkdocs.yml` |
+|---|---|---|
+| `[ ] item` renders as literal bracket text | task lists are not core Markdown | `pymdownx.tasklist` with `custom_checkbox: true` |
+| Bare URLs are plain text, not links | autolinking is not core Markdown | `pymdownx.magiclink` |
+| Table overflows page width; columns clipped | a cell contains an unbreakable token — URLs without hyphens (e.g. AWS doc URLs like `PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication.html`), long code spans | no config fix — replace bare URLs with short named links `[AWS documentation](url)`; keep long tokens out of cells |
+| Mermaid block shows as a code listing | fenced block not routed to Mermaid | `pymdownx.superfences` with the `mermaid` custom fence (see template) |
+| Mermaid node labels show literal `\n` | `\n` support varies by renderer | use `<br/>` inside node labels |
+| Admonitions (`!!! note`) render as plain paragraphs | extension missing | `admonition` (+ `pymdownx.details` for collapsible) |
+| Content tabs (`=== "Tab"`) render as quoted text | extension missing | `pymdownx.tabbed` with `alternate_style: true` |
+| No copy button on code blocks | theme feature missing | `content.code.copy` under `theme.features` |
+
+## Verify the Built HTML
+
+`mkdocs build` succeeding does not mean the page renders as intended. After config changes, check the output:
+
+```bash
+mkdocs build --strict
+grep -c 'class="task-list-item"' site/path/page/index.html   # checkboxes rendered
+grep -c 'class="mermaid"'        site/path/page/index.html   # diagrams rendered
+# bare (unlinked) URLs left in table cells:
+python3 -c "
+import re; html = open('site/path/page/index.html').read()
+tds = re.findall(r'<td>(.*?)</td>', html, re.S)
+print('bare URL cells:', sum(1 for t in tds if 'http' in t and '<a ' not in t))"
+```
+
+## GitHub Pages Deployment
+
+`mkdocs gh-deploy --force` builds and force-pushes the site to the `gh-pages` branch. It does **not** enable Pages — that is a one-time repo setting. Critical traps:
+
+- **Private/internal repos**: the site is served at an obfuscated `https://<random>.pages.github.io/` domain behind org SSO — **not** `https://<org>.github.io/<repo>/`. Read the real URL from `gh api repos/<org>/<repo>/pages --jq .html_url` and set `site_url` to it.
+- **Pages build can error independently** of a successful deploy. Check and rebuild via API — see [references/github-pages.md](references/github-pages.md).
+- `gh-deploy` writes `.nojekyll` automatically; do not add Jekyll config to the branch.
+
+## Common Mistakes
+
+| Mistake | Consequence |
+|---|---|
+| Assuming GitHub-flavored Markdown features work by default | task lists, autolinks, mermaid all need explicit extensions |
+| Verifying the Markdown source instead of `site/` HTML | extension gaps are invisible in source |
+| Skipping `--strict` | broken relative links ship silently |
+| Putting long bare URLs in table cells | unbreakable tokens blow up the layout |
+| Hardcoding `https://<org>.github.io/<repo>/` as `site_url` for a private repo | wrong canonical URLs and sitemap |
+| Treating a green `gh-deploy` as "site is live" | Pages may be disabled or its build errored |

--- a/.claude/skills/mkdocs-material/references/github-pages.md
+++ b/.claude/skills/mkdocs-material/references/github-pages.md
@@ -1,0 +1,76 @@
+# GitHub Pages Deployment Recipes
+
+## Standard flow (public repo)
+
+```bash
+mkdocs build --strict          # gate: never deploy a non-strict build
+mkdocs gh-deploy --force       # builds + force-pushes site to gh-pages branch
+```
+
+`gh-deploy` adds `.nojekyll` automatically. Site appears at
+`https://<org>.github.io/<repo>/` once Pages is enabled.
+
+## Enabling Pages (one-time, required — gh-deploy does not do this)
+
+```bash
+# Check current state; enable from gh-pages branch if 404:
+gh api repos/<org>/<repo>/pages 2>/dev/null \
+  || gh api -X POST repos/<org>/<repo>/pages \
+       -f "source[branch]=gh-pages" -f "source[path]=/"
+```
+
+## Private / internal repos
+
+The site is NOT at `https://<org>.github.io/<repo>/`. GitHub serves it on an
+obfuscated private domain behind org SSO. Get the real URL and use it as
+`site_url` in mkdocs.yml:
+
+```bash
+gh api repos/<org>/<repo>/pages --jq .html_url
+# e.g. https://shiny-adventure-e4ky67z.pages.github.io/
+```
+
+A `curl` of that URL returns `302` to `https://github.com/pages/auth?...` —
+that means it works; auth happens in the browser.
+
+## Verifying the deployment actually built
+
+A successful `gh-deploy` push does not guarantee Pages built the site.
+The Pages build runs server-side and can error independently:
+
+```bash
+gh api repos/<org>/<repo>/pages/builds/latest --jq '{status, error: .error.message}'
+```
+
+- `"status": "built"` — live.
+- `"status": "building"` — poll again; large sites can take 1–3 minutes.
+- `"status": "errored"` — trigger a rebuild, then re-check:
+
+```bash
+gh api -X POST repos/<org>/<repo>/pages/builds
+```
+
+A transient `errored` right after first enabling Pages is common; one
+rebuild usually fixes it. Persistent errors: check the gh-pages branch has
+`index.html` and `.nojekyll` at its root (`git ls-tree --name-only origin/gh-pages`).
+
+## CI auto-deploy (optional)
+
+```yaml
+# .github/workflows/docs.yml
+name: docs
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.x" }
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force
+```

--- a/.claude/skills/mkdocs-material/references/mkdocs.yml.template
+++ b/.claude/skills/mkdocs-material/references/mkdocs.yml.template
@@ -1,0 +1,69 @@
+# Battle-tested baseline for Material for MkDocs.
+# Every extension below prevents a known silent rendering failure.
+
+site_name: My Documentation
+# For private/internal repos, read the real URL first:
+#   gh api repos/<org>/<repo>/pages --jq .html_url
+site_url: https://example.github.io/my-docs/
+repo_url: https://github.com/example/my-docs
+repo_name: example/my-docs
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.instant        # SPA-like navigation
+    - navigation.tracking       # URL updates as you scroll
+    - navigation.sections       # group sidebar items
+    - navigation.top            # back-to-top button
+    - navigation.footer         # prev/next links
+    - navigation.indexes        # section index pages
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy         # copy button on code blocks
+    - content.action.edit       # edit-this-page button
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition                  # !!! note / warning / tip / danger
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details            # collapsible ??? admonitions
+  - pymdownx.tasklist:          # - [ ] checkboxes (literal "[ ]" text without this)
+      custom_checkbox: true
+  - pymdownx.magiclink          # bare URLs become links (plain text without this)
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:            # === "Tab" content tabs
+      alternate_style: true
+  - pymdownx.superfences:       # required for Mermaid; renders as code block without this
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+plugins:
+  - search
+
+# Explicit nav recommended: --strict then catches orphaned pages.
+nav:
+  - Home: index.md


### PR DESCRIPTION
## Summary
Adds the `mkdocs-material` Claude Code skill to the repo under `.claude/skills/`.

Covers creating, configuring, fixing, and deploying MkDocs / Material for MkDocs documentation sites — common rendering issues (task-list checkboxes, bare URLs, table overflow, Mermaid diagrams), `mkdocs.yml` configuration, pymdownx extensions, strict builds, and GitHub Pages deployment.

Files:
- `SKILL.md` — main skill
- `references/github-pages.md` — deployment recipes
- `references/mkdocs.yml.template` — full config template

🤖 Generated with [Claude Code](https://claude.com/claude-code)