### PR TITLE
Refine docs site links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/evaluatorq.svg)](https://pypi.org/project/evaluatorq/)
 [![CI](https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml)
 [![Docs](https://github.com/orq-ai/evaluatorq/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/orq-ai/evaluatorq/actions/workflows/docs.yml)
+[![Docs Site](https://img.shields.io/badge/Docs-Live%20Site-0A7B83)](https://orq-ai.github.io/evaluatorq/)
 [![Release](https://github.com/orq-ai/evaluatorq/actions/workflows/release.yml/badge.svg)](https://github.com/orq-ai/evaluatorq/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/orq-ai/evaluatorq/blob/main/LICENSE)
 
 An evaluation framework library for Python that provides a flexible way to run parallel evaluations and optionally integrate with the Orq AI platform.
-
-**Docs:** [orq-ai.github.io/evaluatorq](https://orq-ai.github.io/evaluatorq/). Agents can read the docs as markdown at [`/llms.txt`](https://orq-ai.github.io/evaluatorq/llms.txt) (curated index) and [`/llms-full.txt`](https://orq-ai.github.io/evaluatorq/llms-full.txt) (full text), per the [llms.txt convention](https://llmstxt.org/).
 
 ## Why evaluatorq?
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/evaluatorq.svg)](https://pypi.org/project/evaluatorq/)
 [![Python versions](https://img.shields.io/pypi/pyversions/evaluatorq.svg)](https://pypi.org/project/evaluatorq/)
 [![CI](https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml)
-[![Docs](https://github.com/orq-ai/evaluatorq/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/orq-ai/evaluatorq/actions/workflows/docs.yml)
+[![Docs CI](https://img.shields.io/github/actions/workflow/status/orq-ai/evaluatorq/docs.yml?branch=main&label=Docs%20CI)](https://github.com/orq-ai/evaluatorq/actions/workflows/docs.yml)
 [![Docs Site](https://img.shields.io/badge/Docs-Live%20Site-0A7B83)](https://orq-ai.github.io/evaluatorq/)
 [![Release](https://github.com/orq-ai/evaluatorq/actions/workflows/release.yml/badge.svg)](https://github.com/orq-ai/evaluatorq/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/orq-ai/evaluatorq/blob/main/LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ in Python — against any agent, with the Orq AI platform as optional infrastruc
 [Get Started](guides/getting-started.md){ .md-button .md-button--primary }
 [View on GitHub](https://github.com/orq-ai/evaluatorq){ .md-button }
 
+!!! info "Agent-readable docs"
+    Coding agents can start with `/llms.txt`, the curated Markdown index for this site.
+    That page points to `/llms-full.txt` when the full docs in one Markdown file is more useful.
+
 ## Install
 
 <!-- termynal -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,7 +98,7 @@ plugins:
   - llmstxt:
       markdown_description: |
         This is the curated docs index. For the complete docs as one Markdown file, use
-        [llms-full.txt](https://orq-ai.github.io/evaluatorq/llms-full.txt).
+        [llms-full.txt](llms-full.txt).
       full_output: llms-full.txt
       sections:
         Getting started:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,9 @@ plugins:
   # (every nav doc must be covered here, or `mkdocs build --strict` fails), so this can't
   # silently drift out of sync with nav again.
   - llmstxt:
+      markdown_description: |
+        This is the curated docs index. For the complete docs as one Markdown file, use
+        [llms-full.txt](https://orq-ai.github.io/evaluatorq/llms-full.txt).
       full_output: llms-full.txt
       sections:
         Getting started:


### PR DESCRIPTION
## Summary
- replace the inline README docs sentence with a docs site badge in the badge row
- remove the README-specific llms.txt explanation and move that guidance into generated llms.txt
- make llms.txt explicitly point agents to llms-full.txt for the full markdown docs

## Test Plan
- uv run --group docs mkdocs build --strict
