### PR TITLE
feat(redteam)!: unify AttackerResponse onto AgentResponse (RES-883)

### DIFF
--- a/src/evaluatorq/openresponses/dataset.py
+++ b/src/evaluatorq/openresponses/dataset.py
@@ -141,7 +141,7 @@ def turns_to_openresponses_input(
     """Convert redteam turns to an OpenResponses input array."""
     out: list[dict[str, Any]] = []
     for idx, turn in enumerate(turns):
-        out.append(user_input_item(turn.attacker.generated_prompt))
+        out.append(user_input_item(turn.attacker.text))
         if idx == len(turns) - 1 and not include_final_assistant:
             continue
         append_assistant_turn(out, turn.target)

--- a/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -869,12 +869,12 @@ class MultiTurnOrchestrator:
                         # The rationale is kept OUT of the transcript on purpose: it is a
                         # signal, not evidence, and must never reach the scorer/judge.
                         attack_prompt = marker_prompt
-                        # Rebuild attacker record with the stripped prompt as its text,
-                        # preserving usage/finish_reason (RES-883: attacker is an AgentResponse).
-                        current_attacker = AgentResponse(
-                            text=attack_prompt,
-                            usage=current_attacker.usage,
-                            finish_reason=current_attacker.finish_reason,
+                        # Rebuild the attacker record with the stripped prompt as its
+                        # only text item, preserving every other field (usage,
+                        # finish_reason, model, response_id, error) via model_copy
+                        # (RES-883: attacker is an AgentResponse).
+                        current_attacker = current_attacker.model_copy(
+                            update={'output': [TextOutputItem(text=attack_prompt, annotations=[])]}
                         )
                         if not attack_prompt:
                             # Nothing left to send. Distinguish a genuine accepted

--- a/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -36,7 +36,6 @@ from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     PIPELINE_CONFIG,
     AgentContext,
-    AttackerResponse,
     AttackStrategy,
     LLMConfig,
     OrchestratorResult,
@@ -786,12 +785,9 @@ class MultiTurnOrchestrator:
                     # Build the canonical attacker record for this turn (used whether
                     # the target then succeeds or fails).
                     fr = finish_reason if isinstance(finish_reason, str) else None
-                    current_attacker = AttackerResponse(
-                        generated_prompt=attack_prompt,
-                        usage=usage,
-                        truncated=fr == 'length',
-                        finish_reason=fr,
-                    )
+                    # Attacker output is an AgentResponse (RES-883): the prompt is the
+                    # response text; truncation is derivable from finish_reason == 'length'.
+                    current_attacker = AgentResponse(text=attack_prompt, usage=usage, finish_reason=fr)
 
                     # Abort if adversarial LLM returned empty content
                     if not attack_prompt.strip():
@@ -873,8 +869,13 @@ class MultiTurnOrchestrator:
                         # The rationale is kept OUT of the transcript on purpose: it is a
                         # signal, not evidence, and must never reach the scorer/judge.
                         attack_prompt = marker_prompt
-                        # Rebuild attacker record with stripped prompt
-                        current_attacker = current_attacker.model_copy(update={'generated_prompt': attack_prompt})
+                        # Rebuild attacker record with the stripped prompt as its text,
+                        # preserving usage/finish_reason (RES-883: attacker is an AgentResponse).
+                        current_attacker = AgentResponse(
+                            text=attack_prompt,
+                            usage=current_attacker.usage,
+                            finish_reason=current_attacker.finish_reason,
+                        )
                         if not attack_prompt:
                             # Nothing left to send. Distinguish a genuine accepted
                             # success from a rejected turn-0 marker (objective_achieved

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -39,7 +39,6 @@ from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     JURY_RAW_OUTPUT_KEY,
     PIPELINE_CONFIG,
-    AttackerResponse,
     AttackOutput,
     AttackStrategy,
     DeliveryMethod,
@@ -448,7 +447,7 @@ def create_dynamic_redteam_job(
                 result_dict = AttackOutput(
                     turns=[
                         Turn(
-                            attacker=AttackerResponse(generated_prompt=prompt),
+                            attacker=AgentResponse(text=prompt),
                             target=agent_resp
                             if agent_resp.output
                             else AgentResponse(
@@ -667,7 +666,7 @@ def create_dynamic_evaluator(
 
         category = output.category or data.inputs.get('category', '')
         vulnerability = output.vulnerability or data.inputs.get('vulnerability', '')
-        input_messages = [{'role': 'user', 'content': t.attacker.generated_prompt} for t in output.turns]
+        input_messages = [{'role': 'user', 'content': t.attacker.text} for t in output.turns]
         output_messages = [item for t in output.turns for item in t.target.output]
 
         # Prefer vulnerability-first path when a valid Vulnerability enum can be resolved

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -882,13 +882,15 @@ def classify_error_type(error: str | None, *, existing_type: str | None = None) 
 # ---------------------------------------------------------------------------
 
 
-# ``AttackerResponse`` was unified onto :class:`evaluatorq.contracts.AgentResponse`
-# (RES-883): the attacker LLM output now uses the same response shape as targets and
-# simulation agents. ``generated_prompt`` maps to ``AgentResponse.text``, ``truncated``
-# is derivable from ``finish_reason == 'length'``, and the attacker gains the shared
-# per-response ``error`` field for free. Kept as a deprecated alias for import
-# compatibility; construct ``AgentResponse(text=...)`` directly.
-AttackerResponse = AgentResponse  # deprecated alias; use AgentResponse directly
+# RES-883: the attacker LLM output was unified onto
+# :class:`evaluatorq.contracts.AgentResponse` — the same response shape used by
+# targets and simulation agents. ``generated_prompt`` is now ``AgentResponse.text``
+# and ``truncated`` is derivable from ``finish_reason == 'length'``. The former
+# ``AttackerResponse`` type is removed outright (a ``feat!`` breaking change) rather
+# than left as a silent alias: ``AttackerResponse = AgentResponse`` would have made
+# ``AttackerResponse(generated_prompt=...)`` quietly drop the prompt (AgentResponse
+# ignores unknown kwargs) and collapse ``isinstance`` discrimination. Construct
+# ``AgentResponse(text=...)`` directly.
 
 
 class Turn(BaseModel):

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -882,28 +882,43 @@ def classify_error_type(error: str | None, *, existing_type: str | None = None) 
 # ---------------------------------------------------------------------------
 
 
-class AttackerResponse(BaseModel):
-    """Adversarial LLM output for a single attack turn.
+# ``AttackerResponse`` was unified onto :class:`evaluatorq.contracts.AgentResponse`
+# (RES-883): the attacker LLM output now uses the same response shape as targets and
+# simulation agents. ``generated_prompt`` maps to ``AgentResponse.text``, ``truncated``
+# is derivable from ``finish_reason == 'length'``, and the attacker gains the shared
+# per-response ``error`` field for free. Kept as a deprecated alias for import
+# compatibility; construct ``AgentResponse(text=...)`` directly.
+AttackerResponse = AgentResponse  # deprecated alias; use AgentResponse directly
 
-    ``generated_prompt`` is the text the attacker LLM produced this turn, which
-    is then sent to the target as the next user message.
+
+class Turn(BaseModel):
+    """One attacker→target exchange in a multi-turn attack.
+
+    Both sides are :class:`evaluatorq.contracts.AgentResponse` (RES-883). The
+    attacker's prompt is ``attacker.text``; ``attacker.finish_reason == 'length'``
+    means the adversarial LLM was truncated.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    generated_prompt: str = Field(description='Attack prompt produced by the adversarial LLM (sent to the target)')
-    usage: TokenUsage | None = Field(default=None, description='Token usage for this adversarial generation')
-    truncated: bool = Field(default=False, description='Adversarial LLM hit max_tokens on this turn')
-    finish_reason: str | None = Field(default=None, description='Adversarial LLM finish reason')
-
-
-class Turn(BaseModel):
-    """One attacker→target exchange in a multi-turn attack."""
-
-    model_config = ConfigDict(frozen=True)
-
-    attacker: AttackerResponse
+    attacker: AgentResponse
     target: AgentResponse
+
+    @model_validator(mode='before')
+    @classmethod
+    def _migrate_attacker_generated_prompt(cls, data: Any) -> Any:
+        """Load reports written before RES-883, where ``attacker`` carried
+        ``generated_prompt`` (+ a now-derived ``truncated``) instead of the
+        ``AgentResponse`` output shape. Maps ``generated_prompt`` → ``text`` and
+        drops ``truncated`` so the old wire format still validates."""
+        if isinstance(data, dict):
+            atk = data.get('attacker')
+            if isinstance(atk, dict) and 'generated_prompt' in atk and 'output' not in atk and 'text' not in atk:
+                atk = dict(atk)
+                atk['text'] = atk.pop('generated_prompt')
+                atk.pop('truncated', None)
+                data = {**data, 'attacker': atk}
+        return data
 
 
 def turns_to_messages(turns: list[Turn], *, skip_errors: bool = False) -> list[Message]:
@@ -925,7 +940,7 @@ def turns_to_messages(turns: list[Turn], *, skip_errors: bool = False) -> list[M
     for turn in turns:
         if skip_errors and turn.target.error is not None:
             continue
-        out.append(Message(role='user', content=turn.attacker.generated_prompt))
+        out.append(Message(role='user', content=turn.attacker.text))
         text_buffer: list[str] = []
         target = turn.target
 
@@ -1082,7 +1097,7 @@ class OrchestratorResult(BaseModel):
             Message(role='user', content=ADVERSARIAL_INITIAL_USER_PROMPT.format(max_turns=self.max_turns)),
         ]
         for prior in self.turns[:turn_index]:
-            msgs.append(Message(role='assistant', content=prior.attacker.generated_prompt))
+            msgs.append(Message(role='assistant', content=prior.attacker.text))
             wrapped = ADVERSARIAL_ANALYSIS_PROMPT.replace(
                 '{response}',
                 f'<target_response>\n{xml_escape(prior.target.text)}\n</target_response>',

--- a/src/evaluatorq/redteam/reports/converters.py
+++ b/src/evaluatorq/redteam/reports/converters.py
@@ -107,10 +107,19 @@ def _coerce_job_output_payload(raw_output: Any) -> JobOutputPayload:
             return d
         conversation: list[dict[str, Any]] = []
         final_response_text = ''
+
+        def _attacker_text(resp: dict[str, Any]) -> str:
+            """Attacker prompt from an AgentResponse dict (RES-883), falling back
+            to the pre-RES-883 ``generated_prompt`` field for older reports."""
+            for item in resp.get('output') or []:
+                if isinstance(item, dict) and item.get('type') == 'output_text' and (text := item.get('text', '')):
+                    return text
+            return resp.get('generated_prompt', '') or ''
+
         for t in turns_val:
             attacker = t.get('attacker') or {}
             target = t.get('target') or {}
-            conversation.append({'role': 'user', 'content': attacker.get('generated_prompt', '')})
+            conversation.append({'role': 'user', 'content': _attacker_text(attacker)})
             target_text = ''
             for item in target.get('output') or []:
                 if not isinstance(item, dict):

--- a/src/evaluatorq/redteam/reports/converters.py
+++ b/src/evaluatorq/redteam/reports/converters.py
@@ -35,6 +35,7 @@ from evaluatorq.redteam.contracts import (
     SeveritySummary,
     TechniqueSummary,
     TokenUsage,
+    Turn,
     TurnTypeSummary,
     UnifiedEvaluationResult,
     Vulnerability,
@@ -108,26 +109,22 @@ def _coerce_job_output_payload(raw_output: Any) -> JobOutputPayload:
         conversation: list[dict[str, Any]] = []
         final_response_text = ''
 
-        def _attacker_text(resp: dict[str, Any]) -> str:
-            """Attacker prompt from an AgentResponse dict (RES-883), falling back
-            to the pre-RES-883 ``generated_prompt`` field for older reports."""
-            for item in resp.get('output') or []:
-                if isinstance(item, dict) and item.get('type') == 'output_text' and (text := item.get('text', '')):
-                    return text
-            return resp.get('generated_prompt', '') or ''
-
+        # Validate each turn through the Turn model — the single migration authority
+        # (its validator maps the pre-RES-883 ``generated_prompt`` to ``text``) — then
+        # read canonical ``AgentResponse.text`` (joins every text item, matching what
+        # turns_to_messages/the judge saw). A turn that fails validation degrades to
+        # empty text for that row rather than dropping the whole coercion.
         for t in turns_val:
-            attacker = t.get('attacker') or {}
-            target = t.get('target') or {}
-            conversation.append({'role': 'user', 'content': _attacker_text(attacker)})
-            target_text = ''
-            for item in target.get('output') or []:
-                if not isinstance(item, dict):
-                    continue
-                if item.get('type') == 'output_text':
-                    target_text = item.get('text', '') or target_text
-            conversation.append({'role': 'assistant', 'content': target_text})
-            final_response_text = target_text or final_response_text
+            try:
+                turn = Turn.model_validate(t)
+                atk_text, tgt_text = turn.attacker.text, turn.target.text
+            except ValidationError:
+                atk_text = tgt_text = ''
+            conversation.extend((
+                {'role': 'user', 'content': atk_text},
+                {'role': 'assistant', 'content': tgt_text},
+            ))
+            final_response_text = tgt_text or final_response_text
         out = dict(d)
         out['turns'] = len(turns_val)
         out.setdefault('conversation', conversation)

--- a/tests/openresponses/test_multi_turn_state.py
+++ b/tests/openresponses/test_multi_turn_state.py
@@ -17,7 +17,7 @@ from evaluatorq.openresponses import (
     turns_to_openresponses_input,
     user_input_item,
 )
-from evaluatorq.redteam.contracts import AttackerResponse, Turn
+from evaluatorq.redteam.contracts import AgentResponse, Turn
 
 
 def _agent_text(text: str) -> AgentResponse:
@@ -26,7 +26,7 @@ def _agent_text(text: str) -> AgentResponse:
 
 def _turn(attacker_prompt: str, agent_text: str) -> Turn:
     return Turn(
-        attacker=AttackerResponse(generated_prompt=attacker_prompt),
+        attacker=AgentResponse(text=attacker_prompt),
         target=_agent_text(agent_text),
     )
 

--- a/tests/openresponses/test_multi_turn_state.py
+++ b/tests/openresponses/test_multi_turn_state.py
@@ -17,7 +17,7 @@ from evaluatorq.openresponses import (
     turns_to_openresponses_input,
     user_input_item,
 )
-from evaluatorq.redteam.contracts import AgentResponse, Turn
+from evaluatorq.redteam.contracts import Turn
 
 
 def _agent_text(text: str) -> AgentResponse:

--- a/tests/redteam/test_contracts.py
+++ b/tests/redteam/test_contracts.py
@@ -14,7 +14,6 @@ from evaluatorq.contracts import (
 )
 from evaluatorq.redteam.contracts import (
     AgentContext,
-    AgentResponse,
     AttackInfo,
     AttackOutput,
     CategorySummary,

--- a/tests/redteam/test_contracts.py
+++ b/tests/redteam/test_contracts.py
@@ -14,7 +14,7 @@ from evaluatorq.contracts import (
 )
 from evaluatorq.redteam.contracts import (
     AgentContext,
-    AttackerResponse,
+    AgentResponse,
     AttackInfo,
     AttackOutput,
     CategorySummary,
@@ -211,7 +211,7 @@ class TestCategorySummary:
 
 def _turn(prompt: str = "hi", reply: str = "ok") -> Turn:
     return Turn(
-        attacker=AttackerResponse(generated_prompt=prompt),
+        attacker=AgentResponse(text=prompt),
         target=AgentResponse(text=reply),
     )
 
@@ -286,7 +286,7 @@ class TestChatCompletionsOrdering:
         return OrchestratorResult(
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt="please call tools"),
+                    attacker=AgentResponse(text="please call tools"),
                     target=AgentResponse(output=output_items),
                 )
             ]
@@ -372,7 +372,7 @@ class TestChatCompletionsOrdering:
         result = OrchestratorResult(
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt="ping"),
+                    attacker=AgentResponse(text="ping"),
                     target=AgentResponse(output=[]),
                 )
             ]
@@ -408,3 +408,31 @@ def test_job_output_payload_tolerates_legacy_tool_calls_per_turn_key():
         'tool_calls_per_turn': [[{'type': 'function_call', 'name': 'search', 'arguments': '{}'}]],
     })
     assert payload.final_response == 'ok'
+
+
+class TestAttackerResponseUnifiedOntoAgentResponse:
+    """RES-883: the attacker side uses AgentResponse (not a separate type)."""
+
+    def test_turn_attacker_is_agent_response_with_error_field(self):
+        turn = Turn(attacker=AgentResponse(text='attack'), target=AgentResponse(text='resp'))
+        assert isinstance(turn.attacker, AgentResponse)
+        assert turn.attacker.text == 'attack'
+        # attacker now carries the shared per-response error field
+        assert turn.attacker.error is None
+
+    def test_truncated_is_derivable_from_finish_reason(self):
+        turn = Turn(
+            attacker=AgentResponse(text='attack', finish_reason='length'),
+            target=AgentResponse(text='resp'),
+        )
+        assert turn.attacker.finish_reason == 'length'  # was the separate `truncated` bool
+
+    def test_pre_res883_report_json_migrates(self):
+        # Reports written before RES-883 carried generated_prompt (+ a now-derived
+        # truncated) on the attacker; they must still load.
+        turn = Turn.model_validate({
+            'attacker': {'generated_prompt': 'legacy attack', 'truncated': True, 'finish_reason': 'length'},
+            'target': {'output': []},
+        })
+        assert turn.attacker.text == 'legacy attack'
+        assert turn.attacker.finish_reason == 'length'

--- a/tests/redteam/test_converters.py
+++ b/tests/redteam/test_converters.py
@@ -503,6 +503,46 @@ class TestCoerceJobOutputPayload:
         assert isinstance(result, JobOutputPayload)
         assert result.final_response is None
 
+    def test_new_shape_turns_flatten_to_conversation(self):
+        # New-shape Turn dicts (attacker + target both AgentResponse) flatten to the
+        # legacy conversation wire format. Multi-segment attacker output must be
+        # CONCATENATED (matching AgentResponse.text), not first-hit.
+        raw = {
+            'turns': [
+                {
+                    'attacker': {'output': [
+                        {'type': 'output_text', 'text': 'part one '},
+                        {'type': 'output_text', 'text': 'part two'},
+                    ]},
+                    'target': {'output': [{'type': 'output_text', 'text': 'agent reply'}]},
+                }
+            ]
+        }
+        result = _coerce_job_output_payload(raw)
+        assert result.turns == 1
+        assert result.conversation[0].role == 'user'
+        assert result.conversation[0].content == 'part one part two'
+        assert result.conversation[1].role == 'assistant'
+        assert result.conversation[1].content == 'agent reply'
+        assert result.final_response == 'agent reply'
+
+    def test_pre_res883_report_round_trips(self):
+        # A report written before RES-883 carried the attacker prompt as
+        # ``generated_prompt`` (not an AgentResponse output). The Turn migrator must
+        # still surface it in the flattened conversation so old reports render.
+        raw = {
+            'turns': [
+                {
+                    'attacker': {'generated_prompt': 'legacy attack', 'truncated': True, 'finish_reason': 'length'},
+                    'target': {'output': [{'type': 'output_text', 'text': 'legacy reply'}]},
+                }
+            ]
+        }
+        result = _coerce_job_output_payload(raw)
+        assert result.turns == 1
+        assert result.conversation[0].content == 'legacy attack'
+        assert result.conversation[1].content == 'legacy reply'
+
     def test_object_with_known_attributes_extracted(self):
         obj = SimpleNamespace(
             final_response='from namespace',

--- a/tests/redteam/test_dynamic_job.py
+++ b/tests/redteam/test_dynamic_job.py
@@ -130,7 +130,7 @@ def _make_target_factory(target: MagicMock | None = None) -> MagicMock:
 
 def _make_orchestrator_result(*, error: str | None = None) -> OrchestratorResult:
     from evaluatorq.contracts import AgentResponse
-    from evaluatorq.redteam.contracts import AgentResponse, Turn
+    from evaluatorq.redteam.contracts import Turn
 
     return OrchestratorResult(
         turns=[

--- a/tests/redteam/test_dynamic_job.py
+++ b/tests/redteam/test_dynamic_job.py
@@ -130,12 +130,12 @@ def _make_target_factory(target: MagicMock | None = None) -> MagicMock:
 
 def _make_orchestrator_result(*, error: str | None = None) -> OrchestratorResult:
     from evaluatorq.contracts import AgentResponse
-    from evaluatorq.redteam.contracts import AttackerResponse, Turn
+    from evaluatorq.redteam.contracts import AgentResponse, Turn
 
     return OrchestratorResult(
         turns=[
             Turn(
-                attacker=AttackerResponse(generated_prompt="Attack prompt"),
+                attacker=AgentResponse(text="Attack prompt"),
                 target=AgentResponse(text="Agent response"),
             )
         ],
@@ -238,7 +238,8 @@ class TestTemplateSingleTurnPath:
         # Output should have exactly 1 turn (attacker + target pair)
         assert len(output["turns"]) == 1
         turn0 = output["turns"][0]
-        assert turn0["attacker"]["generated_prompt"]
+        # RES-883: attacker is an AgentResponse — its prompt is the output text.
+        assert turn0["attacker"]["output"][0]["text"]
         assert turn0["target"]["output"]
 
     @pytest.mark.asyncio

--- a/tests/redteam/test_panel_of_judges.py
+++ b/tests/redteam/test_panel_of_judges.py
@@ -485,7 +485,7 @@ class TestEndToEndScorer:
         from types import SimpleNamespace
 
         from evaluatorq.redteam.adaptive.pipeline import create_dynamic_evaluator
-        from evaluatorq.redteam.contracts import AgentResponse, AttackerResponse, AttackOutput, Turn
+        from evaluatorq.redteam.contracts import AgentResponse, AttackOutput, Turn
 
         client = _model_client({
             'judge-a': [_verdict_json(True)],
@@ -500,7 +500,7 @@ class TestEndToEndScorer:
         )['scorer']
 
         attack_output = AttackOutput(
-            turns=[Turn(attacker=AttackerResponse(generated_prompt='do bad'), target=AgentResponse(text='no'))],
+            turns=[Turn(attacker=AgentResponse(text='do bad'), target=AgentResponse(text='no'))],
             category='ASI01',
             vulnerability='goal_hijacking',
         )

--- a/tests/redteam/test_token_usage_pipeline.py
+++ b/tests/redteam/test_token_usage_pipeline.py
@@ -299,7 +299,7 @@ class TestPipelineTokenUsageAggregation:
 
     @pytest.mark.asyncio
     async def test_aggregated_total_equals_sum_of_per_turn_usage(self) -> None:
-        """Sum of per-turn ``AttackerResponse.usage`` must equal ``token_usage_adversarial``.
+        """Sum of per-turn ``AgentResponse.usage`` must equal ``token_usage_adversarial``.
 
         Pins the invariant that the canonical per-turn record and the
         aggregated counter cannot drift.
@@ -587,7 +587,7 @@ class TestLateAdversarialFailureStillJudged:
 
         from evaluatorq.contracts import AgentResponse
         from evaluatorq.redteam.adaptive.pipeline import create_dynamic_evaluator
-        from evaluatorq.redteam.contracts import AttackerResponse, AttackOutput, Turn
+        from evaluatorq.redteam.contracts import AgentResponse, AttackOutput, Turn
 
         evaluate = self._fake_evaluator(monkeypatch, passed=False)
 
@@ -596,7 +596,7 @@ class TestLateAdversarialFailureStillJudged:
             vulnerability='goal_hijacking',
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='turn 1 attack'),
+                    attacker=AgentResponse(text='turn 1 attack'),
                     target=AgentResponse(text='Sure, the secret is hunter2.'),
                 )
             ],
@@ -652,7 +652,7 @@ class TestLateAdversarialFailureStillJudged:
 
         from evaluatorq.contracts import AgentResponse
         from evaluatorq.redteam.adaptive.pipeline import create_dynamic_evaluator
-        from evaluatorq.redteam.contracts import AttackerResponse, AttackOutput, Turn
+        from evaluatorq.redteam.contracts import AgentResponse, AttackOutput, Turn
 
         evaluate = self._fake_evaluator(monkeypatch, passed=False)
 
@@ -661,7 +661,7 @@ class TestLateAdversarialFailureStillJudged:
             vulnerability='goal_hijacking',
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='turn 1 attack'),
+                    attacker=AgentResponse(text='turn 1 attack'),
                     target=AgentResponse(text='Sure, the secret is hunter2.'),
                 )
             ],
@@ -689,7 +689,7 @@ class TestLateAdversarialFailureStillJudged:
 
         from evaluatorq.contracts import AgentResponse
         from evaluatorq.redteam.adaptive.pipeline import create_dynamic_evaluator
-        from evaluatorq.redteam.contracts import AttackerResponse, AttackOutput, Turn
+        from evaluatorq.redteam.contracts import AgentResponse, AttackOutput, Turn
 
         evaluate = self._fake_evaluator(monkeypatch, passed=False)
 
@@ -698,7 +698,7 @@ class TestLateAdversarialFailureStillJudged:
             vulnerability='goal_hijacking',
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='turn 1 attack'),
+                    attacker=AgentResponse(text='turn 1 attack'),
                     target=AgentResponse(text='Sure, the secret is hunter2.'),
                 )
             ],

--- a/tests/redteam/test_turns_to_messages.py
+++ b/tests/redteam/test_turns_to_messages.py
@@ -9,13 +9,13 @@ from evaluatorq.contracts import (
     TextOutputItem,
     ToolCallOutputItem,
 )
-from evaluatorq.redteam.contracts import AttackerResponse, Turn, turns_to_messages
+from evaluatorq.redteam.contracts import AgentResponse, Turn, turns_to_messages
 
 
 def _turn(prompt: str, reply: str, *, error: bool = False) -> Turn:
     err = AgentResponseError(message=reply, error_type="timeout") if error else None
     return Turn(
-        attacker=AttackerResponse(generated_prompt=prompt),
+        attacker=AgentResponse(text=prompt),
         target=AgentResponse(output=[TextOutputItem(text=reply, annotations=[])], error=err),
     )
 
@@ -39,7 +39,7 @@ def test_multi_turn_alternation():
 
 def test_tool_calls_preserved():
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="go"),
+        attacker=AgentResponse(text="go"),
         target=AgentResponse(output=[
             ToolCallOutputItem(name="lookup", arguments='{"q":"x"}', id="c1", call_id="c1"),
         ]),
@@ -54,7 +54,7 @@ def test_tool_calls_preserved():
 def test_empty_output_emits_empty_assistant_row():
     """An empty target output still yields a user/assistant pair (alternation invariant)."""
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="q"),
+        attacker=AgentResponse(text="q"),
         target=AgentResponse(output=[]),
     )
     msgs = turns_to_messages([turn])
