### PR TITLE
docs: remove internal-spec leakage from public site (RES-1004)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ All configuration is via environment variables. No config file is required.
 |---|---|---|---|
 | `ORQ_API_KEY` | Required for Orq features | — | Authenticates against the Orq platform. Required to fetch datasets, upload results, and invoke deployments. Also auto-enables OpenTelemetry tracing (spans are sent to `https://my.orq.ai/v2/otel`). |
 | `ORQ_BASE_URL` | No | `https://my.orq.ai` | Overrides the Orq API base URL. Affects Orq SDK calls (dataset fetch, deployment invocation) and the derived OTLP tracing endpoint (`<ORQ_BASE_URL>/v2/otel`). Does **not** redirect OpenAI-compatible LLM calls — use `OPENAI_BASE_URL` for that. |
+| `ROUTER_BASE_URL` | Deprecated | — | Predecessor to `ORQ_BASE_URL`, no longer honoured. If set (and `ORQ_BASE_URL` is unset) it only logs a warning. Use `ORQ_BASE_URL` instead. |
 | `OPENAI_API_KEY` | Required if not using Orq | — | API key for the OpenAI (or compatible) backend. Used by the red teaming pipeline and agent simulation when `ORQ_API_KEY` is absent. |
 | `OPENAI_BASE_URL` | No | OpenAI default | Redirect OpenAI-compatible calls to a different host (vLLM, OpenRouter, Azure, local). Honoured by the red teaming and simulation LLM client. |
 | `ORQ_DISABLE_TRACING` | No | unset | Set to `1` or `true` to suppress all OpenTelemetry spans even when `ORQ_API_KEY` or `OTEL_EXPORTER_OTLP_ENDPOINT` is present. |
@@ -58,8 +59,3 @@ To send traces to a custom OTLP collector instead of Orq:
 ```dotenv
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
-
-## Notes
-
-- `EVALUATORQ_OWASP_DATASET_ID` is listed in `CLAUDE.md` but is not present in the current source tree; it was not found in any `os.getenv` / `os.environ.get` call and is not documented here.
-- `ROUTER_BASE_URL` was a predecessor to `ORQ_BASE_URL`. Setting it now triggers a deprecation warning; use `ORQ_BASE_URL` instead.


### PR DESCRIPTION
## What

Removes internal review-notes leakage from the public docs (RES-1004).

The `configuration.md` "## Notes" section read like an author's audit and shipped to the public site:

- Dropped the `EVALUATORQ_OWASP_DATASET_ID` note — a `CLAUDE.md`-vs-source audit line ("listed in `CLAUDE.md` but not present in the current source tree…") that is meaningless to public readers, who have no `CLAUDE.md`. Confirmed the var exists nowhere in `src/`.
- Folded the `ROUTER_BASE_URL` deprecation into the env-var table as a **deprecated row** rather than a free-text note. Verified against the code (`src/evaluatorq/redteam/backends/registry.py:43-44`): it is still handled and logs a "no longer supported" warning, so it belongs in the table as deprecated (not removed).

## The other checkbox — already resolved

`docs/redteam-dashboard-only-views.md` (the internal FastHTML spec) was already removed from `main` via the dashboard consolidation (RES-1006). It no longer exists, nothing references it, it is not in nav, and `mkdocs.yml` already carries `exclude_docs: superpowers/`, so the dead `docs/superpowers/specs/...` references are moot. No change needed there.

## Scope

One file: `docs/configuration.md` (+1 / -5).

## Out of scope

`docs/stylesheets/extra.css` has two developer comments referencing `/DESIGN.md`. Those are source comments in a stylesheet, not readable/indexed doc prose, and outside the ticket's file list — left as-is.
