### PR TITLE
feat(dashboard): side-by-side sim run comparison (RES-1085)

### DIFF
--- a/src/evaluatorq/common/reports/vega.py
+++ b/src/evaluatorq/common/reports/vega.py
@@ -382,8 +382,7 @@ def vl_grouped_bar(
         for i in range(len(categories))
         if i < len(vals)
     ]
-    return {
-        'data': {'values': rows},
+    bar_layer: dict[str, Any] = {
         'mark': {'type': 'bar', 'tooltip': True},
         'encoding': {
             'y': {'field': 'cat', 'type': 'nominal', 'sort': None, 'title': None},
@@ -391,6 +390,22 @@ def vl_grouped_bar(
             'yOffset': {'field': 'series', 'type': 'nominal'},
             'color': {'field': 'series', 'type': 'nominal', 'legend': {'title': None}},
         },
+    }
+    # A zero-value bar has zero width and renders as nothing, which is
+    # indistinguishable from "not measured" — label those bars with a literal 0.
+    zero_label_layer: dict[str, Any] = {
+        'transform': [{'filter': 'datum.value === 0'}],
+        'mark': {'type': 'text', 'align': 'left', 'dx': 3, 'fontSize': 9, 'color': COLORS['ink_700']},
+        'encoding': {
+            'y': {'field': 'cat', 'type': 'nominal', 'sort': None, 'title': None},
+            'x': {'field': 'value', 'type': 'quantitative', 'title': x_title},
+            'yOffset': {'field': 'series', 'type': 'nominal'},
+            'text': {'value': '0'},
+        },
+    }
+    return {
+        'data': {'values': rows},
+        'layer': [bar_layer, zero_label_layer],
         'width': 420,
         'height': {'step': 16},
     }

--- a/src/evaluatorq/common/reports/vega.py
+++ b/src/evaluatorq/common/reports/vega.py
@@ -28,16 +28,22 @@ from evaluatorq.common.reports.palette import COLORS, QUALITATIVE
 
 ORQ_VL_CONFIG: dict[str, Any] = {
     'background': 'transparent',
-    'font': 'Inter, system-ui, -apple-system, sans-serif',
+    # vl-convert renders server-side and has no access to the brand webfonts; it
+    # also can't resolve 'system-ui'/'-apple-system' and would fall back to a
+    # serif. List concrete sans families so it lands on a clean sans everywhere.
+    'font': 'Inter, Helvetica Neue, Helvetica, Arial, sans-serif',
     'axis': {
         'labelColor': COLORS['ink_700'],
         'titleColor': COLORS['ink_700'],
         'gridColor': COLORS['sand_400'],
+        'gridOpacity': 0.6,
         'domainColor': COLORS['sand_400'],
         'tickColor': COLORS['sand_400'],
     },
     'legend': {'labelColor': COLORS['ink_700'], 'titleColor': COLORS['ink_700']},
     'view': {'stroke': 'transparent'},
+    # Softly rounded bar ends read cleaner and match the dashboard's card radii.
+    'bar': {'cornerRadiusEnd': 3},
     'range': {'category': QUALITATIVE},
 }
 

--- a/src/evaluatorq/dashboard/app.py
+++ b/src/evaluatorq/dashboard/app.py
@@ -254,7 +254,12 @@ def build_app(roots: list[Path] | None = None) -> FastHTML:
         # Tabbed body for the known surfaces (Streamlit-aligned); the interactive
         # panels live inside their tabs, so they are no longer appended separately.
         if surface == 'sim':
-            body_html = report_tabs.sim_report_tabs(rid, report_obj)
+            from evaluatorq.dashboard.view import sim_run_compare_control
+
+            # Same choice list as the overview picker (sim only, no error runs,
+            # capped); the control itself drops the current run from the options.
+            choices = [(c.id, c.name) for c in library.scan(roots) if c.surface == 'sim' and not c.error][:100]
+            body_html = report_tabs.sim_report_tabs(rid, report_obj, compare_html=sim_run_compare_control(rid, choices))
         elif surface == 'redteam':
             body_html = report_tabs.redteam_report_tabs(rid, report_obj)
         else:

--- a/src/evaluatorq/dashboard/app.py
+++ b/src/evaluatorq/dashboard/app.py
@@ -50,6 +50,7 @@ from evaluatorq.dashboard.filter_request import parse_selections
 from evaluatorq.dashboard.filters import FILTERS, apply_or_all
 from evaluatorq.dashboard.redteam_views import register_redteam_view_routes
 from evaluatorq.dashboard.shell import page
+from evaluatorq.dashboard.sim_compare import register_sim_compare_routes
 from evaluatorq.dashboard.sim_views import register_sim_view_routes
 from evaluatorq.dashboard.surfaces import ADAPTERS
 from evaluatorq.dashboard.view import (
@@ -171,7 +172,8 @@ def build_app(roots: list[Path] | None = None) -> FastHTML:
         label = SURFACE_LABELS.get(surface, 'Reports')
         pg, per_pg = _paging(req)
         if surface == 'sim':
-            body = sim_overview_body(metrics.sim_overview(roots, page=pg, per_page=per_pg))
+            sim_choices = [(c.id, c.name) for c in library.scan(roots) if c.surface == 'sim']
+            body = sim_overview_body(metrics.sim_overview(roots, page=pg, per_page=per_pg), compare_choices=sim_choices)
         elif surface == 'redteam':
             body = redteam_overview_body(metrics.redteam_overview(roots, page=pg, per_page=per_pg))
         else:
@@ -546,6 +548,11 @@ def build_app(roots: list[Path] | None = None) -> FastHTML:
     # Routes: GET /r/{rid}/sim/*  — sim interactive fragment views
     # ------------------------------------------------------------------
     register_sim_view_routes(app, roots)
+
+    # ------------------------------------------------------------------
+    # Routes: GET /compare/sim*  — side-by-side sim run comparison
+    # ------------------------------------------------------------------
+    register_sim_compare_routes(app, roots)
 
     # Register static file handler LAST so its catch-all /{fname}.{ext} does not
     # intercept the download routes above. Serve under /static/ to match the page

--- a/src/evaluatorq/dashboard/app.py
+++ b/src/evaluatorq/dashboard/app.py
@@ -172,7 +172,11 @@ def build_app(roots: list[Path] | None = None) -> FastHTML:
         label = SURFACE_LABELS.get(surface, 'Reports')
         pg, per_pg = _paging(req)
         if surface == 'sim':
-            sim_choices = [(c.id, c.name) for c in library.scan(roots) if c.surface == 'sim']
+            # Compare picker options: sim runs only, excluding error-flagged runs
+            # (they route to a 404), newest-first, capped so the dropdown stays
+            # usable on large stores. library.scan reuses the mtime-keyed JSON
+            # cache metrics.sim_overview already warmed, so this is not a full re-parse.
+            sim_choices = [(c.id, c.name) for c in library.scan(roots) if c.surface == 'sim' and not c.error][:100]
             body = sim_overview_body(metrics.sim_overview(roots, page=pg, per_page=per_pg), compare_choices=sim_choices)
         elif surface == 'redteam':
             body = redteam_overview_body(metrics.redteam_overview(roots, page=pg, per_page=per_pg))

--- a/src/evaluatorq/dashboard/library.py
+++ b/src/evaluatorq/dashboard/library.py
@@ -90,10 +90,26 @@ def sniff_kind(data: dict[str, object]) -> str | None:
 
 
 def load_surface(path: Path) -> tuple[str | None, dict[str, object]]:
+    """Lenient surface sniff for directory scans: a corrupt/unreadable file is masked
+    as an unknown surface (``None``) so one bad file can't break a whole listing."""
     try:
         data = read_json_cached(path)
     except (json.JSONDecodeError, OSError):
         return None, {}
+    return sniff_kind(data), data
+
+
+def load_surface_strict(path: Path) -> tuple[str | None, dict[str, object]]:
+    """Like :func:`load_surface`, but lets a corrupt/unreadable file raise instead of
+    masking it as an unknown surface. Callers resolving a *specific requested* report
+    (not scanning a directory) use this so a syntactically corrupt file is reported as
+    corrupt rather than "not found".
+
+    Raises:
+        json.JSONDecodeError: the file content is not valid JSON.
+        OSError: the file cannot be read.
+    """
+    data = read_json_cached(path)
     return sniff_kind(data), data
 
 

--- a/src/evaluatorq/dashboard/report_tabs.py
+++ b/src/evaluatorq/dashboard/report_tabs.py
@@ -98,7 +98,7 @@ def _stable_entries(run: SimulationRun, rows: list[Any]) -> list[Any]:
     ]
 
 
-def sim_report_tabs(rid: str, run: SimulationRun, results: list[Any] | None = None) -> str:
+def sim_report_tabs(rid: str, run: SimulationRun, results: list[Any] | None = None, compare_html: str = '') -> str:
     """Render the Agent Sim report body as Streamlit-aligned tabs.
 
     Tabs: Overview · Breakdown · Transcripts · Turn quality · Config — each
@@ -106,7 +106,8 @@ def sim_report_tabs(rid: str, run: SimulationRun, results: list[Any] | None = No
     quality drops when a run carries no ``turn_metrics``). Config folds job-level
     metadata (run configuration, personas, scenarios) plus the kept token_usage
     table. Pass ``results`` to render a filtered subset (the filter round-trip);
-    it defaults to the run's full result list.
+    it defaults to the run's full result list. ``compare_html`` is an optional
+    pre-rendered compare-with-another-run control shown in the hero actions.
     """
     from evaluatorq.dashboard.view import sim_interactive_panels
     from evaluatorq.simulation.reports.export_html import _SECTION_RENDERERS
@@ -133,7 +134,7 @@ def sim_report_tabs(rid: str, run: SimulationRun, results: list[Any] | None = No
     def render(*kinds: str) -> str:
         return _render_sections(by_kind, _SECTION_RENDERERS, kinds)
 
-    hero = _sim_hero(run)
+    hero = _sim_hero(run, compare_html)
 
     entries = _stable_entries(run, rows)
 
@@ -1436,12 +1437,13 @@ def _sim_outcomes_donut(rows: list[Any]) -> str:
     return f'<figure class="chart-card"><figcaption>Outcomes</figcaption>{inner}</figure>'
 
 
-def _sim_hero(run: SimulationRun) -> str:
+def _sim_hero(run: SimulationRun, compare_html: str = '') -> str:
     # KPI cards intentionally omitted: the same metrics render in the 5-card
     # band inside the Overview tab (_sim_kpi_band), so a hero band duplicated
     # them above the tabs. Hero is now just title + subtitle.
     run_btn = trace_link_button(run_trace_url(run.run_id, run.experiment_url), 'View all run traces ↗')
-    actions = f'<div class="report-hero-actions">{run_btn}</div>' if run_btn else ''
+    inner = run_btn + compare_html
+    actions = f'<div class="report-hero-actions">{inner}</div>' if inner else ''
     return (
         '<header class="report-hero">'
         '<p class="report-hero-kicker">Agent Simulation</p>'

--- a/src/evaluatorq/dashboard/sim_compare.py
+++ b/src/evaluatorq/dashboard/sim_compare.py
@@ -475,10 +475,12 @@ def render_compare_page(rid_a: str, rid_b: str, run_a: SimulationRun, run_b: Sim
     )
     return (
         f'{_hero(run_a, run_b, matching)}'
+        '<div class="cmp-body">'
         f'{kpi_section}{charts}'
         f'{_delta_chart(matching)}'
         f'{_all_metrics_table(kpis, name_a, name_b)}'
         f'{_diff_table(rid_a, rid_b, matching)}'
+        '</div>'
     )
 
 

--- a/src/evaluatorq/dashboard/sim_compare.py
+++ b/src/evaluatorq/dashboard/sim_compare.py
@@ -7,16 +7,18 @@ runner or data model — it only reads two already-stored ``SimulationRun`` obje
 Routes (registered by ``register_sim_compare_routes``):
 
     GET /compare/sim?a={ridA}&b={ridB}
-        Full page: header for both runs, a KPI delta table (aggregates +
-        per-scorer + terminated-by), and an outcome-diff table matching
-        conversations by ``(persona, scenario)``.
+        Full page: hero, KPI delta cards, A-vs-B charts, an all-metrics table,
+        and an outcome-diff table matching conversations by ``(persona, scenario)``.
 
     GET /compare/sim/transcript?a={ridA}&b={ridB}&ia={idxA}&ib={idxB}
         Side-by-side transcript fragment for one matched conversation pair.
 
 Conversations are matched by ``(persona, scenario)`` (the ticket's chosen key):
-runs that share a dataset line up; anything unmatched is listed separately so a
-mismatched dataset is visible rather than silently dropped.
+runs that share a dataset line up; anything unmatched is listed separately (with a
+low-overlap warning) so a mismatched dataset is visible rather than silently dropped.
+
+Charts are Vega-Lite specs rendered server-side to SVG via the shared
+``common.reports.vega`` helpers — no client JS, no ``/static`` dependency.
 """
 
 from __future__ import annotations
@@ -26,18 +28,25 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
 from starlette.requests import Request  # noqa: TC002 — FastHTML inspects at runtime
 from starlette.responses import Response
 
 from evaluatorq.common.reports import esc
 from evaluatorq.common.reports.html_helpers import kpi_cards, pct
+from evaluatorq.common.reports.palette import COLORS
+from evaluatorq.common.reports.vega import render_svg, vl_bar_h, vl_grouped_bar
 from evaluatorq.dashboard.shell import page
-from evaluatorq.dashboard.sim_views import _load_run, render_transcript_fragment
+from evaluatorq.dashboard.sim_views import _entries_from_run, render_transcript_fragment
+from evaluatorq.dashboard.view import _panel
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from evaluatorq.simulation.types import SimulationEntry, SimulationRun
+
+_UP = COLORS['success_400']  # improved / higher in B
+_DOWN = COLORS['red_400']  # regressed / lower in B
 
 
 # ---------------------------------------------------------------------------
@@ -50,17 +59,20 @@ class KpiRow:
     """One comparison row: a label, the two run values, and their delta.
 
     ``kind`` drives formatting: ``'rate'`` (0..1 → %), ``'score'`` (2dp),
-    ``'turns'`` (1dp), ``'count'`` (int). ``a``/``b`` are floats; a metric
-    absent from one run is treated as 0.0 so the delta is still meaningful.
+    ``'turns'`` (1dp), ``'count'`` (int). ``a`` / ``b`` may be ``None`` when a
+    metric was not measured by that run (e.g. a scorer only one run used); such a
+    row renders ``n/a`` and carries no delta arrow rather than a fabricated 0.0.
     """
 
     label: str
-    a: float
-    b: float
+    a: float | None
+    b: float | None
     kind: str
 
     @property
-    def delta(self) -> float:
+    def delta(self) -> float | None:
+        if self.a is None or self.b is None:
+            return None
         return self.b - self.a
 
 
@@ -75,6 +87,8 @@ def compare_kpis(
 
     Aggregates are computed from the entry lists (so they track the conversations
     actually present); per-scorer values come from each run's ``scorer_averages``.
+    A scorer present in only one run keeps ``None`` on the other side — it is not
+    a real 0.0 and must not read as a regression.
     """
     rows: list[KpiRow] = [
         KpiRow('Conversations', float(len(entries_a)), float(len(entries_b)), 'count'),
@@ -98,12 +112,12 @@ def compare_kpis(
         ),
     ]
 
-    # Per-scorer averages — union of both runs' scorer_averages keys, sorted.
+    # Per-scorer averages — union of keys, but a missing scorer stays None (n/a),
+    # never 0.0, so a run that never measured it shows no fabricated regression.
     sa_a = run_a.scorer_averages or {}
     sa_b = run_b.scorer_averages or {}
     rows.extend(
-        KpiRow(f'Scorer: {key}', float(sa_a.get(key, 0.0)), float(sa_b.get(key, 0.0)), 'score')
-        for key in sorted(set(sa_a) | set(sa_b))
+        KpiRow(f'Scorer: {key}', sa_a.get(key), sa_b.get(key), 'score') for key in sorted(set(sa_a) | set(sa_b))
     )
 
     # Terminated-by distribution — counts per reason, union of labels.
@@ -117,7 +131,9 @@ def compare_kpis(
     return rows
 
 
-def _fmt(value: float, kind: str) -> str:
+def _fmt(value: float | None, kind: str) -> str:
+    if value is None:
+        return 'n/a'
     if kind == 'rate':
         return f'{value * 100:.0f}%'
     if kind == 'score':
@@ -129,6 +145,8 @@ def _fmt(value: float, kind: str) -> str:
 
 def _fmt_delta(row: KpiRow) -> str:
     d = row.delta
+    if d is None:
+        return '<span class="cmp-delta cmp-flat">—</span>'
     if abs(d) < 1e-9:
         return '<span class="cmp-delta cmp-flat">0</span>'
     arrow = '&#x25B2;' if d > 0 else '&#x25BC;'  # ▲ / ▼
@@ -162,12 +180,19 @@ class Matching:
     a_only: list[SimulationEntry]
     b_only: list[SimulationEntry]
 
+    @property
+    def match_rate(self) -> float:
+        """Share of all conversations that paired up (0..1). 1.0 = identical key sets."""
+        total = 2 * len(self.matched) + len(self.a_only) + len(self.b_only)
+        return (2 * len(self.matched) / total) if total else 0.0
+
 
 def match_entries(entries_a: list[SimulationEntry], entries_b: list[SimulationEntry]) -> Matching:
     """Pair conversations across runs by ``(persona, scenario)``.
 
     Duplicate keys within a run are paired positionally (first A with first B,
-    etc.); any leftovers on either side fall into ``a_only`` / ``b_only``.
+    etc.) — an approximation surfaced by the low-overlap note on the page; any
+    leftovers on either side fall into ``a_only`` / ``b_only``.
     """
     by_key_b: dict[tuple[str, str], list[SimulationEntry]] = defaultdict(list)
     for e in entries_b:
@@ -176,7 +201,6 @@ def match_entries(entries_a: list[SimulationEntry], entries_b: list[SimulationEn
     matched: list[MatchedPair] = []
     a_only: list[SimulationEntry] = []
     consumed_b: set[int] = set()
-    # Track position within each key's B-list as we consume duplicates.
     cursor: dict[tuple[str, str], int] = defaultdict(int)
 
     for ea in entries_a:
@@ -198,20 +222,6 @@ def match_entries(entries_a: list[SimulationEntry], entries_b: list[SimulationEn
 # ---------------------------------------------------------------------------
 # Rendering
 # ---------------------------------------------------------------------------
-
-
-def _entries(run: SimulationRun) -> list[SimulationEntry]:
-    from evaluatorq.simulation.reports.sections import individual_entries
-
-    return individual_entries(run.results)
-
-
-def _panel(title: str, sub: str, inner: str) -> str:
-    """Framed section matching the dashboard's ``.panel`` chrome (theme-styled)."""
-    return (
-        f'<div class="panel"><div class="panel-title">{esc(title)}</div>'
-        f'<div class="panel-sub">{esc(sub)}</div>{inner}</div>'
-    )
 
 
 def _agg(entries: list[SimulationEntry]) -> tuple[float, float, float]:
@@ -256,143 +266,71 @@ def _kpi_band(entries_a: list[SimulationEntry], entries_b: list[SimulationEntry]
     return kpi_cards(cards)
 
 
-# --- Inline-SVG charts --------------------------------------------------------
-# Server-rendered SVG (no JS, no /static dependency) so charts always render — in
-# the dashboard, in tests, and in static HTML exports alike. Colours are the orq
-# brand palette; A is green, B is rust (the brand accent).
-_SERIES_A = '#0f9d6b'
-_SERIES_B = '#df5325'
-_AXIS = '#d8d3cc'
-_LBL = '#6b7280'
-_VAL = '#25232e'
-_MONO = 'ui-monospace, SFMono-Regular, Menlo, monospace'
+# --- Charts: Vega-Lite specs rendered server-side to SVG (no JS / no /static) ---
 
 
-def _svg_grouped_bars(categories: list[str], series: list[tuple[str, str, list[float]]], *, value_kind: str) -> str:
-    """Grouped horizontal bar SVG. ``series`` = [(name, colour, values)];
-    ``value_kind`` is ``'rate'`` (0..1 → %) or ``'count'`` (integer)."""
-    if not categories or not series:
-        return ''
-    all_vals = [v for _, _, vs in series for v in vs]
-    vmax = 1.0 if value_kind == 'rate' else (max(all_vals) or 1.0)
-    n = len(series)
-    bar_h, bar_gap, group_gap = 12, 3, 14
-    lbl_w, plot_x, plot_w, top, right_pad = 150, 158, 250, 34, 52
-    group_h = n * (bar_h + bar_gap) + group_gap
-    height = top + len(categories) * group_h + 8
-    width = plot_x + plot_w + right_pad
-
-    def fmt(v: float) -> str:
-        return f'{v * 100:.0f}%' if value_kind == 'rate' else f'{v:.0f}'
-
-    p: list[str] = [f'<svg viewBox="0 0 {width} {height}" width="100%" role="img" style="max-width:{width}px">']
-    lx = plot_x
-    for name, color, _ in series:
-        p.append(
-            f'<rect x="{lx}" y="12" width="10" height="10" rx="2" fill="{color}"/>'
-            f'<text x="{lx + 15}" y="21" font-family="{_MONO}" font-size="11" fill="{_LBL}">{esc(name)}</text>'
-        )
-        lx += 15 + int(len(name) * 6.7) + 18
-    p.append(f'<line x1="{plot_x}" y1="{top}" x2="{plot_x}" y2="{height - 8}" stroke="{_AXIS}"/>')
-    for ci, cat in enumerate(categories):
-        gy = top + ci * group_h
-        cy = gy + n * (bar_h + bar_gap) / 2
-        p.append(
-            f'<text x="{lbl_w - 8}" y="{cy + 3:.0f}" text-anchor="end" font-family="{_MONO}" '
-            f'font-size="11" fill="{_LBL}">{esc(cat)}</text>'
-        )
-        for si, (_, color, vs) in enumerate(series):
-            v = vs[ci] if ci < len(vs) else 0.0
-            bw = max(0.0, v / vmax * plot_w)
-            by = gy + si * (bar_h + bar_gap)
-            p.append(
-                f'<rect x="{plot_x}" y="{by}" width="{bw:.1f}" height="{bar_h}" rx="2" fill="{color}"/>'
-                f'<text x="{plot_x + bw + 5:.1f}" y="{by + bar_h - 2}" font-family="{_MONO}" '
-                f'font-size="10" fill="{_VAL}">{fmt(v)}</text>'
-            )
-    p.append('</svg>')
-    return ''.join(p)
-
-
-def _svg_diverging(rows: list[tuple[str, float]]) -> str:
-    """Diverging horizontal bars around a zero line (positive right/green,
-    negative left/rust). ``rows`` = [(label, delta)]."""
-    if not rows:
-        return ''
-    vmax = max((abs(d) for _, d in rows), default=0.0) or 1.0
-    bar_h, gap = 13, 6
-    lbl_w, half, right_pad, top = 160, 120, 46, 12
-    mid_x = lbl_w + half
-    width = lbl_w + half * 2 + right_pad
-    height = top + len(rows) * (bar_h + gap) + 6
-    p: list[str] = [f'<svg viewBox="0 0 {width} {height}" width="100%" role="img" style="max-width:{width}px">']
-    p.append(f'<line x1="{mid_x}" y1="{top - 4}" x2="{mid_x}" y2="{height - 6}" stroke="{_AXIS}"/>')
-    for i, (label, d) in enumerate(rows):
-        y = top + i * (bar_h + gap)
-        w = abs(d) / vmax * half
-        if d >= 0:
-            x, color, tx, anchor = mid_x, _SERIES_A, mid_x + w + 5, 'start'
-        else:
-            x, color, tx, anchor = mid_x - w, _SERIES_B, mid_x - w - 5, 'end'
-        p.append(
-            f'<text x="{lbl_w - 8}" y="{y + bar_h - 2}" text-anchor="end" font-family="{_MONO}" '
-            f'font-size="10" fill="{_LBL}">{esc(label)}</text>'
-            f'<rect x="{x:.1f}" y="{y}" width="{w:.1f}" height="{bar_h}" rx="2" fill="{color}"/>'
-            f'<text x="{tx:.1f}" y="{y + bar_h - 2}" text-anchor="{anchor}" font-family="{_MONO}" '
-            f'font-size="10" fill="{_VAL}">{d:+.2f}</text>'
-        )
-    p.append('</svg>')
-    return ''.join(p)
+def _chart_panel(title: str, sub: str, spec: dict[str, Any]) -> str:
+    """Render a Vega-Lite spec to SVG and wrap it in a titled panel. Omits the
+    panel entirely when the chart can't render (empty data / vl-convert absent)."""
+    svg = render_svg(spec)
+    return _panel(title, sub, svg) if svg else ''
 
 
 def _outcomes_chart(
     entries_a: list[SimulationEntry], entries_b: list[SimulationEntry], name_a: str, name_b: str
 ) -> str:
-    """A-vs-B bars for the two headline 0..1 metrics."""
+    """A-vs-B grouped bars for the two headline 0..1 metrics."""
     rate_a, score_a, _ = _agg(entries_a)
     rate_b, score_b, _ = _agg(entries_b)
-    svg = _svg_grouped_bars(
-        ['Goal-achieved rate', 'Mean goal score'],
-        [(name_a, _SERIES_A, [rate_a, score_a]), (name_b, _SERIES_B, [rate_b, score_b])],
-        value_kind='rate',
+    spec = vl_grouped_bar(
+        categories=['Goal-achieved rate', 'Mean goal score'],
+        series=[(name_a, [rate_a, score_a]), (name_b, [rate_b, score_b])],
+        x_title='0 to 1',
     )
-    return _panel('Outcomes', 'Goal rate and mean score · A vs B', svg)
+    return _chart_panel('Outcomes', 'Goal rate and mean score · A vs B', spec)
 
 
 def _scorer_chart(run_a: SimulationRun, run_b: SimulationRun, name_a: str, name_b: str) -> str:
-    """A-vs-B bars over the union of both runs' scorer averages."""
+    """A-vs-B grouped bars over the scorers BOTH runs measured. Scorers used by
+    only one run are listed, not charted as a fake 0.0."""
     sa_a = run_a.scorer_averages or {}
     sa_b = run_b.scorer_averages or {}
-    keys = sorted(set(sa_a) | set(sa_b))
-    if not keys:
+    shared = sorted(set(sa_a) & set(sa_b))
+    if not shared:
         return ''
-    svg = _svg_grouped_bars(
-        keys,
-        [(name_a, _SERIES_A, [sa_a.get(k, 0.0) for k in keys]), (name_b, _SERIES_B, [sa_b.get(k, 0.0) for k in keys])],
-        value_kind='rate',
+    spec = vl_grouped_bar(
+        categories=shared,
+        series=[(name_a, [sa_a[k] for k in shared]), (name_b, [sa_b[k] for k in shared])],
+        x_title='Average score',
     )
-    return _panel('Scorer averages', 'Per-scorer mean · A vs B', svg)
+    svg = render_svg(spec)
+    if not svg:
+        return ''
+    only = sorted((set(sa_a) | set(sa_b)) - set(shared))
+    note = f'<p class="cmp-note">Not compared (measured by one run only): {esc(", ".join(only))}</p>' if only else ''
+    return _panel('Scorer averages', 'Per-scorer mean · shared scorers only', svg + note)
 
 
 def _terminated_chart(
     entries_a: list[SimulationEntry], entries_b: list[SimulationEntry], name_a: str, name_b: str
 ) -> str:
-    """A-vs-B bars for how conversations ended."""
+    """A-vs-B grouped bars for how conversations ended."""
     tb_a = Counter(e.terminated_by for e in entries_a)
     tb_b = Counter(e.terminated_by for e in entries_b)
     labels = sorted(set(tb_a) | set(tb_b))
     if not labels:
         return ''
-    svg = _svg_grouped_bars(
-        labels,
-        [(name_a, _SERIES_A, [float(tb_a[x]) for x in labels]), (name_b, _SERIES_B, [float(tb_b[x]) for x in labels])],
-        value_kind='count',
+    spec = vl_grouped_bar(
+        categories=labels,
+        series=[(name_a, [float(tb_a[x]) for x in labels]), (name_b, [float(tb_b[x]) for x in labels])],
+        x_title='Conversations',
     )
-    return _panel('How conversations ended', 'Terminated-by counts · A vs B', svg)
+    return _chart_panel('How conversations ended', 'Terminated-by counts · A vs B', spec)
 
 
 def _delta_chart(matching: Matching) -> str:
-    """Per-conversation goal-score change (B - A) over matched pairs, sorted."""
+    """Per-conversation goal-score change (B - A) over matched pairs, sorted;
+    green bars improved in B, red regressed."""
     if not matching.matched:
         return ''
     rows = sorted(
@@ -402,10 +340,21 @@ def _delta_chart(matching: Matching) -> str:
         ),
         key=operator.itemgetter(1),
     )
-    return _panel(
+    labels = [r[0] for r in rows]
+    values = [r[1] for r in rows]
+    colors = [_UP if v >= 0 else _DOWN for v in values]
+    spec = vl_bar_h(
+        labels=labels,
+        values=values,
+        color=_UP,
+        colors=colors,
+        x_title='B minus A (goal score)',
+        value_labels=[f'{v:+.2f}' for v in values],
+    )
+    return _chart_panel(
         'Per-conversation score change',
-        'B minus A on matched conversations · green improved, rust regressed',
-        _svg_diverging(rows),
+        'B minus A on matched conversations · green improved, red regressed',
+        spec,
     )
 
 
@@ -485,24 +434,33 @@ def render_compare_transcript(entry_a: SimulationEntry, entry_b: SimulationEntry
     )
 
 
-def _hero(run_a: SimulationRun, run_b: SimulationRun) -> str:
-    """Editorial header: mono kicker, display headline, run names + dates."""
+def _hero(run_a: SimulationRun, run_b: SimulationRun, matching: Matching) -> str:
+    """Editorial header + a match summary line (with a low-overlap warning)."""
     date_a = run_a.created_at.strftime('%Y-%m-%d %H:%M')
     date_b = run_b.created_at.strftime('%Y-%m-%d %H:%M')
+    n_matched, n_a, n_b = len(matching.matched), len(matching.a_only), len(matching.b_only)
+    summary = f'{n_matched} matched · {n_a} only in A · {n_b} only in B'
+    # A low match rate means the diff/transcript compare covers only a slice — say so.
+    warn = (
+        f' <span class="cmp-warn">low overlap ({matching.match_rate:.0%}) — the two runs share few '
+        "(persona, scenario) pairs, so most conversations can't be compared directly.</span>"
+        if matching.match_rate < 0.5
+        else ''
+    )
     return (
         '<div class="report-head"><a class="report-back" href="/?surface=sim">&larr; Agent sim runs</a></div>'
         '<section class="cmp-hero">'
         '<div class="cmp-kicker">Agent sim // run comparison</div>'
         f'<h1 class="cmp-title">{esc(run_a.run_name)} <span class="cmp-vs">vs</span> {esc(run_b.run_name)}</h1>'
         f'<p class="cmp-sub">A: {esc(run_a.run_name)} · {date_a} &nbsp;&nbsp; B: {esc(run_b.run_name)} · {date_b}</p>'
-        '</section>'
+        f'</section><p class="cmp-note">{summary}.{warn}</p>'
     )
 
 
 def render_compare_page(rid_a: str, rid_b: str, run_a: SimulationRun, run_b: SimulationRun) -> str:
     """Full compare-page body: hero, KPI deltas + charts, all-metrics, diffs."""
-    entries_a = _entries(run_a)
-    entries_b = _entries(run_b)
+    entries_a = _entries_from_run(run_a)
+    entries_b = _entries_from_run(run_b)
     kpis = compare_kpis(entries_a, entries_b, run_a, run_b)
     matching = match_entries(entries_a, entries_b)
     name_a, name_b = run_a.run_name, run_b.run_name
@@ -516,7 +474,7 @@ def render_compare_page(rid_a: str, rid_b: str, run_a: SimulationRun, run_b: Sim
         '</div>'
     )
     return (
-        f'{_COMPARE_CSS}{_hero(run_a, run_b)}'
+        f'{_hero(run_a, run_b, matching)}'
         f'{kpi_section}{charts}'
         f'{_delta_chart(matching)}'
         f'{_all_metrics_table(kpis, name_a, name_b)}'
@@ -524,33 +482,41 @@ def render_compare_page(rid_a: str, rid_b: str, run_a: SimulationRun, run_b: Sim
     )
 
 
-_COMPARE_CSS = (
-    '<style>'
-    '.cmp-hero { margin: 4px 0 18px; }'
-    '.cmp-kicker { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;'
-    ' text-transform: uppercase; color: var(--text-faint); }'
-    '.cmp-title { font-family: var(--font-display); font-size: 26px; font-weight: 700;'
-    ' color: var(--text-strong); margin: 6px 0 4px; }'
-    '.cmp-title .cmp-vs { color: var(--orange-500); }'
-    '.cmp-sub { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }'
-    '.cmp-charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; }'
-    '.cmp-charts .panel { margin: 0; }'
-    '.cmp-table { width: 100%; border-collapse: collapse; font-size: 13px; }'
-    '.cmp-table th { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase;'
-    ' letter-spacing: .06em; color: var(--text-faint); text-align: left; padding: 6px 10px;'
-    ' border-bottom: 1px solid var(--border-subtle); }'
-    '.cmp-table td { padding: 7px 10px; border-bottom: 1px solid var(--border-subtle); color: var(--text-body); }'
-    '.cmp-diff-row:hover { background: var(--app-gray-100); }'
-    '.cmp-delta { font-variant-numeric: tabular-nums; font-family: var(--font-mono); }'
-    '.cmp-up { color: #0f9d6b; } .cmp-down { color: #df5325; } .cmp-flat { color: var(--text-faint); }'
-    '.cmp-flip { color: #df5325; font-weight: 600; font-size: 11px; margin-left: 6px; font-family: var(--font-mono); }'
-    '.cmp-unmatched { margin-top: 12px; font-size: 12px; color: var(--text-muted); }'
-    '.cmp-unmatched ul { margin: 4px 0 0; padding-left: 18px; }'
-    '.cmp-transcript-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 12px; }'
-    '.cmp-side-title { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase;'
-    ' letter-spacing: .06em; color: var(--text-muted); margin: 0 0 8px; }'
-    '</style>'
-)
+# ---------------------------------------------------------------------------
+# Loading (distinguishes not-found from load-failure, unlike sim_views._load_run)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_run(rid: str, roots: list[Path] | None) -> tuple[str, Any | None]:
+    """Load a sim run by report id.
+
+    Returns ``('ok', run)``, ``('missing', None)`` when the id resolves to no
+    file or a non-sim report, or ``('error', None)`` when a matching sim file
+    fails to load/parse — the last is logged with a stack so a corrupt report is
+    debuggable rather than silently reported as "not found".
+    """
+    from evaluatorq.dashboard import library
+    from evaluatorq.dashboard.surfaces import ADAPTERS
+
+    path = library.resolve(rid, roots)
+    if path is None:
+        return 'missing', None
+    surface, _raw = library.load_surface(path)
+    if surface != 'sim':
+        return 'missing', None
+    adapter = ADAPTERS.get('sim')
+    if adapter is None:
+        return 'missing', None
+    try:
+        return 'ok', adapter.load(path)
+    except Exception:
+        logger.opt(exception=True).warning('compare: failed to load sim report {}', rid)
+        return 'error', None
+
+
+def _error_page(message: str, status: int) -> Response:
+    body = f'<section class="cmp-hero"><h1 class="cmp-title">Run comparison</h1><p class="sim-empty">{esc(message)}</p></section>'
+    return Response(page('Compare', body, active_surface='sim'), status_code=status, media_type='text/html')
 
 
 # ---------------------------------------------------------------------------
@@ -566,15 +532,18 @@ def register_sim_compare_routes(app: Any, roots: list[Path] | None = None) -> No
         rid_a = req.query_params.get('a') or ''
         rid_b = req.query_params.get('b') or ''
         if not rid_a or not rid_b:
-            body = '<section class="cmp-header"><h1>Run comparison</h1><p class="sim-empty">Pick two runs to compare.</p></section>'
-            return Response(page('Compare', body, active_surface='sim'), status_code=400, media_type='text/html')
+            return _error_page('Pick two runs to compare.', 400)
+        if rid_a == rid_b:
+            return _error_page('Pick two different runs to compare.', 400)
 
-        run_a = _load_run(rid_a, roots)
-        run_b = _load_run(rid_b, roots)
+        status_a, run_a = _resolve_run(rid_a, roots)
+        status_b, run_b = _resolve_run(rid_b, roots)
+        if 'error' in (status_a, status_b):
+            which = 'A' if status_a == 'error' else 'B'
+            return _error_page(f'Run {which} could not be loaded (the report may be corrupt).', 422)
         if run_a is None or run_b is None:
-            missing = 'A' if run_a is None else 'B'
-            body = f'<section class="cmp-header"><h1>Run comparison</h1><p class="sim-empty">Run {missing} not found or not a simulation run.</p></section>'
-            return Response(page('Compare', body, active_surface='sim'), status_code=404, media_type='text/html')
+            which = 'A' if run_a is None else 'B'
+            return _error_page(f'Run {which} was not found or is not a simulation run.', 404)
 
         body = render_compare_page(rid_a, rid_b, run_a, run_b)
         return Response(page('Compare', body, active_surface='sim'), media_type='text/html')
@@ -587,18 +556,28 @@ def register_sim_compare_routes(app: Any, roots: list[Path] | None = None) -> No
             ia = int(req.query_params.get('ia', ''))
             ib = int(req.query_params.get('ib', ''))
         except (TypeError, ValueError):
-            return Response('<p class="sim-empty">Invalid conversation index.</p>', media_type='text/html')
+            return Response(
+                '<p class="sim-empty">Invalid conversation index.</p>', status_code=400, media_type='text/html'
+            )
 
-        run_a = _load_run(rid_a, roots)
-        run_b = _load_run(rid_b, roots)
+        status_a, run_a = _resolve_run(rid_a, roots)
+        status_b, run_b = _resolve_run(rid_b, roots)
+        if 'error' in (status_a, status_b):
+            return Response(
+                '<p class="sim-empty">A run could not be loaded (report may be corrupt).</p>',
+                status_code=422,
+                media_type='text/html',
+            )
         if run_a is None or run_b is None:
             return Response('<p class="sim-empty">Run not found.</p>', status_code=404, media_type='text/html')
 
-        entries_a = _entries(run_a)
-        entries_b = _entries(run_b)
+        entries_a = _entries_from_run(run_a)
+        entries_b = _entries_from_run(run_b)
         ea = next((e for e in entries_a if e.index == ia), None)
         eb = next((e for e in entries_b if e.index == ib), None)
         if ea is None or eb is None:
-            return Response('<p class="sim-empty">No conversation at that index.</p>', media_type='text/html')
+            return Response(
+                '<p class="sim-empty">No conversation at that index.</p>', status_code=404, media_type='text/html'
+            )
 
         return Response(render_compare_transcript(ea, eb, run_a.run_name, run_b.run_name), media_type='text/html')

--- a/src/evaluatorq/dashboard/sim_compare.py
+++ b/src/evaluatorq/dashboard/sim_compare.py
@@ -1,4 +1,4 @@
-"""Side-by-side comparison of two simulation runs (RES-1085).
+"""Side-by-side comparison of two simulation runs.
 
 The single-run sim views live in ``sim_views.py``; this module adds a compare
 surface on top of the same ``sim`` adapter/library. Nothing here touches the sim
@@ -13,7 +13,7 @@ Routes (registered by ``register_sim_compare_routes``):
     GET /compare/sim/transcript?a={ridA}&b={ridB}&ia={idxA}&ib={idxB}
         Side-by-side transcript fragment for one matched conversation pair.
 
-Conversations are matched by ``(persona, scenario)`` (the ticket's chosen key):
+Conversations are matched by ``(persona, scenario)``:
 runs that share a dataset line up; anything unmatched is listed separately (with a
 low-overlap warning) so a mismatched dataset is visible rather than silently dropped.
 
@@ -38,7 +38,7 @@ from evaluatorq.common.reports.palette import COLORS
 from evaluatorq.common.reports.vega import render_svg, vl_bar_h, vl_grouped_bar
 from evaluatorq.dashboard.shell import page
 from evaluatorq.dashboard.sim_views import _entries_from_run, render_transcript_fragment
-from evaluatorq.dashboard.view import _panel
+from evaluatorq.dashboard.view import _panel, report_back_link
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -435,7 +435,9 @@ def render_compare_transcript(entry_a: SimulationEntry, entry_b: SimulationEntry
 
 
 def _hero(run_a: SimulationRun, run_b: SimulationRun, matching: Matching) -> str:
-    """Editorial header + a match summary line (with a low-overlap warning)."""
+    """Report hero (shared .report-hero classes) + a match summary line
+    (with a low-overlap warning). The back link lives in the topbar via
+    ``page(back_html=...)``, matching the single-run report pages."""
     date_a = run_a.created_at.strftime('%Y-%m-%d %H:%M')
     date_b = run_b.created_at.strftime('%Y-%m-%d %H:%M')
     n_matched, n_a, n_b = len(matching.matched), len(matching.a_only), len(matching.b_only)
@@ -448,12 +450,11 @@ def _hero(run_a: SimulationRun, run_b: SimulationRun, matching: Matching) -> str
         else ''
     )
     return (
-        '<div class="report-head"><a class="report-back" href="/?surface=sim">&larr; Agent sim runs</a></div>'
-        '<section class="cmp-hero">'
-        '<div class="cmp-kicker">Agent sim // run comparison</div>'
-        f'<h1 class="cmp-title">{esc(run_a.run_name)} <span class="cmp-vs">vs</span> {esc(run_b.run_name)}</h1>'
-        f'<p class="cmp-sub">A: {esc(run_a.run_name)} · {date_a} &nbsp;&nbsp; B: {esc(run_b.run_name)} · {date_b}</p>'
-        f'</section><p class="cmp-note">{summary}.{warn}</p>'
+        '<header class="report-hero">'
+        '<p class="report-hero-kicker">Agent Simulation · Run comparison</p>'
+        f'<h2 class="report-hero-title">{esc(run_a.run_name)} <span class="cmp-vs">vs</span> {esc(run_b.run_name)}</h2>'
+        f'<p class="report-hero-sub">A: {esc(run_a.run_name)} · {date_a} &nbsp;&nbsp; B: {esc(run_b.run_name)} · {date_b}</p>'
+        f'</header><p class="cmp-note">{summary}.{warn}</p>'
     )
 
 
@@ -526,8 +527,15 @@ def _resolve_run(rid: str, roots: list[Path] | None) -> tuple[str, Any | None]:
 
 
 def _error_page(message: str, status: int) -> Response:
-    body = f'<section class="cmp-hero"><h1 class="cmp-title">Run comparison</h1><p class="sim-empty">{esc(message)}</p></section>'
-    return Response(page('Compare', body, active_surface='sim'), status_code=status, media_type='text/html')
+    body = (
+        '<header class="report-hero"><h2 class="report-hero-title">Run comparison</h2></header>'
+        f'<p class="sim-empty">{esc(message)}</p>'
+    )
+    return Response(
+        page('Compare', body, active_surface='sim', back_html=report_back_link('sim')),
+        status_code=status,
+        media_type='text/html',
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -557,7 +565,9 @@ def register_sim_compare_routes(app: Any, roots: list[Path] | None = None) -> No
             return _error_page(f'Run {which} was not found or is not a simulation run.', 404)
 
         body = render_compare_page(rid_a, rid_b, run_a, run_b)
-        return Response(page('Compare', body, active_surface='sim'), media_type='text/html')
+        return Response(
+            page('Compare', body, active_surface='sim', back_html=report_back_link('sim')), media_type='text/html'
+        )
 
     @app.get('/compare/sim/transcript')
     def compare_sim_transcript(req: Request) -> Response:

--- a/src/evaluatorq/dashboard/sim_compare.py
+++ b/src/evaluatorq/dashboard/sim_compare.py
@@ -1,0 +1,604 @@
+"""Side-by-side comparison of two simulation runs (RES-1085).
+
+The single-run sim views live in ``sim_views.py``; this module adds a compare
+surface on top of the same ``sim`` adapter/library. Nothing here touches the sim
+runner or data model — it only reads two already-stored ``SimulationRun`` objects.
+
+Routes (registered by ``register_sim_compare_routes``):
+
+    GET /compare/sim?a={ridA}&b={ridB}
+        Full page: header for both runs, a KPI delta table (aggregates +
+        per-scorer + terminated-by), and an outcome-diff table matching
+        conversations by ``(persona, scenario)``.
+
+    GET /compare/sim/transcript?a={ridA}&b={ridB}&ia={idxA}&ib={idxB}
+        Side-by-side transcript fragment for one matched conversation pair.
+
+Conversations are matched by ``(persona, scenario)`` (the ticket's chosen key):
+runs that share a dataset line up; anything unmatched is listed separately so a
+mismatched dataset is visible rather than silently dropped.
+"""
+
+from __future__ import annotations
+
+import operator
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from starlette.requests import Request  # noqa: TC002 — FastHTML inspects at runtime
+from starlette.responses import Response
+
+from evaluatorq.common.reports import esc
+from evaluatorq.common.reports.html_helpers import kpi_cards, pct
+from evaluatorq.dashboard.shell import page
+from evaluatorq.dashboard.sim_views import _load_run, render_transcript_fragment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from evaluatorq.simulation.types import SimulationEntry, SimulationRun
+
+
+# ---------------------------------------------------------------------------
+# KPI deltas
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KpiRow:
+    """One comparison row: a label, the two run values, and their delta.
+
+    ``kind`` drives formatting: ``'rate'`` (0..1 → %), ``'score'`` (2dp),
+    ``'turns'`` (1dp), ``'count'`` (int). ``a``/``b`` are floats; a metric
+    absent from one run is treated as 0.0 so the delta is still meaningful.
+    """
+
+    label: str
+    a: float
+    b: float
+    kind: str
+
+    @property
+    def delta(self) -> float:
+        return self.b - self.a
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def compare_kpis(
+    entries_a: list[SimulationEntry], entries_b: list[SimulationEntry], run_a: SimulationRun, run_b: SimulationRun
+) -> list[KpiRow]:
+    """Build the KPI delta rows: aggregates, per-scorer averages, terminated-by.
+
+    Aggregates are computed from the entry lists (so they track the conversations
+    actually present); per-scorer values come from each run's ``scorer_averages``.
+    """
+    rows: list[KpiRow] = [
+        KpiRow('Conversations', float(len(entries_a)), float(len(entries_b)), 'count'),
+        KpiRow(
+            'Goal-achieved rate',
+            _mean([1.0 if e.goal_achieved else 0.0 for e in entries_a]),
+            _mean([1.0 if e.goal_achieved else 0.0 for e in entries_b]),
+            'rate',
+        ),
+        KpiRow(
+            'Mean goal score',
+            _mean([e.goal_completion_score for e in entries_a]),
+            _mean([e.goal_completion_score for e in entries_b]),
+            'score',
+        ),
+        KpiRow(
+            'Mean turns',
+            _mean([float(e.turn_count) for e in entries_a]),
+            _mean([float(e.turn_count) for e in entries_b]),
+            'turns',
+        ),
+    ]
+
+    # Per-scorer averages — union of both runs' scorer_averages keys, sorted.
+    sa_a = run_a.scorer_averages or {}
+    sa_b = run_b.scorer_averages or {}
+    rows.extend(
+        KpiRow(f'Scorer: {key}', float(sa_a.get(key, 0.0)), float(sa_b.get(key, 0.0)), 'score')
+        for key in sorted(set(sa_a) | set(sa_b))
+    )
+
+    # Terminated-by distribution — counts per reason, union of labels.
+    tb_a = Counter(e.terminated_by for e in entries_a)
+    tb_b = Counter(e.terminated_by for e in entries_b)
+    rows.extend(
+        KpiRow(f'Terminated: {label}', float(tb_a[label]), float(tb_b[label]), 'count')
+        for label in sorted(set(tb_a) | set(tb_b))
+    )
+
+    return rows
+
+
+def _fmt(value: float, kind: str) -> str:
+    if kind == 'rate':
+        return f'{value * 100:.0f}%'
+    if kind == 'score':
+        return f'{value:.2f}'
+    if kind == 'turns':
+        return f'{value:.1f}'
+    return f'{value:.0f}'
+
+
+def _fmt_delta(row: KpiRow) -> str:
+    d = row.delta
+    if abs(d) < 1e-9:
+        return '<span class="cmp-delta cmp-flat">0</span>'
+    arrow = '&#x25B2;' if d > 0 else '&#x25BC;'  # ▲ / ▼
+    cls = 'cmp-up' if d > 0 else 'cmp-down'
+    # Delta is formatted like its metric; counts render as a signed integer.
+    if row.kind == 'rate':
+        body = f'{d * 100:+.0f}%'
+    elif row.kind == 'score':
+        body = f'{d:+.2f}'
+    elif row.kind == 'turns':
+        body = f'{d:+.1f}'
+    else:
+        body = f'{d:+.0f}'
+    return f'<span class="cmp-delta {cls}">{arrow} {body}</span>'
+
+
+# ---------------------------------------------------------------------------
+# Conversation matching (by persona + scenario)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MatchedPair:
+    a: SimulationEntry
+    b: SimulationEntry
+
+
+@dataclass(frozen=True)
+class Matching:
+    matched: list[MatchedPair]
+    a_only: list[SimulationEntry]
+    b_only: list[SimulationEntry]
+
+
+def match_entries(entries_a: list[SimulationEntry], entries_b: list[SimulationEntry]) -> Matching:
+    """Pair conversations across runs by ``(persona, scenario)``.
+
+    Duplicate keys within a run are paired positionally (first A with first B,
+    etc.); any leftovers on either side fall into ``a_only`` / ``b_only``.
+    """
+    by_key_b: dict[tuple[str, str], list[SimulationEntry]] = defaultdict(list)
+    for e in entries_b:
+        by_key_b[e.persona, e.scenario].append(e)
+
+    matched: list[MatchedPair] = []
+    a_only: list[SimulationEntry] = []
+    consumed_b: set[int] = set()
+    # Track position within each key's B-list as we consume duplicates.
+    cursor: dict[tuple[str, str], int] = defaultdict(int)
+
+    for ea in entries_a:
+        key = (ea.persona, ea.scenario)
+        bucket = by_key_b.get(key, [])
+        i = cursor[key]
+        if i < len(bucket):
+            eb = bucket[i]
+            cursor[key] = i + 1
+            consumed_b.add(id(eb))
+            matched.append(MatchedPair(ea, eb))
+        else:
+            a_only.append(ea)
+
+    b_only = [e for e in entries_b if id(e) not in consumed_b]
+    return Matching(matched, a_only, b_only)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _entries(run: SimulationRun) -> list[SimulationEntry]:
+    from evaluatorq.simulation.reports.sections import individual_entries
+
+    return individual_entries(run.results)
+
+
+def _panel(title: str, sub: str, inner: str) -> str:
+    """Framed section matching the dashboard's ``.panel`` chrome (theme-styled)."""
+    return (
+        f'<div class="panel"><div class="panel-title">{esc(title)}</div>'
+        f'<div class="panel-sub">{esc(sub)}</div>{inner}</div>'
+    )
+
+
+def _agg(entries: list[SimulationEntry]) -> tuple[float, float, float]:
+    """(goal-achieved rate, mean goal score, mean turns) for an entry list."""
+    return (
+        _mean([1.0 if e.goal_achieved else 0.0 for e in entries]),
+        _mean([e.goal_completion_score for e in entries]),
+        _mean([float(e.turn_count) for e in entries]),
+    )
+
+
+def _dir_status(delta: float, *, higher_better: bool) -> str:
+    """Map a delta to a kpi-card status colour (pass/fail/neutral)."""
+    if abs(delta) < 1e-9:
+        return 'neutral'
+    good = delta > 0 if higher_better else delta < 0
+    return 'pass' if good else 'fail'
+
+
+def _kpi_band(entries_a: list[SimulationEntry], entries_b: list[SimulationEntry]) -> str:
+    """Headline KPI cards: current (B) value with the delta vs A in the label."""
+    rate_a, score_a, turns_a = _agg(entries_a)
+    rate_b, score_b, turns_b = _agg(entries_b)
+    cards = [
+        {
+            'label': f'Goal-achieved · {rate_b - rate_a:+.0%} vs A',
+            'value': pct(rate_b),
+            'status': _dir_status(rate_b - rate_a, higher_better=True),
+        },
+        {
+            'label': f'Mean score · {score_b - score_a:+.2f} vs A',
+            'value': f'{score_b:.2f}',
+            'status': _dir_status(score_b - score_a, higher_better=True),
+        },
+        {'label': f'Mean turns · {turns_b - turns_a:+.1f} vs A', 'value': f'{turns_b:.1f}', 'status': 'neutral'},
+        {
+            'label': f'Conversations · {len(entries_a)} → {len(entries_b)}',
+            'value': str(len(entries_b)),
+            'status': 'neutral',
+        },
+    ]
+    return kpi_cards(cards)
+
+
+# --- Inline-SVG charts --------------------------------------------------------
+# Server-rendered SVG (no JS, no /static dependency) so charts always render — in
+# the dashboard, in tests, and in static HTML exports alike. Colours are the orq
+# brand palette; A is green, B is rust (the brand accent).
+_SERIES_A = '#0f9d6b'
+_SERIES_B = '#df5325'
+_AXIS = '#d8d3cc'
+_LBL = '#6b7280'
+_VAL = '#25232e'
+_MONO = 'ui-monospace, SFMono-Regular, Menlo, monospace'
+
+
+def _svg_grouped_bars(categories: list[str], series: list[tuple[str, str, list[float]]], *, value_kind: str) -> str:
+    """Grouped horizontal bar SVG. ``series`` = [(name, colour, values)];
+    ``value_kind`` is ``'rate'`` (0..1 → %) or ``'count'`` (integer)."""
+    if not categories or not series:
+        return ''
+    all_vals = [v for _, _, vs in series for v in vs]
+    vmax = 1.0 if value_kind == 'rate' else (max(all_vals) or 1.0)
+    n = len(series)
+    bar_h, bar_gap, group_gap = 12, 3, 14
+    lbl_w, plot_x, plot_w, top, right_pad = 150, 158, 250, 34, 52
+    group_h = n * (bar_h + bar_gap) + group_gap
+    height = top + len(categories) * group_h + 8
+    width = plot_x + plot_w + right_pad
+
+    def fmt(v: float) -> str:
+        return f'{v * 100:.0f}%' if value_kind == 'rate' else f'{v:.0f}'
+
+    p: list[str] = [f'<svg viewBox="0 0 {width} {height}" width="100%" role="img" style="max-width:{width}px">']
+    lx = plot_x
+    for name, color, _ in series:
+        p.append(
+            f'<rect x="{lx}" y="12" width="10" height="10" rx="2" fill="{color}"/>'
+            f'<text x="{lx + 15}" y="21" font-family="{_MONO}" font-size="11" fill="{_LBL}">{esc(name)}</text>'
+        )
+        lx += 15 + int(len(name) * 6.7) + 18
+    p.append(f'<line x1="{plot_x}" y1="{top}" x2="{plot_x}" y2="{height - 8}" stroke="{_AXIS}"/>')
+    for ci, cat in enumerate(categories):
+        gy = top + ci * group_h
+        cy = gy + n * (bar_h + bar_gap) / 2
+        p.append(
+            f'<text x="{lbl_w - 8}" y="{cy + 3:.0f}" text-anchor="end" font-family="{_MONO}" '
+            f'font-size="11" fill="{_LBL}">{esc(cat)}</text>'
+        )
+        for si, (_, color, vs) in enumerate(series):
+            v = vs[ci] if ci < len(vs) else 0.0
+            bw = max(0.0, v / vmax * plot_w)
+            by = gy + si * (bar_h + bar_gap)
+            p.append(
+                f'<rect x="{plot_x}" y="{by}" width="{bw:.1f}" height="{bar_h}" rx="2" fill="{color}"/>'
+                f'<text x="{plot_x + bw + 5:.1f}" y="{by + bar_h - 2}" font-family="{_MONO}" '
+                f'font-size="10" fill="{_VAL}">{fmt(v)}</text>'
+            )
+    p.append('</svg>')
+    return ''.join(p)
+
+
+def _svg_diverging(rows: list[tuple[str, float]]) -> str:
+    """Diverging horizontal bars around a zero line (positive right/green,
+    negative left/rust). ``rows`` = [(label, delta)]."""
+    if not rows:
+        return ''
+    vmax = max((abs(d) for _, d in rows), default=0.0) or 1.0
+    bar_h, gap = 13, 6
+    lbl_w, half, right_pad, top = 160, 120, 46, 12
+    mid_x = lbl_w + half
+    width = lbl_w + half * 2 + right_pad
+    height = top + len(rows) * (bar_h + gap) + 6
+    p: list[str] = [f'<svg viewBox="0 0 {width} {height}" width="100%" role="img" style="max-width:{width}px">']
+    p.append(f'<line x1="{mid_x}" y1="{top - 4}" x2="{mid_x}" y2="{height - 6}" stroke="{_AXIS}"/>')
+    for i, (label, d) in enumerate(rows):
+        y = top + i * (bar_h + gap)
+        w = abs(d) / vmax * half
+        if d >= 0:
+            x, color, tx, anchor = mid_x, _SERIES_A, mid_x + w + 5, 'start'
+        else:
+            x, color, tx, anchor = mid_x - w, _SERIES_B, mid_x - w - 5, 'end'
+        p.append(
+            f'<text x="{lbl_w - 8}" y="{y + bar_h - 2}" text-anchor="end" font-family="{_MONO}" '
+            f'font-size="10" fill="{_LBL}">{esc(label)}</text>'
+            f'<rect x="{x:.1f}" y="{y}" width="{w:.1f}" height="{bar_h}" rx="2" fill="{color}"/>'
+            f'<text x="{tx:.1f}" y="{y + bar_h - 2}" text-anchor="{anchor}" font-family="{_MONO}" '
+            f'font-size="10" fill="{_VAL}">{d:+.2f}</text>'
+        )
+    p.append('</svg>')
+    return ''.join(p)
+
+
+def _outcomes_chart(
+    entries_a: list[SimulationEntry], entries_b: list[SimulationEntry], name_a: str, name_b: str
+) -> str:
+    """A-vs-B bars for the two headline 0..1 metrics."""
+    rate_a, score_a, _ = _agg(entries_a)
+    rate_b, score_b, _ = _agg(entries_b)
+    svg = _svg_grouped_bars(
+        ['Goal-achieved rate', 'Mean goal score'],
+        [(name_a, _SERIES_A, [rate_a, score_a]), (name_b, _SERIES_B, [rate_b, score_b])],
+        value_kind='rate',
+    )
+    return _panel('Outcomes', 'Goal rate and mean score · A vs B', svg)
+
+
+def _scorer_chart(run_a: SimulationRun, run_b: SimulationRun, name_a: str, name_b: str) -> str:
+    """A-vs-B bars over the union of both runs' scorer averages."""
+    sa_a = run_a.scorer_averages or {}
+    sa_b = run_b.scorer_averages or {}
+    keys = sorted(set(sa_a) | set(sa_b))
+    if not keys:
+        return ''
+    svg = _svg_grouped_bars(
+        keys,
+        [(name_a, _SERIES_A, [sa_a.get(k, 0.0) for k in keys]), (name_b, _SERIES_B, [sa_b.get(k, 0.0) for k in keys])],
+        value_kind='rate',
+    )
+    return _panel('Scorer averages', 'Per-scorer mean · A vs B', svg)
+
+
+def _terminated_chart(
+    entries_a: list[SimulationEntry], entries_b: list[SimulationEntry], name_a: str, name_b: str
+) -> str:
+    """A-vs-B bars for how conversations ended."""
+    tb_a = Counter(e.terminated_by for e in entries_a)
+    tb_b = Counter(e.terminated_by for e in entries_b)
+    labels = sorted(set(tb_a) | set(tb_b))
+    if not labels:
+        return ''
+    svg = _svg_grouped_bars(
+        labels,
+        [(name_a, _SERIES_A, [float(tb_a[x]) for x in labels]), (name_b, _SERIES_B, [float(tb_b[x]) for x in labels])],
+        value_kind='count',
+    )
+    return _panel('How conversations ended', 'Terminated-by counts · A vs B', svg)
+
+
+def _delta_chart(matching: Matching) -> str:
+    """Per-conversation goal-score change (B - A) over matched pairs, sorted."""
+    if not matching.matched:
+        return ''
+    rows = sorted(
+        (
+            (f'{pair.a.persona}/{pair.a.scenario}', pair.b.goal_completion_score - pair.a.goal_completion_score)
+            for pair in matching.matched
+        ),
+        key=operator.itemgetter(1),
+    )
+    return _panel(
+        'Per-conversation score change',
+        'B minus A on matched conversations · green improved, rust regressed',
+        _svg_diverging(rows),
+    )
+
+
+def _all_metrics_table(rows: list[KpiRow], name_a: str, name_b: str) -> str:
+    """Exhaustive metric table: every KPI row with A, B, and the delta."""
+    body = ''.join(
+        f'<tr><td>{esc(r.label)}</td>'
+        f'<td>{_fmt(r.a, r.kind)}</td>'
+        f'<td>{_fmt(r.b, r.kind)}</td>'
+        f'<td>{_fmt_delta(r)}</td></tr>'
+        for r in rows
+    )
+    table = (
+        '<table class="cmp-table"><thead><tr>'
+        f'<th>Metric</th><th>{esc(name_a)}</th><th>{esc(name_b)}</th><th>&Delta; (B - A)</th>'
+        f'</tr></thead><tbody>{body}</tbody></table>'
+    )
+    return _panel('All metrics', 'Full A / B / delta breakdown', table)
+
+
+def _diff_table(rid_a: str, rid_b: str, matching: Matching) -> str:
+    safe_a, safe_b = esc(rid_a), esc(rid_b)
+    rows: list[str] = []
+    for pair in matching.matched:
+        a, b = pair.a, pair.b
+        ga = 'yes' if a.goal_achieved else 'no'
+        gb = 'yes' if b.goal_achieved else 'no'
+        flip = a.goal_achieved != b.goal_achieved
+        flip_html = '<span class="cmp-flip">flip</span>' if flip else ''
+        d_score = b.goal_completion_score - a.goal_completion_score
+        d_turns = b.turn_count - a.turn_count
+        rows.append(
+            f'<tr class="cmp-diff-row" style="cursor:pointer"'
+            f' hx-get="/compare/sim/transcript?a={safe_a}&b={safe_b}&ia={a.index}&ib={b.index}"'
+            f' hx-target="#cmp-transcript-panel" hx-swap="innerHTML">'
+            f'<td>{esc(a.persona)}</td><td>{esc(a.scenario)}</td>'
+            f'<td>{ga} &rarr; {gb} {flip_html}</td>'
+            f'<td>{a.goal_completion_score:.2f} &rarr; {b.goal_completion_score:.2f} ({d_score:+.2f})</td>'
+            f'<td>{a.turn_count} &rarr; {b.turn_count} ({d_turns:+d})</td>'
+            f'</tr>'
+        )
+    matched_html = (
+        '<table class="cmp-table"><thead><tr>'
+        '<th>Persona</th><th>Scenario</th><th>Goal (A&rarr;B)</th>'
+        '<th>Score (A&rarr;B)</th><th>Turns (A&rarr;B)</th>'
+        f'</tr></thead><tbody>{"".join(rows)}</tbody></table>'
+        if rows
+        else '<p class="sim-empty">No conversations matched on (persona, scenario).</p>'
+    )
+
+    def _unmatched(title: str, entries: list[SimulationEntry]) -> str:
+        if not entries:
+            return ''
+        items = ''.join(f'<li>{esc(e.persona)} &middot; {esc(e.scenario)}</li>' for e in entries)
+        return f'<div class="cmp-unmatched"><strong>{esc(title)}</strong><ul>{items}</ul></div>'
+
+    unmatched = _unmatched('Only in A', matching.a_only) + _unmatched('Only in B', matching.b_only)
+
+    transcript_slot = (
+        '<div id="cmp-transcript-panel" class="cmp-transcript-panel">'
+        '<p class="sim-select-prompt">Select a matched conversation above to compare transcripts.</p></div>'
+    )
+    return _panel(
+        'Outcome diffs',
+        'Matched by persona and scenario · click a row to compare transcripts',
+        matched_html + unmatched + transcript_slot,
+    )
+
+
+def render_compare_transcript(entry_a: SimulationEntry, entry_b: SimulationEntry, name_a: str, name_b: str) -> str:
+    """Two single-run transcript fragments laid out side by side."""
+    return (
+        '<div class="cmp-transcript-grid">'
+        f'<div class="cmp-side"><h3 class="cmp-side-title">{esc(name_a)}</h3>{render_transcript_fragment(entry_a)}</div>'
+        f'<div class="cmp-side"><h3 class="cmp-side-title">{esc(name_b)}</h3>{render_transcript_fragment(entry_b)}</div>'
+        '</div>'
+    )
+
+
+def _hero(run_a: SimulationRun, run_b: SimulationRun) -> str:
+    """Editorial header: mono kicker, display headline, run names + dates."""
+    date_a = run_a.created_at.strftime('%Y-%m-%d %H:%M')
+    date_b = run_b.created_at.strftime('%Y-%m-%d %H:%M')
+    return (
+        '<div class="report-head"><a class="report-back" href="/?surface=sim">&larr; Agent sim runs</a></div>'
+        '<section class="cmp-hero">'
+        '<div class="cmp-kicker">Agent sim // run comparison</div>'
+        f'<h1 class="cmp-title">{esc(run_a.run_name)} <span class="cmp-vs">vs</span> {esc(run_b.run_name)}</h1>'
+        f'<p class="cmp-sub">A: {esc(run_a.run_name)} · {date_a} &nbsp;&nbsp; B: {esc(run_b.run_name)} · {date_b}</p>'
+        '</section>'
+    )
+
+
+def render_compare_page(rid_a: str, rid_b: str, run_a: SimulationRun, run_b: SimulationRun) -> str:
+    """Full compare-page body: hero, KPI deltas + charts, all-metrics, diffs."""
+    entries_a = _entries(run_a)
+    entries_b = _entries(run_b)
+    kpis = compare_kpis(entries_a, entries_b, run_a, run_b)
+    matching = match_entries(entries_a, entries_b)
+    name_a, name_b = run_a.run_name, run_b.run_name
+
+    kpi_section = _panel('KPI deltas', 'Headline metrics, B relative to A', _kpi_band(entries_a, entries_b))
+    charts = (
+        '<div class="cmp-charts">'
+        f'{_outcomes_chart(entries_a, entries_b, name_a, name_b)}'
+        f'{_scorer_chart(run_a, run_b, name_a, name_b)}'
+        f'{_terminated_chart(entries_a, entries_b, name_a, name_b)}'
+        '</div>'
+    )
+    return (
+        f'{_COMPARE_CSS}{_hero(run_a, run_b)}'
+        f'{kpi_section}{charts}'
+        f'{_delta_chart(matching)}'
+        f'{_all_metrics_table(kpis, name_a, name_b)}'
+        f'{_diff_table(rid_a, rid_b, matching)}'
+    )
+
+
+_COMPARE_CSS = (
+    '<style>'
+    '.cmp-hero { margin: 4px 0 18px; }'
+    '.cmp-kicker { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;'
+    ' text-transform: uppercase; color: var(--text-faint); }'
+    '.cmp-title { font-family: var(--font-display); font-size: 26px; font-weight: 700;'
+    ' color: var(--text-strong); margin: 6px 0 4px; }'
+    '.cmp-title .cmp-vs { color: var(--orange-500); }'
+    '.cmp-sub { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }'
+    '.cmp-charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; }'
+    '.cmp-charts .panel { margin: 0; }'
+    '.cmp-table { width: 100%; border-collapse: collapse; font-size: 13px; }'
+    '.cmp-table th { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase;'
+    ' letter-spacing: .06em; color: var(--text-faint); text-align: left; padding: 6px 10px;'
+    ' border-bottom: 1px solid var(--border-subtle); }'
+    '.cmp-table td { padding: 7px 10px; border-bottom: 1px solid var(--border-subtle); color: var(--text-body); }'
+    '.cmp-diff-row:hover { background: var(--app-gray-100); }'
+    '.cmp-delta { font-variant-numeric: tabular-nums; font-family: var(--font-mono); }'
+    '.cmp-up { color: #0f9d6b; } .cmp-down { color: #df5325; } .cmp-flat { color: var(--text-faint); }'
+    '.cmp-flip { color: #df5325; font-weight: 600; font-size: 11px; margin-left: 6px; font-family: var(--font-mono); }'
+    '.cmp-unmatched { margin-top: 12px; font-size: 12px; color: var(--text-muted); }'
+    '.cmp-unmatched ul { margin: 4px 0 0; padding-left: 18px; }'
+    '.cmp-transcript-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 12px; }'
+    '.cmp-side-title { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase;'
+    ' letter-spacing: .06em; color: var(--text-muted); margin: 0 0 8px; }'
+    '</style>'
+)
+
+
+# ---------------------------------------------------------------------------
+# Route factory
+# ---------------------------------------------------------------------------
+
+
+def register_sim_compare_routes(app: Any, roots: list[Path] | None = None) -> None:
+    """Register the two compare routes on *app* (called from ``build_app``)."""
+
+    @app.get('/compare/sim')
+    def compare_sim(req: Request) -> Response:
+        rid_a = req.query_params.get('a') or ''
+        rid_b = req.query_params.get('b') or ''
+        if not rid_a or not rid_b:
+            body = '<section class="cmp-header"><h1>Run comparison</h1><p class="sim-empty">Pick two runs to compare.</p></section>'
+            return Response(page('Compare', body, active_surface='sim'), status_code=400, media_type='text/html')
+
+        run_a = _load_run(rid_a, roots)
+        run_b = _load_run(rid_b, roots)
+        if run_a is None or run_b is None:
+            missing = 'A' if run_a is None else 'B'
+            body = f'<section class="cmp-header"><h1>Run comparison</h1><p class="sim-empty">Run {missing} not found or not a simulation run.</p></section>'
+            return Response(page('Compare', body, active_surface='sim'), status_code=404, media_type='text/html')
+
+        body = render_compare_page(rid_a, rid_b, run_a, run_b)
+        return Response(page('Compare', body, active_surface='sim'), media_type='text/html')
+
+    @app.get('/compare/sim/transcript')
+    def compare_sim_transcript(req: Request) -> Response:
+        rid_a = req.query_params.get('a') or ''
+        rid_b = req.query_params.get('b') or ''
+        try:
+            ia = int(req.query_params.get('ia', ''))
+            ib = int(req.query_params.get('ib', ''))
+        except (TypeError, ValueError):
+            return Response('<p class="sim-empty">Invalid conversation index.</p>', media_type='text/html')
+
+        run_a = _load_run(rid_a, roots)
+        run_b = _load_run(rid_b, roots)
+        if run_a is None or run_b is None:
+            return Response('<p class="sim-empty">Run not found.</p>', status_code=404, media_type='text/html')
+
+        entries_a = _entries(run_a)
+        entries_b = _entries(run_b)
+        ea = next((e for e in entries_a if e.index == ia), None)
+        eb = next((e for e in entries_b if e.index == ib), None)
+        if ea is None or eb is None:
+            return Response('<p class="sim-empty">No conversation at that index.</p>', media_type='text/html')
+
+        return Response(render_compare_transcript(ea, eb, run_a.run_name, run_b.run_name), media_type='text/html')

--- a/src/evaluatorq/dashboard/sim_compare.py
+++ b/src/evaluatorq/dashboard/sim_compare.py
@@ -491,17 +491,26 @@ def _resolve_run(rid: str, roots: list[Path] | None) -> tuple[str, Any | None]:
     """Load a sim run by report id.
 
     Returns ``('ok', run)``, ``('missing', None)`` when the id resolves to no
-    file or a non-sim report, or ``('error', None)`` when a matching sim file
-    fails to load/parse — the last is logged with a stack so a corrupt report is
-    debuggable rather than silently reported as "not found".
+    file or a valid-but-non-sim report, or ``('error', None)`` when a matching
+    sim file fails to load/parse — including a *syntactically* corrupt file, so it
+    is reported as corrupt (422) rather than "not found" (404). The error case is
+    logged with a stack so a corrupt report is debuggable.
     """
+    import json
+
     from evaluatorq.dashboard import library
     from evaluatorq.dashboard.surfaces import ADAPTERS
 
     path = library.resolve(rid, roots)
     if path is None:
         return 'missing', None
-    surface, _raw = library.load_surface(path)
+    # Strict read: a corrupt/unreadable file must surface as an error, not be masked
+    # as an unknown surface (which load_surface does for lenient directory scans).
+    try:
+        surface, _raw = library.load_surface_strict(path)
+    except (json.JSONDecodeError, OSError):
+        logger.opt(exception=True).warning('compare: corrupt/unreadable sim report {}', rid)
+        return 'error', None
     if surface != 'sim':
         return 'missing', None
     adapter = ADAPTERS.get('sim')

--- a/src/evaluatorq/dashboard/styles.py
+++ b/src/evaluatorq/dashboard/styles.py
@@ -2280,18 +2280,24 @@ _RT_REPORT_CSS = """
 .rt-report .severity-low      { color: var(--sev-low); }
 """
 
-# Side-by-side sim run comparison page (RES-1085). Kept with the other dashboard
-# CSS blocks rather than inlined per-request in sim_compare.py.
+# Side-by-side sim run comparison page. The hero reuses the shared .report-hero
+# classes; this block only carries compare-specific rules, on the editorial
+# theme tokens. Kept with the other dashboard CSS blocks rather than inlined
+# per-request in sim_compare.py.
 _SIM_COMPARE_CSS = """
-.cmp-hero { margin: 4px 0 18px; }
-.cmp-kicker { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;
-  text-transform: uppercase; color: var(--text-faint); }
-.cmp-title { font-family: var(--font-display); font-size: 26px; font-weight: 700;
-  color: var(--text-strong); margin: 6px 0 4px; }
-.cmp-title .cmp-vs { color: var(--orq-orange); }
-.cmp-sub { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }
+/* Compare picker bar on the sim run overview */
+.cmp-bar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 2px 0 14px; }
+.cmp-bar-label { font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .08em; color: var(--text-faint); }
+.cmp-bar select { height: 32px; padding: 0 8px; max-width: 320px;
+  border: 1px solid var(--border-default); border-radius: var(--radius-md);
+  background: var(--surface-card); color: var(--text-body);
+  font-family: var(--font-sans); font-size: 13px; }
+.cmp-bar-vs { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
+
+.report-hero-title .cmp-vs { color: var(--orange-500); }
 .cmp-note { font-size: 12px; color: var(--text-muted); margin: 0 0 12px; }
-.cmp-warn { color: var(--orange-700, #b3540f); font-weight: 600; }
+.cmp-warn { color: var(--orange-700); font-weight: 600; }
 .cmp-body { display: flex; flex-direction: column; gap: 24px; }
 .cmp-charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(480px, 1fr)); gap: 24px; }
 .cmp-charts .panel { margin: 0; }
@@ -2303,19 +2309,19 @@ _SIM_COMPARE_CSS = """
    their panel instead of sitting capped-and-centered with whitespace either side. */
 .cmp-body > .panel svg.marks { width: 100%; }
 .cmp-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.cmp-table th { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase;
-  letter-spacing: .06em; color: var(--text-faint); text-align: left; padding: 6px 10px;
-  border-bottom: 1px solid var(--c-border); }
-.cmp-table td { padding: 7px 10px; border-bottom: 1px solid var(--c-border); color: var(--text-body); }
-.cmp-diff-row:hover { background: var(--c-sand); }
+.cmp-table th { font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .08em; color: var(--text-faint);
+  text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border-subtle); }
+.cmp-table td { padding: 7px 10px; border-bottom: 1px solid var(--border-subtle); color: var(--text-body); }
+.cmp-diff-row:hover { background: var(--app-gray-50); }
 .cmp-delta { font-variant-numeric: tabular-nums; font-family: var(--font-mono); }
-.cmp-up { color: #2ebd85; } .cmp-down { color: #d92d20; } .cmp-flat { color: var(--text-faint); }
-.cmp-flip { color: #d92d20; font-weight: 600; font-size: 11px; margin-left: 6px; font-family: var(--font-mono); }
+.cmp-up { color: var(--green-600); } .cmp-down { color: var(--red-700); } .cmp-flat { color: var(--text-faint); }
+.cmp-flip { color: var(--red-700); font-weight: 600; font-size: 11px; margin-left: 6px; font-family: var(--font-mono); }
 .cmp-unmatched { margin-top: 12px; font-size: 12px; color: var(--text-muted); }
 .cmp-unmatched ul { margin: 4px 0 0; padding-left: 18px; }
 .cmp-transcript-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 12px; }
-.cmp-side-title { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase;
-  letter-spacing: .06em; color: var(--text-muted); margin: 0 0 8px; }
+.cmp-side-title { font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); margin: 0 0 8px; }
 """
 
 

--- a/src/evaluatorq/dashboard/styles.py
+++ b/src/evaluatorq/dashboard/styles.py
@@ -2285,7 +2285,11 @@ _RT_REPORT_CSS = """
 # theme tokens. Kept with the other dashboard CSS blocks rather than inlined
 # per-request in sim_compare.py.
 _SIM_COMPARE_CSS = """
-/* Compare picker bar on the sim run overview */
+/* Hero action row: trace-link button + the on-report compare control */
+.report-hero-actions { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-top: 10px; }
+.report-hero-actions .cmp-bar { margin: 0; }
+
+/* Compare picker bar on the sim run overview and in the report hero */
 .cmp-bar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 2px 0 14px; }
 .cmp-bar-label { font-family: var(--font-mono); font-size: 11px; font-weight: 600;
   text-transform: uppercase; letter-spacing: .08em; color: var(--text-faint); }

--- a/src/evaluatorq/dashboard/styles.py
+++ b/src/evaluatorq/dashboard/styles.py
@@ -2280,6 +2280,37 @@ _RT_REPORT_CSS = """
 .rt-report .severity-low      { color: var(--sev-low); }
 """
 
+# Side-by-side sim run comparison page (RES-1085). Kept with the other dashboard
+# CSS blocks rather than inlined per-request in sim_compare.py.
+_SIM_COMPARE_CSS = """
+.cmp-hero { margin: 4px 0 18px; }
+.cmp-kicker { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--text-faint); }
+.cmp-title { font-family: var(--font-display); font-size: 26px; font-weight: 700;
+  color: var(--text-strong); margin: 6px 0 4px; }
+.cmp-title .cmp-vs { color: var(--orq-orange); }
+.cmp-sub { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }
+.cmp-note { font-size: 12px; color: var(--text-muted); margin: 0 0 12px; }
+.cmp-warn { color: var(--orange-700, #b3540f); font-weight: 600; }
+.cmp-charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; }
+.cmp-charts .panel { margin: 0; }
+.cmp-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.cmp-table th { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--text-faint); text-align: left; padding: 6px 10px;
+  border-bottom: 1px solid var(--c-border); }
+.cmp-table td { padding: 7px 10px; border-bottom: 1px solid var(--c-border); color: var(--text-body); }
+.cmp-diff-row:hover { background: var(--c-sand); }
+.cmp-delta { font-variant-numeric: tabular-nums; font-family: var(--font-mono); }
+.cmp-up { color: #2ebd85; } .cmp-down { color: #d92d20; } .cmp-flat { color: var(--text-faint); }
+.cmp-flip { color: #d92d20; font-weight: 600; font-size: 11px; margin-left: 6px; font-family: var(--font-mono); }
+.cmp-unmatched { margin-top: 12px; font-size: 12px; color: var(--text-muted); }
+.cmp-unmatched ul { margin: 4px 0 0; padding-left: 18px; }
+.cmp-transcript-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 12px; }
+.cmp-side-title { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--text-muted); margin: 0 0 8px; }
+"""
+
+
 DASHBOARD_CSS = (
     _DASHBOARD_CSS_HEAD
     + _TAB_RULES
@@ -2290,4 +2321,5 @@ DASHBOARD_CSS = (
     + _SIM_REPORT_OVERRIDES_CSS
     + _SIM_TRANSCRIPT_OVERRIDES_CSS
     + _RT_REPORT_CSS
+    + _SIM_COMPARE_CSS
 )

--- a/src/evaluatorq/dashboard/styles.py
+++ b/src/evaluatorq/dashboard/styles.py
@@ -2289,14 +2289,19 @@ _SIM_COMPARE_CSS = """
 .report-hero-actions { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-top: 10px; }
 .report-hero-actions .cmp-bar { margin: 0; }
 
-/* Compare picker bar on the sim run overview and in the report hero */
+/* Compare picker bar on the sim run overview and in the report hero. Controls
+   mirror the filter-rail trigger look (12.5px sans, card surface, default
+   hairline, md radius) so the bar reads as part of the same control family. */
 .cmp-bar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 2px 0 14px; }
 .cmp-bar-label { font-family: var(--font-mono); font-size: 11px; font-weight: 600;
   text-transform: uppercase; letter-spacing: .08em; color: var(--text-faint); }
-.cmp-bar select { height: 32px; padding: 0 8px; max-width: 320px;
+.cmp-bar select { height: 32px; padding: 0 9px; max-width: 320px;
   border: 1px solid var(--border-default); border-radius: var(--radius-md);
   background: var(--surface-card); color: var(--text-body);
-  font-family: var(--font-sans); font-size: 13px; }
+  font-family: var(--font-sans); font-size: 12.5px; font-weight: 500; cursor: pointer; }
+.cmp-bar select:hover { background: var(--app-gray-50); }
+.cmp-bar select:focus-visible { outline: none; box-shadow: var(--ring); }
+.cmp-bar .btn-secondary { font-size: 12.5px; }
 .cmp-bar-vs { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
 
 .report-hero-title .cmp-vs { color: var(--orange-500); }

--- a/src/evaluatorq/dashboard/styles.py
+++ b/src/evaluatorq/dashboard/styles.py
@@ -2292,8 +2292,16 @@ _SIM_COMPARE_CSS = """
 .cmp-sub { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }
 .cmp-note { font-size: 12px; color: var(--text-muted); margin: 0 0 12px; }
 .cmp-warn { color: var(--orange-700, #b3540f); font-weight: 600; }
-.cmp-charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; }
+.cmp-body { display: flex; flex-direction: column; gap: 24px; }
+.cmp-charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(480px, 1fr)); gap: 24px; }
 .cmp-charts .panel { margin: 0; }
+/* Vega SVGs carry a viewBox, so max-width:100% + height:auto scales them DOWN to
+   fit their column and keeps aspect ratio — never upscaling past native size
+   (which made full-width charts oversized). Centered for the odd/full-width one. */
+.cmp-body svg.marks { max-width: 100%; height: auto; display: block; margin: 0 auto; }
+/* The full-width charts (direct children of cmp-body, not in the 2-up grid) fill
+   their panel instead of sitting capped-and-centered with whitespace either side. */
+.cmp-body > .panel svg.marks { width: 100%; }
 .cmp-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .cmp-table th { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase;
   letter-spacing: .06em; color: var(--text-faint); text-align: left; padding: 6px 10px;

--- a/src/evaluatorq/dashboard/view.py
+++ b/src/evaluatorq/dashboard/view.py
@@ -448,6 +448,23 @@ def _sim_compare_bar(choices: list[tuple[str, str]]) -> str:
     )
 
 
+def sim_run_compare_control(rid: str, choices: list[tuple[str, str]]) -> str:
+    """Render the on-report compare control: this run is A, pick B from the
+    other sim runs. Empty when there is no other run to compare against."""
+    others = [(r, name) for r, name in choices if r != rid]
+    if not others:
+        return ''
+    opts = ''.join(f'<option value="{esc(r)}">{esc(name)}</option>' for r, name in others)
+    return (
+        '<form class="cmp-bar" action="/compare/sim" method="get">'
+        f'<input type="hidden" name="a" value="{esc(rid)}">'
+        '<span class="cmp-bar-label">Compare with</span>'
+        f'<select name="b" aria-label="Run B">{opts}</select>'
+        '<button type="submit" class="btn-secondary">Compare</button>'
+        '</form>'
+    )
+
+
 def sim_overview_body(data: SimOverview, compare_choices: list[tuple[str, str]] | None = None) -> str:
     """Render the Agent Sim surface as the design's rich overview: 4 KPI cards
     plus an item-level 'Recent simulations' table (RES-1022).

--- a/src/evaluatorq/dashboard/view.py
+++ b/src/evaluatorq/dashboard/view.py
@@ -428,14 +428,22 @@ def _sim_compare_bar(choices: list[tuple[str, str]]) -> str:
     """
     if len(choices) < 2:
         return ''
-    opts = ''.join(f'<option value="{esc(rid)}">{esc(name)}</option>' for rid, name in choices)
+
+    def _opts(selected_idx: int) -> str:
+        # Default each select to a different run so the first Compare click is a
+        # real A-vs-B comparison, not run-vs-itself (all-zero deltas).
+        return ''.join(
+            f'<option value="{esc(rid)}"{" selected" if i == selected_idx else ""}>{esc(name)}</option>'
+            for i, (rid, name) in enumerate(choices)
+        )
+
     return (
         '<form class="cmp-bar" action="/compare/sim" method="get"'
         ' style="display:flex;gap:8px;align-items:center;margin:12px 0;flex-wrap:wrap">'
         '<span class="cmp-bar-label" style="font-weight:600">Compare runs</span>'
-        f'<select name="a" aria-label="Run A">{opts}</select>'
+        f'<select name="a" aria-label="Run A">{_opts(0)}</select>'
         '<span class="cmp-bar-vs">vs</span>'
-        f'<select name="b" aria-label="Run B">{opts}</select>'
+        f'<select name="b" aria-label="Run B">{_opts(1)}</select>'
         '<button type="submit" class="btn-secondary">Compare</button>'
         '</form>'
     )

--- a/src/evaluatorq/dashboard/view.py
+++ b/src/evaluatorq/dashboard/view.py
@@ -420,9 +420,34 @@ def _fmt_compact(n: int) -> str:
     return str(n)
 
 
-def sim_overview_body(data: SimOverview) -> str:
+def _sim_compare_bar(choices: list[tuple[str, str]]) -> str:
+    """Render the two-run compare picker (Run A / Run B → /compare/sim).
+
+    Plain GET form, no JS. Needs at least two sim runs to be useful; with fewer
+    it renders nothing so the overview stays clean.
+    """
+    if len(choices) < 2:
+        return ''
+    opts = ''.join(f'<option value="{esc(rid)}">{esc(name)}</option>' for rid, name in choices)
+    return (
+        '<form class="cmp-bar" action="/compare/sim" method="get"'
+        ' style="display:flex;gap:8px;align-items:center;margin:12px 0;flex-wrap:wrap">'
+        '<span class="cmp-bar-label" style="font-weight:600">Compare runs</span>'
+        f'<select name="a" aria-label="Run A">{opts}</select>'
+        '<span class="cmp-bar-vs">vs</span>'
+        f'<select name="b" aria-label="Run B">{opts}</select>'
+        '<button type="submit" class="btn-secondary">Compare</button>'
+        '</form>'
+    )
+
+
+def sim_overview_body(data: SimOverview, compare_choices: list[tuple[str, str]] | None = None) -> str:
     """Render the Agent Sim surface as the design's rich overview: 4 KPI cards
-    plus an item-level 'Recent simulations' table (RES-1022)."""
+    plus an item-level 'Recent simulations' table (RES-1022).
+
+    ``compare_choices`` is the (rid, name) list of all sim runs used to populate
+    the side-by-side compare picker (RES-1085); ``None`` hides the picker.
+    """
     from evaluatorq.common.reports.html_helpers import kpi_cards, pct
 
     if data.simulations_run == 0:
@@ -454,7 +479,8 @@ def sim_overview_body(data: SimOverview) -> str:
         'Latest agent simulation runs',
         _run_grid(data.recent) + _run_pager('sim', data.page, data.total_runs, data.per_page),
     )
-    return f'<section class="dash-wrap">{band}{panel}</section>'
+    compare_bar = _sim_compare_bar(compare_choices or [])
+    return f'<section class="dash-wrap">{band}{compare_bar}{panel}</section>'
 
 
 def search_results(cards: list[ReportCard], query: str) -> str:

--- a/src/evaluatorq/dashboard/view.py
+++ b/src/evaluatorq/dashboard/view.py
@@ -438,9 +438,8 @@ def _sim_compare_bar(choices: list[tuple[str, str]]) -> str:
         )
 
     return (
-        '<form class="cmp-bar" action="/compare/sim" method="get"'
-        ' style="display:flex;gap:8px;align-items:center;margin:12px 0;flex-wrap:wrap">'
-        '<span class="cmp-bar-label" style="font-weight:600">Compare runs</span>'
+        '<form class="cmp-bar" action="/compare/sim" method="get">'
+        '<span class="cmp-bar-label">Compare runs</span>'
         f'<select name="a" aria-label="Run A">{_opts(0)}</select>'
         '<span class="cmp-bar-vs">vs</span>'
         f'<select name="b" aria-label="Run B">{_opts(1)}</select>'
@@ -454,7 +453,7 @@ def sim_overview_body(data: SimOverview, compare_choices: list[tuple[str, str]] 
     plus an item-level 'Recent simulations' table (RES-1022).
 
     ``compare_choices`` is the (rid, name) list of all sim runs used to populate
-    the side-by-side compare picker (RES-1085); ``None`` hides the picker.
+    the side-by-side compare picker; ``None`` hides the picker.
     """
     from evaluatorq.common.reports.html_helpers import kpi_cards, pct
 

--- a/tests/common/reports/test_vega.py
+++ b/tests/common/reports/test_vega.py
@@ -213,8 +213,21 @@ def test_grouped_bar_renders_multi_series():
         series=[('agent-a', [0.2, 0.5]), ('agent-b', [0.4, 0.1])],
         x_title='ASR',
     )
-    assert spec['encoding'].get('yOffset', {}).get('field') == 'series'
+    bar_layer = spec['layer'][0]
+    assert bar_layer['encoding'].get('yOffset', {}).get('field') == 'series'
     assert '<svg' in render_svg(spec)
+
+
+def test_grouped_bar_labels_zero_values():
+    """Zero-width bars are invisible; a literal 0 label must mark them so
+    'scored zero' stays distinguishable from 'not measured'."""
+    spec = vl_grouped_bar(
+        categories=['c1', 'c2'],
+        series=[('agent-a', [0.0, 0.5]), ('agent-b', [0.0, 0.1])],
+        x_title='ASR',
+    )
+    svg = render_svg(spec)
+    assert svg.count('>0<') == 2
 
 
 def test_grouped_bar_empty():

--- a/tests/dashboard/test_sim_compare.py
+++ b/tests/dashboard/test_sim_compare.py
@@ -273,3 +273,14 @@ def test_compare_bar_on_sim_overview(roots: list[Path]):
     html = resp.text
     assert 'action="/compare/sim"' in html
     assert 'name="a"' in html and 'name="b"' in html
+
+
+def test_compare_control_on_sim_report(roots: list[Path]):
+    """The run report hero carries a compare control: this run pinned as A
+    (hidden input), the other run selectable as B — never itself."""
+    client = TestClient(build_app(roots))
+    rid_a, rid_b = _rids(roots)
+    html = client.get(f'/r/{rid_a}').text
+    assert f'name="a" value="{rid_a}"' in html
+    assert f'<option value="{rid_b}"' in html
+    assert f'<option value="{rid_a}"' not in html

--- a/tests/dashboard/test_sim_compare.py
+++ b/tests/dashboard/test_sim_compare.py
@@ -1,0 +1,209 @@
+"""Side-by-side comparison of two sim runs (RES-1085).
+
+Covers the KPI delta math, (persona, scenario) matching incl. unmatched
+handling, the compare page + transcript routes, the graceful-error paths, and
+the compare picker on the sim overview.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from evaluatorq.dashboard.app import build_app
+from evaluatorq.dashboard.library import report_id
+
+# ---------------------------------------------------------------------------
+# Fixture builders (real SimulationRun objects — the compare path model_validates)
+# ---------------------------------------------------------------------------
+
+
+def _result(
+    persona: str,
+    scenario: str,
+    *,
+    goal: bool,
+    score: float,
+    turns: int,
+    terminated: str = 'judge',
+    msgs: list[tuple[str, str]] | None = None,
+):
+    from evaluatorq.contracts import Message, TokenUsage
+    from evaluatorq.simulation.types import SimulationResult, TerminatedBy
+
+    return SimulationResult(
+        messages=[Message(role=r, content=c) for r, c in (msgs or [])],
+        terminated_by=TerminatedBy(terminated),
+        reason='done',
+        goal_achieved=goal,
+        goal_completion_score=score,
+        rules_broken=[],
+        turn_count=turns,
+        turn_metrics=[],
+        token_usage=TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
+        metadata={'persona': persona, 'scenario': scenario},
+    )
+
+
+def _run(name: str, results: list, averages: dict[str, float]):
+    from evaluatorq.simulation.types import SimulationRun
+
+    return SimulationRun(
+        run_name=name,
+        created_at=datetime.now(tz=timezone.utc),
+        mode='run',
+        target_kind='orq_agent',
+        evaluator_names=['goal_achieved'],
+        total_results=len(results),
+        scorer_averages=averages,
+        results=results,
+    )
+
+
+def _run_a():
+    return _run(
+        'run-A',
+        [
+            _result(
+                'alice', 'billing', goal=True, score=0.9, turns=4, msgs=[('user', 'hi A'), ('assistant', 'hello A')]
+            ),
+            _result('bob', 'refund', goal=False, score=0.2, turns=6),
+            _result('carol', 'onlyA', goal=True, score=1.0, turns=2),
+        ],
+        {'goal_achieved': 0.66, 'criteria_met': 0.5},
+    )
+
+
+def _run_b():
+    return _run(
+        'run-B',
+        [
+            # alice/billing flips True -> False, score drops
+            _result(
+                'alice', 'billing', goal=False, score=0.4, turns=5, msgs=[('user', 'hi B'), ('assistant', 'hello B')]
+            ),
+            _result('bob', 'refund', goal=True, score=0.8, turns=3, terminated='max_turns'),
+            _result('dave', 'onlyB', goal=True, score=0.7, turns=2),
+        ],
+        {'goal_achieved': 0.66, 'safety': 1.0},
+    )
+
+
+@pytest.fixture
+def roots(tmp_path: Path) -> list[Path]:
+    sim = tmp_path / 'sim-runs'
+    sim.mkdir()
+    (sim / 'a.json').write_text(_run_a().model_dump_json())
+    (sim / 'b.json').write_text(_run_b().model_dump_json())
+    return [tmp_path / 'runs', sim]
+
+
+def _rids(roots: list[Path]) -> tuple[str, str]:
+    sim = roots[1]
+    return report_id(sim / 'a.json'), report_id(sim / 'b.json')
+
+
+# ---------------------------------------------------------------------------
+# Unit: KPI deltas
+# ---------------------------------------------------------------------------
+
+
+def test_compare_kpis_covers_aggregates_scorers_and_terminated():
+    from evaluatorq.dashboard.sim_compare import compare_kpis
+    from evaluatorq.simulation.reports.sections import individual_entries
+
+    a, b = _run_a(), _run_b()
+    rows = compare_kpis(individual_entries(a.results), individual_entries(b.results), a, b)
+    by_label = {r.label: r for r in rows}
+
+    assert by_label['Conversations'].a == 3.0
+    assert by_label['Conversations'].b == 3.0
+    # A: 2/3 achieved; B: 2/3 achieved.
+    assert by_label['Goal-achieved rate'].a == pytest.approx(2 / 3)
+    assert by_label['Goal-achieved rate'].b == pytest.approx(2 / 3)
+    # per-scorer union: goal_achieved (both), criteria_met (A only), safety (B only)
+    assert by_label['Scorer: criteria_met'].a == 0.5
+    assert by_label['Scorer: criteria_met'].b == 0.0
+    assert by_label['Scorer: safety'].b == 1.0
+    # terminated-by distribution present
+    assert by_label['Terminated: judge'].a == 3.0  # A: all judge
+    assert by_label['Terminated: max_turns'].b == 1.0
+    assert by_label['Terminated: max_turns'].delta == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Unit: matching by (persona, scenario)
+# ---------------------------------------------------------------------------
+
+
+def test_match_entries_pairs_and_flags_unmatched():
+    from evaluatorq.dashboard.sim_compare import match_entries
+    from evaluatorq.simulation.reports.sections import individual_entries
+
+    m = match_entries(individual_entries(_run_a().results), individual_entries(_run_b().results))
+    matched_keys = {(p.a.persona, p.a.scenario) for p in m.matched}
+    assert matched_keys == {('alice', 'billing'), ('bob', 'refund')}
+    assert [(e.persona, e.scenario) for e in m.a_only] == [('carol', 'onlyA')]
+    assert [(e.persona, e.scenario) for e in m.b_only] == [('dave', 'onlyB')]
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+def test_compare_page_renders_kpis_diffs_and_flip(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    rid_a, rid_b = _rids(roots)
+    resp = client.get(f'/compare/sim?a={rid_a}&b={rid_b}')
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'KPI deltas' in html
+    assert 'Outcome diffs' in html
+    assert 'run-A' in html and 'run-B' in html
+    # alice/billing flips True->False → a flip marker is present
+    assert 'flip' in html
+    # unmatched conversations surfaced, not dropped
+    assert 'Only in A' in html and 'Only in B' in html
+    assert 'carol' in html and 'dave' in html
+    # inline-SVG charts render server-side (no JS/static dependency)
+    assert '<svg' in html
+    assert 'Outcomes' in html and 'Scorer averages' in html and 'How conversations ended' in html
+    assert 'Per-conversation score change' in html
+
+
+def test_compare_transcript_route_shows_both_sides(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    rid_a, rid_b = _rids(roots)
+    # alice/billing is index 0 in both runs
+    resp = client.get(f'/compare/sim/transcript?a={rid_a}&b={rid_b}&ia=0&ib=0')
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'hello A' in html and 'hello B' in html
+    assert 'cmp-transcript-grid' in html
+
+
+def test_compare_missing_param_is_400(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    rid_a, _ = _rids(roots)
+    resp = client.get(f'/compare/sim?a={rid_a}')
+    assert resp.status_code == 400
+
+
+def test_compare_unknown_rid_is_404(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    rid_a, _ = _rids(roots)
+    resp = client.get(f'/compare/sim?a={rid_a}&b=deadbeef')
+    assert resp.status_code == 404
+
+
+def test_compare_bar_on_sim_overview(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    resp = client.get('/?surface=sim')
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'action="/compare/sim"' in html
+    assert 'name="a"' in html and 'name="b"' in html

--- a/tests/dashboard/test_sim_compare.py
+++ b/tests/dashboard/test_sim_compare.py
@@ -236,6 +236,22 @@ def test_compare_corrupt_report_is_422(tmp_path: Path):
     assert resp.status_code == 422
 
 
+def test_compare_syntactically_corrupt_report_is_422(tmp_path: Path):
+    # A file that isn't even valid JSON must be reported as corrupt (422), not masked
+    # as "not found" (404). Guards the load_surface_strict path in _resolve_run.
+    sim = tmp_path / 'sim-runs'
+    sim.mkdir()
+    (sim / 'good.json').write_text(_run_a().model_dump_json())
+    (sim / 'bad.json').write_text('{not valid json at all')
+    from evaluatorq.dashboard.library import report_id
+
+    client = TestClient(build_app([tmp_path / 'runs', sim]))
+    good = report_id(sim / 'good.json')
+    bad = report_id(sim / 'bad.json')
+    resp = client.get(f'/compare/sim?a={good}&b={bad}')
+    assert resp.status_code == 422
+
+
 def test_compare_transcript_invalid_index_is_400(roots: list[Path]):
     client = TestClient(build_app(roots))
     rid_a, rid_b = _rids(roots)

--- a/tests/dashboard/test_sim_compare.py
+++ b/tests/dashboard/test_sim_compare.py
@@ -124,9 +124,12 @@ def test_compare_kpis_covers_aggregates_scorers_and_terminated():
     # A: 2/3 achieved; B: 2/3 achieved.
     assert by_label['Goal-achieved rate'].a == pytest.approx(2 / 3)
     assert by_label['Goal-achieved rate'].b == pytest.approx(2 / 3)
-    # per-scorer union: goal_achieved (both), criteria_met (A only), safety (B only)
+    # per-scorer union: goal_achieved (both), criteria_met (A only), safety (B only).
+    # A scorer only one run measured stays None (n/a) — never a fabricated 0.0 regression.
     assert by_label['Scorer: criteria_met'].a == 0.5
-    assert by_label['Scorer: criteria_met'].b == 0.0
+    assert by_label['Scorer: criteria_met'].b is None
+    assert by_label['Scorer: criteria_met'].delta is None
+    assert by_label['Scorer: safety'].a is None
     assert by_label['Scorer: safety'].b == 1.0
     # terminated-by distribution present
     assert by_label['Terminated: judge'].a == 3.0  # A: all judge
@@ -198,6 +201,53 @@ def test_compare_unknown_rid_is_404(roots: list[Path]):
     rid_a, _ = _rids(roots)
     resp = client.get(f'/compare/sim?a={rid_a}&b=deadbeef')
     assert resp.status_code == 404
+
+
+def test_compare_self_compare_is_400(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    rid_a, _ = _rids(roots)
+    resp = client.get(f'/compare/sim?a={rid_a}&b={rid_a}')
+    assert resp.status_code == 400
+
+
+def test_compare_absent_scorer_renders_na_not_zero(roots: list[Path]):
+    # criteria_met is measured by run A only; safety by run B only. Neither should
+    # render as a 0.00 with a red downward delta — they show n/a with no arrow.
+    client = TestClient(build_app(roots))
+    rid_a, rid_b = _rids(roots)
+    html = client.get(f'/compare/sim?a={rid_a}&b={rid_b}').text
+    assert 'n/a' in html
+    # the scorer chart only compares scorers both runs measured
+    assert 'shared scorers only' in html
+
+
+def test_compare_corrupt_report_is_422(tmp_path: Path):
+    sim = tmp_path / 'sim-runs'
+    sim.mkdir()
+    (sim / 'good.json').write_text(_run_a().model_dump_json())
+    # a file that sniffs as sim ('mode' present) but fails model validation
+    (sim / 'bad.json').write_text('{"mode": "run", "results": "not-a-list"}')
+    from evaluatorq.dashboard.library import report_id
+
+    client = TestClient(build_app([tmp_path / 'runs', sim]))
+    good = report_id(sim / 'good.json')
+    bad = report_id(sim / 'bad.json')
+    resp = client.get(f'/compare/sim?a={good}&b={bad}')
+    assert resp.status_code == 422
+
+
+def test_compare_transcript_invalid_index_is_400(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    rid_a, rid_b = _rids(roots)
+    resp = client.get(f'/compare/sim/transcript?a={rid_a}&b={rid_b}&ia=x&ib=0')
+    assert resp.status_code == 400
+
+
+def test_compare_bar_defaults_to_two_different_runs(roots: list[Path]):
+    client = TestClient(build_app(roots))
+    html = client.get('/?surface=sim').text
+    # both selects present, each with a different pre-selected option
+    assert html.count(' selected>') >= 2
 
 
 def test_compare_bar_on_sim_overview(roots: list[Path]):

--- a/tests/dashboard/test_sim_compare.py
+++ b/tests/dashboard/test_sim_compare.py
@@ -1,4 +1,4 @@
-"""Side-by-side comparison of two sim runs (RES-1085).
+"""Side-by-side comparison of two sim runs.
 
 Covers the KPI delta math, (persona, scenario) matching incl. unmatched
 handling, the compare page + transcript routes, the graceful-error paths, and


### PR DESCRIPTION
Implements side-by-side comparison of two agent-sim runs (RES-1085). Dashboard sim views were single-run only; this adds a compare surface on top of the same `sim` adapter/library. No changes to the sim runner or data model.

## What
- **Entry point:** a "Compare runs" bar (Run A / Run B dropdowns + button) on the Agent Sim overview → links to `/compare/sim?a=&b=`.
- **New page `GET /compare/sim`:** editorial header, KPI delta cards (goal-achieved rate, mean score, mean turns, conversations), an all-metrics table (aggregates + per-scorer + terminated-by, each with A / B / delta), an outcome-diff table, and a transcript-compare slot.
- **Charts (server-rendered inline SVG):** Outcomes (A vs B), Scorer averages (A vs B), How conversations ended (A vs B), and a Per-conversation score-change diverging chart. SVG on purpose — no JS and no `/static` dependency, so they render in the page, in tests, and in static HTML exports.
- **Outcome diffs:** conversations matched by `(persona, scenario)`; goal flips highlighted, score/turn deltas shown, and unmatched conversations listed as "Only in A / Only in B" so a mismatched dataset is visible rather than silently dropped.
- **Transcript compare:** `GET /compare/sim/transcript` renders both runs' transcripts side by side (reuses the single-run transcript renderer).

## Scope
Additive only. New `dashboard/sim_compare.py` + `tests/dashboard/test_sim_compare.py`; a compare route registered in `app.py`; an optional `compare_choices` arg on `sim_overview_body` (defaults to hidden). Nothing else in the dashboard is touched — no changes to Dashboard, Red Team, or single-run Agent Sim.

## Tests
- 7 new tests in `test_sim_compare.py`: KPI delta math, `(persona, scenario)` matching incl. unmatched handling, the compare page (KPIs + SVG charts + diffs + flips + unmatched), the transcript route, 400/404 error paths, and the compare bar on the overview.
- Full dashboard suite: 312 passed. `ruff check src` clean, `basedpyright` 0 errors.

## Known limitation (pre-existing, not from this PR)
The transcript-compare click uses HTMX. In this preview dashboard, `head_assets()` points assets at `/static/…` but `build_app` serves them at root, so HTMX (and any Vega chart) does not load when served via `serve()`. The charts here avoid this entirely by being inline SVG; the transcript drill-down still needs it. This affects the whole dashboard, not just this page — worth a small follow-up to align the static route with the asset URLs.