@@ -63,7 +63,7 @@ def test_empty_output_emits_empty_assistant_row():
 
 def test_tool_result_emits_following_tool_row():
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="go"),
+        attacker=AgentResponse(text="go"),
         target=AgentResponse(output=[
             ToolCallOutputItem(name="lookup", arguments='{"q":"x"}', id="c1", call_id="c1", result="found"),
         ]),
@@ -100,7 +100,7 @@ def test_reasoning_only_output_emits_empty_assistant_row():
     would 400 on the broken alternation.
     """
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="q"),
+        attacker=AgentResponse(text="q"),
         target=AgentResponse(output=[ReasoningOutputItem(text="thinking...")]),
     )
     msgs = turns_to_messages([turn])
@@ -110,7 +110,7 @@ def test_reasoning_only_output_emits_empty_assistant_row():
 def test_tool_call_with_result_does_not_emit_extra_assistant_row():
     """A turn ending in a tool result must not get a trailing empty assistant row."""
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="go"),
+        attacker=AgentResponse(text="go"),
         target=AgentResponse(output=[
             ToolCallOutputItem(name="lookup", arguments='{"q":"x"}', id="c1", call_id="c1", result="found"),
         ]),
@@ -122,7 +122,7 @@ def test_tool_call_with_result_does_not_emit_extra_assistant_row():
 def test_tool_call_preserves_responses_item_id():
     """Responses-API fc_* item id round-trips through StrategyToolCall.item_id."""
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="go"),
+        attacker=AgentResponse(text="go"),
         target=AgentResponse(output=[
             ToolCallOutputItem(name="lookup", arguments='{"q":"x"}', id="fc_abc", call_id="call_xyz"),
         ]),
@@ -141,7 +141,7 @@ def test_interleaved_text_tool_text_emits_three_assistant_rows():
     break multi-turn replay for agents that narrate around tool use.
     """
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="search"),
+        attacker=AgentResponse(text="search"),
         target=AgentResponse(output=[
             TextOutputItem(text="thinking...", annotations=[]),
             ToolCallOutputItem(name="lookup", arguments="{}", id="c1", call_id="c1"),
@@ -161,7 +161,7 @@ def test_consecutive_text_items_collapse_into_one_assistant_row():
     Documented in ``turns_to_messages``; pinning the behavior here.
     """
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="hi"),
+        attacker=AgentResponse(text="hi"),
         target=AgentResponse(output=[
             TextOutputItem(text="part one ", annotations=[]),
             TextOutputItem(text="part two", annotations=[]),
@@ -178,7 +178,7 @@ def test_tool_result_empty_string_still_emits_tool_row():
     to ``if item.result:`` would silently drop the row and break alternation.
     """
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="go"),
+        attacker=AgentResponse(text="go"),
         target=AgentResponse(output=[
             ToolCallOutputItem(name="noop", arguments="{}", id="c1", call_id="c1", result=""),
         ]),
@@ -196,7 +196,7 @@ def test_reasoning_interleaved_with_text_and_tool_dropped_silently():
     from evaluatorq.contracts import ReasoningOutputItem
 
     turn = Turn(
-        attacker=AttackerResponse(generated_prompt="q"),
+        attacker=AgentResponse(text="q"),
         target=AgentResponse(output=[
             TextOutputItem(text="hello", annotations=[]),
             ReasoningOutputItem(text="(internal)"),

--- a/tests/redteam/test_turns_to_messages.py
+++ b/tests/redteam/test_turns_to_messages.py
@@ -9,7 +9,7 @@ from evaluatorq.contracts import (
     TextOutputItem,
     ToolCallOutputItem,
 )
-from evaluatorq.redteam.contracts import AgentResponse, Turn, turns_to_messages
+from evaluatorq.redteam.contracts import Turn, turns_to_messages
 
 
 def _turn(prompt: str, reply: str, *, error: bool = False) -> Turn:

--- a/tests/unit/test_openai_agents_target.py
+++ b/tests/unit/test_openai_agents_target.py
@@ -353,7 +353,7 @@ class TestToolCallOutputRoundTrip:
     async def test_function_call_output_attaches_result_to_matching_call(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from evaluatorq.redteam.contracts import turns_to_messages, Turn, AttackerResponse
+        from evaluatorq.redteam.contracts import turns_to_messages, Turn, AgentResponse
 
         result = MagicMock()
         result.final_output = "done"
@@ -390,7 +390,7 @@ class TestToolCallOutputRoundTrip:
         # Round-trip through transcript replay: the orphan-function_call bug
         # would show up here as a missing ``tool`` row, which then renders to a
         # Responses-API function_call without function_call_output.
-        turn = Turn(attacker=AttackerResponse(generated_prompt="lookup x"), target=response)
+        turn = Turn(attacker=AgentResponse(text="lookup x"), target=response)
         msgs = turns_to_messages([turn])
         roles = [m.role for m in msgs]
         assert "tool" in roles, "tool result row missing — function_call_output was dropped"

--- a/tests/unit/test_tool_call_interception.py
+++ b/tests/unit/test_tool_call_interception.py
@@ -11,7 +11,7 @@ import pytest
 from evaluatorq.redteam.backends.base import _coerce_to_agent_response
 from evaluatorq.redteam.contracts import (
     AgentResponse,
-    AttackerResponse,
+    AgentResponse,
     Message,
     OrchestratorResult,
     OutputMessage,
@@ -162,7 +162,7 @@ class TestOrchestratorResultToolCalls:
         result = OrchestratorResult(
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='do it'),
+                    attacker=AgentResponse(text='do it'),
                     target=AgentResponse(
                         output=[
                             TextOutputItem(text='done', annotations=[]),
@@ -180,7 +180,7 @@ class TestOrchestratorResultToolCalls:
         result = OrchestratorResult(
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='hi'),
+                    attacker=AgentResponse(text='hi'),
                     target=AgentResponse(text='hello'),
                 )
             ],
@@ -442,11 +442,11 @@ class TestCreateDynamicEvaluatorScorer:
         attack_output = AttackOutput(
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='hi'),
+                    attacker=AgentResponse(text='hi'),
                     target=AgentResponse(output=[TextOutputItem(text='ok', annotations=[]), tc_a]),
                 ),
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='again'),
+                    attacker=AgentResponse(text='again'),
                     target=AgentResponse(output=[TextOutputItem(text='done', annotations=[]), tc_b]),
                 ),
             ],
@@ -484,7 +484,7 @@ class TestCreateDynamicEvaluatorScorer:
         attack_output = AttackOutput(
             turns=[
                 Turn(
-                    attacker=AttackerResponse(generated_prompt='hi'),
+                    attacker=AgentResponse(text='hi'),
                     target=AgentResponse(text='nope'),
                 ),
             ],

--- a/tests/unit/test_tool_call_interception.py
+++ b/tests/unit/test_tool_call_interception.py
@@ -11,7 +11,6 @@ import pytest
 from evaluatorq.redteam.backends.base import _coerce_to_agent_response
 from evaluatorq.redteam.contracts import (
     AgentResponse,
-    AgentResponse,
     Message,
     OrchestratorResult,
     OutputMessage,


### PR DESCRIPTION
Unifies the redteam attacker output onto the shared `AgentResponse` type (RES-883). Follow-up from RES-877 (RES-808 PR4), which added `AgentResponse` + the per-response `AgentResponseError`. The attacker was the odd one out with its own `AttackerResponse` type; this makes one response shape across attacker, target, and simulation agents.

## What changed
- `Turn.attacker` is now `AgentResponse` (was `AttackerResponse`).
  - `generated_prompt` → `AgentResponse.text`.
  - `truncated` is dropped — it was always `finish_reason == 'length'` and is derivable (it was never read anywhere; `truncated_turns` is computed independently in the orchestrator).
  - The attacker gains the shared per-response `error` field for free.
- `AttackerResponse` is kept as a deprecated alias (`AttackerResponse = AgentResponse`), matching the existing `SendResult = AgentResponse` precedent, so imports keep working.
- Construction sites updated: `orchestrator.py` (turn record + marker-stripped rebuild), `pipeline.py`. Read sites updated: `turns_to_messages`, `attacker_input_at`, `openresponses/dataset.py`, `reports/converters.py`.

## Back-compat (breaking schema, mitigated)
The serialized report shape changes (attacker uses `output` items instead of `generated_prompt`/`truncated`). A `@model_validator(mode='before')` on `Turn` migrates pre-RES-883 report JSON (`generated_prompt` → `text`, drops `truncated`), and `converters.py` falls back to `generated_prompt` when reading old serialized turns — so **old reports still load**. This mirrors the existing `_migrate_scope_to_vulnerability_domain` pattern in the same module.

Marked `feat!:` / BREAKING CHANGE for the tag-driven semver.

## Tests
- New `TestAttackerResponseUnifiedOntoAgentResponse` in `test_contracts.py`: attacker is an `AgentResponse` with the `error` field, `truncated` is derivable from `finish_reason`, and pre-RES-883 report JSON migrates.
- All prior `AttackerResponse(generated_prompt=...)` test constructions migrated to `AgentResponse(text=...)`.
- Full non-integration suite: 2683 passed. `ruff check src` clean, `basedpyright` 0 errors.

## Design decision
Chose **full unification with a deprecated alias** over subclassing/wrapping: `Turn.attacker` is genuinely an `AgentResponse` (the ticket's goal — one response shape), and the alias keeps import back-compat without a second model. `.text` is the right mapping for `generated_prompt` — all three read sites already turned it into a user message.
