### PR TITLE
feat(observability): link dashboard runs to Orq traces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ src/evaluatorq/
 - `ORQ_API_KEY` — ORQ platform authentication
 - `ORQ_BASE_URL` — ORQ API base URL (optional override; default `https://my.orq.ai`)
 - `OPENAI_API_KEY` — for direct OpenAI backend or pipeline LLM calls
-- `ORQ_WORKSPACE_SLUG` (or `ORQ_WORKSPACE`) — workspace slug for dashboard→Orq trace deep-links; buttons hidden when unset
+- `ORQ_WORKSPACE` (or `ORQ_WORKSPACE_SLUG`) — workspace slug for dashboard→Orq trace deep-links; buttons hidden when unset
 - `ORQ_UI_BASE_URL` — optional Orq UI base for deep-links (defaults to `ORQ_BASE_URL` or `https://my.orq.ai`)
 
 ### Code Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,8 @@ src/evaluatorq/
 - `ORQ_API_KEY` — ORQ platform authentication
 - `ORQ_BASE_URL` — ORQ API base URL (optional override; default `https://my.orq.ai`)
 - `OPENAI_API_KEY` — for direct OpenAI backend or pipeline LLM calls
+- `ORQ_WORKSPACE_SLUG` (or `ORQ_WORKSPACE`) — workspace slug for dashboard→Orq trace deep-links; buttons hidden when unset
+- `ORQ_UI_BASE_URL` — optional Orq UI base for deep-links (defaults to `ORQ_BASE_URL` or `https://my.orq.ai`)
 
 ### Code Style
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -45,6 +45,10 @@ eq dashboard .evaluatorq/runs/red-team_20260626_143024.json
 
 # Bind a custom host / port (default 127.0.0.1:8080)
 eq dashboard --host 0.0.0.0 --port 8888
+
+# Enable “View Traces” links in reports. Use the workspace slug from the
+# Orq URL (https://my.orq.ai/<workspace>/...), not an API key or workspace UUID.
+ORQ_WORKSPACE=orq-research eq dashboard
 ```
 
 | Invocation | What it scans |
@@ -55,6 +59,18 @@ eq dashboard --host 0.0.0.0 --port 8888
 
 With no `PATH` the server prints the local URL to open. Pointing at a file
 prints that report's direct URL so you land straight on it.
+
+### Orq trace links
+
+Set `ORQ_WORKSPACE` when launching the dashboard to show **View Traces** links
+for conversations and runs. Its value is the workspace slug in the Orq UI URL;
+for example, `https://my.orq.ai/orq-research/traces` uses
+`ORQ_WORKSPACE=orq-research`. It is configured explicitly and is not derived
+from `ORQ_API_KEY`. If it is unset, trace-link buttons are hidden.
+
+`ORQ_WORKSPACE_SLUG` remains supported as an alias. For a self-hosted or
+staging Orq UI, set `ORQ_UI_BASE_URL` as well; otherwise the dashboard uses
+`ORQ_BASE_URL`, then `https://my.orq.ai`.
 
 !!! note "Legacy Streamlit views"
     `eq redteam ui` and `eq sim ui` launch the older Streamlit dashboards,

--- a/src/evaluatorq/common/thread_context.py
+++ b/src/evaluatorq/common/thread_context.py
@@ -1,0 +1,64 @@
+"""Per-conversation Orq thread id, carried via a ContextVar.
+
+Multi-turn calls on the Orq router / Responses API are grouped in Orq
+observability by sending a ``thread: {id: ...}`` body param on every turn
+(see https://docs.orq.ai/docs/ai-gateway/thread-management). The id must be
+stable for one conversation but distinct across conversations.
+
+Targets are stateless and shared across concurrently-running conversations
+(one ``SimulationRunner`` / target instance serves every datapoint), so the
+thread id can't live on the target instance. A ContextVar carries it instead:
+each asyncio Task gets an isolated copy of the context, so concurrent
+conversations don't leak thread ids into each other.
+
+Callers that own a conversation (the sim runner, the redteam orchestrator)
+wrap it in ``conversation_thread()``; the target reads ``current_thread_id()``
+and attaches the thread param. When unset, no thread param is sent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_thread_id: ContextVar[str | None] = ContextVar('orq_thread_id', default=None)
+
+
+def current_thread_id() -> str | None:
+    """Return the thread id for the active conversation, or None if unset."""
+    return _thread_id.get()
+
+
+def thread_body_param() -> dict[str, dict[str, str]]:
+    """Return ``{'thread': {'id': ...}}`` for the active conversation, or ``{}``.
+
+    Ready to splat into an Orq router request body / SDK ``extra_body``.
+    """
+    tid = _thread_id.get()
+    return {'thread': {'id': tid}} if tid else {}
+
+
+@contextmanager
+def conversation_thread(thread_id: str | None = None) -> Iterator[str]:
+    """Bind a thread id for the duration of one conversation.
+
+    Generates a uuid when none is given. Restores the previous value on exit so
+    nested/sequential conversations don't bleed into each other.
+
+    Yields:
+        The bound thread id.
+    """
+    tid = thread_id or str(uuid.uuid4())
+    token = _thread_id.set(tid)
+    try:
+        yield tid
+    finally:
+        _thread_id.reset(token)
+
+
+__all__ = ['conversation_thread', 'current_thread_id', 'thread_body_param']

--- a/src/evaluatorq/common/thread_context.py
+++ b/src/evaluatorq/common/thread_context.py
@@ -28,6 +28,26 @@ if TYPE_CHECKING:
 
 _thread_id: ContextVar[str | None] = ContextVar('orq_thread_id', default=None)
 
+# Separator joining the run id and the per-conversation discriminators into a
+# thread id. Kept out of the OQL query grammar's way: the run id is uuid hex and
+# the parts are ints / sanitized keys, so ':' never appears inside a segment.
+_THREAD_ID_SEP = ':'
+
+
+def build_thread_id(run_id: str | None, *parts: object) -> str | None:
+    """Compose a run-scoped thread id, or None when there is no run to link.
+
+    Single source of truth for the ``{run_id}:{...}`` format that the dashboard's
+    run-level deep link (``thread_id:contains:{run_id}``) depends on: sim passes
+    ``build_thread_id(run_id, index)`` → ``{run_id}:{index}``; red teaming passes
+    ``build_thread_id(run_id, agent_key, index)`` → ``{run_id}:{agent_key}:{index}``.
+    The ``run_id`` prefix is what makes the run-level ``contains`` query match
+    every conversation in the run.
+    """
+    if not run_id:
+        return None
+    return _THREAD_ID_SEP.join([run_id, *(str(p) for p in parts)])
+
 
 def current_thread_id() -> str | None:
     """Return the thread id for the active conversation, or None if unset."""
@@ -61,4 +81,4 @@ def conversation_thread(thread_id: str | None = None) -> Iterator[str]:
         _thread_id.reset(token)
 
 
-__all__ = ['conversation_thread', 'current_thread_id', 'thread_body_param']
+__all__ = ['build_thread_id', 'conversation_thread', 'current_thread_id', 'thread_body_param']

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -685,6 +685,11 @@ class AgentResponse(BaseModel):
     usage: TokenUsage | None = None
     model: str | None = None
     response_id: str | None = None
+    # Orq trace id for this call (both the router and agents endpoints read
+    # `response.telemetry.trace_id` from the response body). Links this
+    # response back to the trace in Orq observability. None when not routed
+    # through Orq.
+    trace_id: str | None = None
     finish_reason: str | None = None
     error: AgentResponseError | None = None
 
@@ -698,6 +703,7 @@ class AgentResponse(BaseModel):
             usage: TokenUsage | None = None,
             model: str | None = None,
             response_id: str | None = None,
+            trace_id: str | None = None,
             finish_reason: str | None = None,
             error: AgentResponseError | None = None,
         ) -> None: ...

--- a/src/evaluatorq/dashboard/redteam_transcripts.py
+++ b/src/evaluatorq/dashboard/redteam_transcripts.py
@@ -23,6 +23,7 @@ from evaluatorq.dashboard.redteam_charts import (
     fmt_vulnerability,
 )
 from evaluatorq.dashboard.report_kit import tag
+from evaluatorq.dashboard.trace_links import thread_trace_url, trace_link_button
 from evaluatorq.dashboard.view import render_message_list
 from evaluatorq.redteam.reports.converters import _is_evaluated, _is_vulnerable
 
@@ -88,7 +89,12 @@ def render_attack_fragment(r: RedTeamResult) -> str:
 
     transcript_html = render_message_list(r.messages, role_labels=_RT_ROLE_LABELS, class_prefix='rt')
 
-    return f'{tags_html}{verdict_html}{transcript_html}'
+    # Deep-link to this conversation's Orq traces (hidden when unconfigured or
+    # for older reports without a thread id).
+    trace_btn = trace_link_button(thread_trace_url(r.thread_id), 'View conversation traces ↗')
+    trace_html = f'<div class="rt-conv-actions">{trace_btn}</div>' if trace_btn else ''
+
+    return f'{tags_html}{verdict_html}{trace_html}{transcript_html}'
 
 
 # ---------------------------------------------------------------------------

--- a/src/evaluatorq/dashboard/redteam_transcripts.py
+++ b/src/evaluatorq/dashboard/redteam_transcripts.py
@@ -91,7 +91,7 @@ def render_attack_fragment(r: RedTeamResult) -> str:
 
     # Deep-link to this conversation's Orq traces (hidden when unconfigured or
     # for older reports without a thread id).
-    trace_btn = trace_link_button(thread_trace_url(r.thread_id), 'View conversation traces ↗')
+    trace_btn = trace_link_button(thread_trace_url(r.thread_id), 'View Traces')
     trace_html = f'<div class="rt-conv-actions">{trace_btn}</div>' if trace_btn else ''
 
     return f'{tags_html}{verdict_html}{trace_html}{transcript_html}'

--- a/src/evaluatorq/dashboard/report_tabs.py
+++ b/src/evaluatorq/dashboard/report_tabs.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from evaluatorq.common.reports import esc
+from evaluatorq.dashboard.trace_links import run_trace_url, trace_link_button
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -818,10 +819,12 @@ def _sim_hero(run: SimulationRun) -> str:
     # KPI cards intentionally omitted: the same metrics render in the 5-card
     # band inside the Overview tab (_sim_kpi_band), so a hero band duplicated
     # them above the tabs. Hero is now just title + subtitle.
+    run_btn = trace_link_button(run_trace_url(run.run_id), 'View all run traces ↗')
+    actions = f'<div class="report-hero-actions">{run_btn}</div>' if run_btn else ''
     return (
         f'<header class="report-hero"><h1 class="report-hero-title">Agent Simulation</h1>'
         f'<p class="report-hero-sub">{esc(run.run_name)} · target {esc(run.target_kind)}</p>'
-        f'</header>'
+        f'{actions}</header>'
     )
 
 
@@ -1704,10 +1707,13 @@ def _redteam_hero(summary_section: Any, report: RedTeamReport) -> str:
         agent_stats = _rt_agent_stats(report)
         pills = ''.join(_rt_agent_pill(stats) for stats in agent_stats.values())
         agent_pills_html = f'<div class="rt-hero-agent-row">{pills}</div>'
+    run_btn = trace_link_button(run_trace_url(report.run_id), 'View all run traces ↗')
+    actions = f'<div class="report-hero-actions">{run_btn}</div>' if run_btn else ''
     return (
         '<header class="report-hero rt-hero">'
         f'<h1 class="rt-hero-title">Red Team{agents_pill}</h1>'
         f'<p class="report-hero-sub">{esc(report.description or "Red teaming report")}</p>'
         f'{agent_pills_html}'
+        f'{actions}'
         '</header>'
     )

--- a/src/evaluatorq/dashboard/sim_views.py
+++ b/src/evaluatorq/dashboard/sim_views.py
@@ -127,8 +127,14 @@ def render_sim_row_list(rid: str, entries: list[SimulationEntry]) -> str:
             tint = 'sim-tint-missed'
             badge = status_badge('Goal missed', 'fail')
 
+        # Trace deep-link on the summary line, next to the outcome badge.
+        # stopPropagation so clicking it opens the trace without toggling the row.
+        trace_btn = trace_link_button(
+            thread_trace_url(e.thread_id), 'View Traces', onclick='event.stopPropagation()'
+        )
         right_cluster = (
-            f'{tag(f"{e.turn_count} turns")}{tag(f"score {e.goal_completion_score:.2f}")}{tag(e.terminated_by)}{badge}'
+            f'{tag(f"{e.turn_count} turns")}{tag(f"score {e.goal_completion_score:.2f}")}'
+            f'{tag(e.terminated_by)}{badge}{trace_btn}'
         )
         summary = (
             f'<summary class="sim-conv-summary {tint}">'
@@ -223,11 +229,6 @@ def render_transcript_fragment(entry: SimulationEntry) -> str:
     judge_reason = esc(entry.judge_reason or '')
     error = entry.error
 
-    # Deep-link to this conversation's Orq traces (hidden when unconfigured or
-    # for older reports without a thread id).
-    trace_btn = trace_link_button(thread_trace_url(entry.thread_id), 'View conversation traces ↗')
-    trace_html = f'<div class="sim-transcript-actions">{trace_btn}</div>' if trace_btn else ''
-
     # No title here: the collapsed conversation card already shows
     # "#N · persona · scenario" directly above this fragment, so repeating it
     # (the old sim-transcript-header) was a duplicate the mockup doesn't have.
@@ -235,7 +236,7 @@ def render_transcript_fragment(entry: SimulationEntry) -> str:
 
     if error:
         error_html = f'<div class="sim-transcript-error"><strong>Error:</strong> {esc(str(error))}</div>'
-        return f'<div class="sim-transcript-detail">{trace_html}{error_html}{criteria_col}</div>'
+        return f'<div class="sim-transcript-detail">{error_html}{criteria_col}</div>'
 
     judge_html = ''
     if judge_reason:
@@ -263,7 +264,7 @@ def render_transcript_fragment(entry: SimulationEntry) -> str:
     )
     grid_html = f'<div class="sim-transcript-grid">{bubbles_html}{criteria_col}</div>'
 
-    return f'<div class="sim-transcript-detail">{trace_html}{judge_html}{grid_html}</div>'
+    return f'<div class="sim-transcript-detail">{judge_html}{grid_html}</div>'
 
 
 # ---------------------------------------------------------------------------

--- a/src/evaluatorq/dashboard/sim_views.py
+++ b/src/evaluatorq/dashboard/sim_views.py
@@ -24,6 +24,7 @@ from evaluatorq.common.messages import coerce_content_text
 from evaluatorq.common.reports import esc
 from evaluatorq.dashboard.filter_request import parse_selections
 from evaluatorq.dashboard.filters import apply_or_all
+from evaluatorq.dashboard.trace_links import thread_trace_url, trace_link_button
 from evaluatorq.dashboard.view import _sim_rowlist_wrapper, render_message_list
 
 if TYPE_CHECKING:
@@ -222,6 +223,11 @@ def render_transcript_fragment(entry: SimulationEntry) -> str:
     judge_reason = esc(entry.judge_reason or '')
     error = entry.error
 
+    # Deep-link to this conversation's Orq traces (hidden when unconfigured or
+    # for older reports without a thread id).
+    trace_btn = trace_link_button(thread_trace_url(entry.thread_id), 'View conversation traces ↗')
+    trace_html = f'<div class="sim-transcript-actions">{trace_btn}</div>' if trace_btn else ''
+
     # No title here: the collapsed conversation card already shows
     # "#N · persona · scenario" directly above this fragment, so repeating it
     # (the old sim-transcript-header) was a duplicate the mockup doesn't have.
@@ -229,7 +235,7 @@ def render_transcript_fragment(entry: SimulationEntry) -> str:
 
     if error:
         error_html = f'<div class="sim-transcript-error"><strong>Error:</strong> {esc(str(error))}</div>'
-        return f'<div class="sim-transcript-detail">{error_html}{criteria_col}</div>'
+        return f'<div class="sim-transcript-detail">{trace_html}{error_html}{criteria_col}</div>'
 
     judge_html = ''
     if judge_reason:
@@ -257,7 +263,7 @@ def render_transcript_fragment(entry: SimulationEntry) -> str:
     )
     grid_html = f'<div class="sim-transcript-grid">{bubbles_html}{criteria_col}</div>'
 
-    return f'<div class="sim-transcript-detail">{judge_html}{grid_html}</div>'
+    return f'<div class="sim-transcript-detail">{trace_html}{judge_html}{grid_html}</div>'
 
 
 # ---------------------------------------------------------------------------

--- a/src/evaluatorq/dashboard/trace_links.py
+++ b/src/evaluatorq/dashboard/trace_links.py
@@ -14,7 +14,7 @@ Configuration (env):
 
 * ``ORQ_UI_BASE_URL`` — UI host (default: ``ORQ_BASE_URL`` env, else
   ``https://my.orq.ai``).
-* ``ORQ_WORKSPACE_SLUG`` / ``ORQ_WORKSPACE`` — workspace slug for the URL path.
+* ``ORQ_WORKSPACE`` / ``ORQ_WORKSPACE_SLUG`` — workspace slug for the URL path.
   When neither is set the buttons are hidden (the URL builders return ``None``),
   so we never render a broken link.
 """
@@ -37,7 +37,7 @@ def ui_base_url() -> str:
 
 def workspace_slug() -> str | None:
     """Return the configured workspace slug, or ``None`` when unset."""
-    slug = os.environ.get('ORQ_WORKSPACE_SLUG') or os.environ.get('ORQ_WORKSPACE') or ''
+    slug = os.environ.get('ORQ_WORKSPACE') or os.environ.get('ORQ_WORKSPACE_SLUG') or ''
     slug = slug.strip().strip('/')
     return slug or None
 

--- a/src/evaluatorq/dashboard/trace_links.py
+++ b/src/evaluatorq/dashboard/trace_links.py
@@ -2,8 +2,10 @@
 
 Builds ``…/<workspace-slug>/traces?query=…`` URLs so a conversation or a whole
 run can be opened in the Orq traces UI. Each run mints a ``run_id`` and its
-conversations use ``thread_id = f"{run_id}:{seq}"`` (see
-``evaluatorq.common.thread_context``), so:
+conversations get a run-scoped ``thread_id`` built by
+``evaluatorq.common.thread_context.build_thread_id`` — ``{run_id}:{index}`` for
+simulations, ``{run_id}:{agent_key}:{index}`` for red-team attacks. Both share
+the ``run_id`` prefix, so:
 
 * a single conversation is matched with ``thread_id:is:<thread_id>``;
 * every conversation in a run is matched with ``thread_id:contains:<run_id>``.

--- a/src/evaluatorq/dashboard/trace_links.py
+++ b/src/evaluatorq/dashboard/trace_links.py
@@ -1,0 +1,78 @@
+"""Deep links from the dashboard into Orq trace observability.
+
+Builds ``…/<workspace-slug>/traces?query=…`` URLs so a conversation or a whole
+run can be opened in the Orq traces UI. Each run mints a ``run_id`` and its
+conversations use ``thread_id = f"{run_id}:{seq}"`` (see
+``evaluatorq.common.thread_context``), so:
+
+* a single conversation is matched with ``thread_id:is:<thread_id>``;
+* every conversation in a run is matched with ``thread_id:contains:<run_id>``.
+
+Configuration (env):
+
+* ``ORQ_UI_BASE_URL`` — UI host (default: ``ORQ_BASE_URL`` env, else
+  ``https://my.orq.ai``).
+* ``ORQ_WORKSPACE_SLUG`` / ``ORQ_WORKSPACE`` — workspace slug for the URL path.
+  When neither is set the buttons are hidden (the URL builders return ``None``),
+  so we never render a broken link.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import quote
+
+from evaluatorq.common.reports import esc
+
+_DEFAULT_UI_BASE = 'https://my.orq.ai'
+
+
+def ui_base_url() -> str:
+    """Return the Orq UI base URL (no trailing slash)."""
+    base = os.environ.get('ORQ_UI_BASE_URL') or os.environ.get('ORQ_BASE_URL') or _DEFAULT_UI_BASE
+    return base.rstrip('/')
+
+
+def workspace_slug() -> str | None:
+    """Return the configured workspace slug, or ``None`` when unset."""
+    slug = os.environ.get('ORQ_WORKSPACE_SLUG') or os.environ.get('ORQ_WORKSPACE') or ''
+    slug = slug.strip().strip('/')
+    return slug or None
+
+
+def _traces_url(query: str) -> str | None:
+    slug = workspace_slug()
+    if not slug:
+        return None
+    return f'{ui_base_url()}/{quote(slug, safe="")}/traces?query={quote(query, safe="")}'
+
+
+def thread_trace_url(thread_id: str | None) -> str | None:
+    """URL that filters traces to a single conversation's thread.
+
+    Returns ``None`` when *thread_id* is empty or no workspace slug is set.
+    """
+    if not thread_id:
+        return None
+    return _traces_url(f'thread_id:is:{thread_id}')
+
+
+def run_trace_url(run_id: str | None) -> str | None:
+    """URL that filters traces to every conversation in a run.
+
+    Uses the ``contains`` operator so it matches all ``{run_id}:{seq}`` threads.
+    Returns ``None`` when *run_id* is empty or no workspace slug is set.
+    """
+    if not run_id:
+        return None
+    return _traces_url(f'thread_id:contains:{run_id}')
+
+
+def trace_link_button(url: str | None, label: str) -> str:
+    """Render a trace deep-link as a secondary button, or '' when *url* is None."""
+    if not url:
+        return ''
+    return (
+        f'<a class="btn-secondary trace-link" href="{esc(url)}" '
+        f'target="_blank" rel="noopener noreferrer">{esc(label)}</a>'
+    )

--- a/src/evaluatorq/dashboard/trace_links.py
+++ b/src/evaluatorq/dashboard/trace_links.py
@@ -70,11 +70,17 @@ def run_trace_url(run_id: str | None) -> str | None:
     return _traces_url(f'thread_id:contains:{run_id}')
 
 
-def trace_link_button(url: str | None, label: str) -> str:
-    """Render a trace deep-link as a secondary button, or '' when *url* is None."""
+def trace_link_button(url: str | None, label: str, *, onclick: str | None = None) -> str:
+    """Render a trace deep-link as a secondary button, or '' when *url* is None.
+
+    ``onclick`` is for callers that embed the button inside a ``<summary>`` and
+    need ``event.stopPropagation()`` so clicking the link doesn't toggle the
+    surrounding ``<details>``.
+    """
     if not url:
         return ''
+    onclick_attr = f' onclick="{esc(onclick)}"' if onclick else ''
     return (
         f'<a class="btn-secondary trace-link" href="{esc(url)}" '
-        f'target="_blank" rel="noopener noreferrer">{esc(label)}</a>'
+        f'target="_blank" rel="noopener noreferrer"{onclick_attr}>{esc(label)}</a>'
     )

--- a/src/evaluatorq/openresponses/target.py
+++ b/src/evaluatorq/openresponses/target.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import Self
 
 from evaluatorq.common.retry import with_retry
+from evaluatorq.common.thread_context import thread_body_param
 from evaluatorq.contracts import AgentContext, AgentResponse, AgentTarget, LLMCallConfig, Message
 from evaluatorq.openresponses.client import build_simulation_client
 from evaluatorq.openresponses.tracing import (
@@ -135,6 +136,10 @@ class OrqResponsesTarget(AgentTarget):
                 kwargs['tools'] = self.tools
             if self.instructions is not None:
                 kwargs['instructions'] = self.instructions
+            # Group multi-turn calls in Orq observability under one thread.
+            thread = thread_body_param()
+            if thread:
+                kwargs['extra_body'] = {**kwargs.get('extra_body', {}), **thread}
 
             async with with_llm_span(
                 model=self.config.model,
@@ -145,7 +150,12 @@ class OrqResponsesTarget(AgentTarget):
                 record_openresponses_request(span, kwargs)
                 coro = self._client.responses.create(**kwargs)
                 response = await (asyncio.wait_for(coro, timeout=timeout_s) if timeout_s else coro)
+                # The Orq router returns the trace id in the response body under
+                # ``telemetry.trace_id`` (absent for plain OpenAI responses).
+                trace_id = getattr(getattr(response, 'telemetry', None), 'trace_id', None)
                 record_openresponses_response(span, response)
+                if span is not None and trace_id:
+                    span.set_attribute('orq.trace_id', trace_id)
 
             agent_response = AgentResponse.from_openresponses(response)
             if not agent_response.output:
@@ -155,6 +165,8 @@ class OrqResponsesTarget(AgentTarget):
                     f'an API error or unexpected response format.'
                 )
             updates: dict[str, Any] = {'model': agent_response.model or self.config.model}
+            if trace_id:
+                updates['trace_id'] = trace_id
             if agent_response.usage is not None:
                 updates['usage'] = agent_response.usage.model_copy(update={'calls': 1})
             return agent_response.model_copy(update=updates)

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -23,6 +23,7 @@ from loguru import logger
 
 from evaluatorq import DataPoint, EvaluationResult, Job, job
 from evaluatorq.common.jury import append_jury_summary
+from evaluatorq.common.thread_context import conversation_thread
 from evaluatorq.common.tracing import set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentResponse, Message
 from evaluatorq.redteam.adaptive.attack_generator import generate_attack_prompt, generate_objective
@@ -306,6 +307,7 @@ def create_dynamic_redteam_job(
     verbosity: int = 0,
     llm_kwargs: dict[str, Any] | None = None,
     pipeline_config: LLMConfig | None = None,
+    run_id: str | None = None,
 ) -> Job:
     """Create an evaluatorq Job that runs a red-team attack.
 
@@ -342,6 +344,7 @@ def create_dynamic_redteam_job(
         category = str(inputs['category'])
         vulnerability = str(inputs.get('vulnerability', ''))
         effective_max_turns = 1 if strategy.turn_type == TurnType.SINGLE else max_turns
+        thread_id = f'{run_id}:{safe_agent_key}:{_row}' if run_id else None
 
         async with (
             with_redteam_span(
@@ -400,10 +403,11 @@ def create_dynamic_redteam_job(
                             'orq.redteam.input': truncate_for_span(prompt),
                         },
                     ) as tgt_span:
-                        raw = await asyncio.wait_for(
-                            target.respond([Message(role='user', content=prompt)]),
-                            timeout=target_timeout_s,
-                        )
+                        with conversation_thread(thread_id):
+                            raw = await asyncio.wait_for(
+                                target.respond([Message(role='user', content=prompt)]),
+                                timeout=target_timeout_s,
+                            )
                         agent_resp = _coerce_to_agent_response(raw)
                         response = agent_resp.text
                         token_usage: TokenUsage | None = agent_resp.usage
@@ -482,7 +486,7 @@ def create_dynamic_redteam_job(
                 if active_progress is not None:
                     await active_progress.finish_attack(None)
 
-                return {**result_dict.model_dump(mode='json'), 'max_turns': effective_max_turns}
+                return {**result_dict.model_dump(mode='json'), 'max_turns': effective_max_turns, 'thread_id': thread_id}
 
             # Dynamic single-turn (max_turns=1) or multi-turn — orchestrator handles both
             llm_client = attack_llm_client or create_async_llm_client()
@@ -497,13 +501,15 @@ def create_dynamic_redteam_job(
             )
 
             try:
-                result = await orchestrator.run_attack(
-                    target=target,
-                    strategy=strategy,
-                    objective=objective,
-                    agent_context=agent_context,
-                    max_turns=effective_max_turns,
-                )
+                # One Orq thread per attack groups all its turns in observability.
+                with conversation_thread(thread_id):
+                    result = await orchestrator.run_attack(
+                        target=target,
+                        strategy=strategy,
+                        objective=objective,
+                        agent_context=agent_context,
+                        max_turns=effective_max_turns,
+                    )
             except asyncio.TimeoutError as e:
                 tb = traceback.format_exc(limit=8)
                 mapped_code, mapped_msg = resolved_backend.map_error(e)
@@ -559,7 +565,7 @@ def create_dynamic_redteam_job(
             if result_dict.final_response:
                 set_span_attrs(attack_span, {'output': truncate_for_span(result_dict.final_response)})
             _set_attack_span_attrs(attack_span, result_dict)
-            return {**result_dict.model_dump(mode='json'), 'max_turns': effective_max_turns}
+            return {**result_dict.model_dump(mode='json'), 'max_turns': effective_max_turns, 'thread_id': thread_id}
 
     return dynamic_job
 

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -23,7 +23,7 @@ from loguru import logger
 
 from evaluatorq import DataPoint, EvaluationResult, Job, job
 from evaluatorq.common.jury import append_jury_summary
-from evaluatorq.common.thread_context import conversation_thread
+from evaluatorq.common.thread_context import build_thread_id, conversation_thread
 from evaluatorq.common.tracing import set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentResponse, Message
 from evaluatorq.redteam.adaptive.attack_generator import generate_attack_prompt, generate_objective
@@ -344,7 +344,7 @@ def create_dynamic_redteam_job(
         category = str(inputs['category'])
         vulnerability = str(inputs.get('vulnerability', ''))
         effective_max_turns = 1 if strategy.turn_type == TurnType.SINGLE else max_turns
-        thread_id = f'{run_id}:{safe_agent_key}:{_row}' if run_id else None
+        thread_id = build_thread_id(run_id, safe_agent_key, _row)
 
         async with (
             with_redteam_span(
@@ -403,7 +403,7 @@ def create_dynamic_redteam_job(
                             'orq.redteam.input': truncate_for_span(prompt),
                         },
                     ) as tgt_span:
-                        with conversation_thread(thread_id):
+                        with conversation_thread(thread_id) as thread_id:
                             raw = await asyncio.wait_for(
                                 target.respond([Message(role='user', content=prompt)]),
                                 timeout=target_timeout_s,
@@ -502,7 +502,7 @@ def create_dynamic_redteam_job(
 
             try:
                 # One Orq thread per attack groups all its turns in observability.
-                with conversation_thread(thread_id):
+                with conversation_thread(thread_id) as thread_id:
                     result = await orchestrator.run_attack(
                         target=target,
                         strategy=strategy,

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -43,6 +43,7 @@ def _get_orq_server_url() -> str:
     return url.rstrip('/').removesuffix('/v3/router')
 
 
+from evaluatorq.common.thread_context import thread_body_param
 from evaluatorq.common.tracing import record_token_usage, set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentTarget, Message, content_to_text
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
@@ -248,6 +249,10 @@ class ORQAgentTarget(AgentTarget):
                     kwargs['task_id'] = self._task_id
                 if self.memory_entity_id:
                     kwargs['memory'] = {'entity_id': self.memory_entity_id}
+                # Named thread for Orq observability (selectable on traces); the
+                # task_id already threads server-side state, thread groups the
+                # turns under one id in the Threads tab.
+                kwargs.update(thread_body_param())
 
                 response = await asyncio.to_thread(self.orq_client.agents.responses.create, **kwargs)
 
@@ -287,6 +292,7 @@ class ORQAgentTarget(AgentTarget):
                         message={'role': 'tool', 'parts': tool_parts},
                         task_id=self._task_id,
                         background=False,
+                        **thread_body_param(),
                     )
                     if response.task_id:
                         self._task_id = response.task_id
@@ -307,6 +313,12 @@ class ORQAgentTarget(AgentTarget):
                 if response_model:
                     set_span_attrs(span, {'gen_ai.response.model': str(response_model)})
 
+                # Agents endpoint returns the root trace id in the response body
+                # (telemetry.trace_id) rather than a header — links back to Orq.
+                trace_id = getattr(getattr(response, 'telemetry', None), 'trace_id', None)
+                if trace_id:
+                    set_span_attrs(span, {'orq.trace_id': str(trace_id)})
+
                 result_text = text_response or ''
                 set_span_attrs(
                     span,
@@ -326,6 +338,7 @@ class ORQAgentTarget(AgentTarget):
                     usage=usage,
                     model=str(response_model) if response_model else None,
                     response_id=getattr(response, 'task_id', None),
+                    trace_id=str(trace_id) if trace_id else None,
                     finish_reason=None,
                 )
 

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -1303,7 +1303,7 @@ class RedTeamResult(BaseModel):
     error_details: dict[str, Any] | None = None
     thread_id: str | None = Field(
         default=None,
-        description='Orq observability thread id ({run_id}:{index}); None for older reports.',
+        description='Orq observability thread id ({run_id}:{agent_key}:{index}); None for older reports.',
     )
 
     @property
@@ -1505,7 +1505,9 @@ class RedTeamReport(BaseModel):
     experiment_url: str | None = None
     run_id: str | None = Field(
         default=None,
-        description='Orq run id powering the dashboard "View all run traces" deep-link; None for older reports.',
+        description='Client-minted run-grouping id (uuid hex, not an Orq-side run/experiment id) '
+        'shared by every attack\'s thread_id; powers the dashboard "View all run traces" '
+        'deep-link. None for older reports.',
     )
 
     @field_validator('pipeline', mode='before')

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -1247,6 +1247,7 @@ class JobOutputPayload(BaseModel):
     error_turn: int | None = None
     truncated_turns: list[int] = Field(default_factory=list)
     finish_reason: str | None = None
+    thread_id: str | None = None
 
     @property
     def response_text(self) -> str:
@@ -1300,6 +1301,10 @@ class RedTeamResult(BaseModel):
     error_stage: str | None = None
     error_code: str | None = None
     error_details: dict[str, Any] | None = None
+    thread_id: str | None = Field(
+        default=None,
+        description='Orq observability thread id ({run_id}:{index}); None for older reports.',
+    )
 
     @property
     def error_info(self) -> 'RunError | None':
@@ -1498,6 +1503,10 @@ class RedTeamReport(BaseModel):
     duration_seconds: float | None = None
     pipeline_warnings: list[str] = Field(default_factory=list)
     experiment_url: str | None = None
+    run_id: str | None = Field(
+        default=None,
+        description='Orq run id powering the dashboard "View all run traces" deep-link; None for older reports.',
+    )
 
     @field_validator('pipeline', mode='before')
     @classmethod

--- a/src/evaluatorq/redteam/reports/converters.py
+++ b/src/evaluatorq/redteam/reports/converters.py
@@ -391,6 +391,7 @@ def dynamic_evaluatorq_results_to_report(
     duration_seconds: float | None = None,
     description: str | None = None,
     categories_tested: list[str] | None = None,  # deprecated, derived from results
+    run_id: str | None = None,
 ) -> RedTeamReport:
     """Convert evaluatorq dynamic results to a unified RedTeamReport."""
     unified: list[RedTeamResult] = []
@@ -517,6 +518,7 @@ def dynamic_evaluatorq_results_to_report(
                 error_stage=error_stage,
                 error_code=error_code,
                 error_details=error_details,
+                thread_id=job_output.thread_id,
             )
         )
 
@@ -543,6 +545,7 @@ def dynamic_evaluatorq_results_to_report(
         results=unified,
         summary=summary,
         duration_seconds=duration_seconds,
+        run_id=run_id,
     )
 
 
@@ -1126,4 +1129,5 @@ def merge_reports(
         agent_contexts=merged_agent_contexts,
         results=all_results,
         summary=summary,
+        run_id=next((r.run_id for r in reports if r.run_id), None),
     )

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import os
 import re
+import uuid
 import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -1077,6 +1078,7 @@ async def _prepare_target(
     pipeline_config: LLMConfig | None = None,
     resolved_strategy_names: set[str] | None = None,
     resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
+    run_id: str | None = None,
 ) -> PreparedTarget:
     """Prepare all per-target state for a dynamic or hybrid run.
 
@@ -1207,6 +1209,7 @@ async def _prepare_target(
         attacker_instructions=attacker_instructions,
         verbosity=verbosity,
         pipeline_config=pipeline_config,
+        run_id=run_id,
     )
 
     # --- Mode-specific path ---------------------------------------------------
@@ -1379,6 +1382,10 @@ async def _run_dynamic_or_hybrid(
     )
 
     resolved_name = name or 'red-team'
+
+    # One Orq observability run id shared across every target/attack in this run,
+    # so the dashboard "View all run traces" deep-link spans the whole invocation.
+    run_id = uuid.uuid4().hex
 
     resolved_hooks: PipelineHooks = hooks or DefaultHooks()
     pipeline_start = datetime.now(tz=timezone.utc).astimezone()
@@ -1734,6 +1741,7 @@ async def _run_dynamic_or_hybrid(
             pipeline_config=pipeline_config,
             resolved_strategy_names=resolved_strategy_names,
             resolved_delivery_methods=resolved_delivery_methods,
+            run_id=run_id,
         )
 
         prepared_targets: list[PreparedTarget]
@@ -1810,6 +1818,7 @@ async def _run_dynamic_or_hybrid(
                     attacker_instructions=attacker_instructions,
                     verbosity=verbosity,
                     pipeline_config=pipeline_config,
+                    run_id=run_id,
                 )
 
                 at_safe = _make_safe_target(at_label)
@@ -2155,6 +2164,7 @@ async def _run_dynamic_or_hybrid(
                         results=dynamic_results,
                         duration_seconds=pipeline_duration,
                         description=f'{description or "Hybrid"} ({pt.target}) (dynamic)',
+                        run_id=run_id,
                     )
                     target_sub_reports.append(dyn_report)
 
@@ -2188,6 +2198,7 @@ async def _run_dynamic_or_hybrid(
                         results=target_results,
                         duration_seconds=pipeline_duration,
                         description=f'{description or "Dynamic red teaming"} ({pt.target})',
+                        run_id=run_id,
                     )
                 else:
                     t_report = static_results_to_report(

--- a/src/evaluatorq/simulation/agents/base.py
+++ b/src/evaluatorq/simulation/agents/base.py
@@ -17,6 +17,7 @@ from openai import BadRequestError
 
 from evaluatorq.common.llm_call import execute_chat_completion
 from evaluatorq.common.retry import with_retry
+from evaluatorq.common.thread_context import thread_body_param
 from evaluatorq.common.tracing import get_trace_context_headers, record_llm_input, record_llm_response
 from evaluatorq.contracts import (
     AgentResponse,
@@ -380,6 +381,9 @@ class BaseAgent(ABC):
                 call_kwargs: dict[str, Any] = dict(params)
                 if trace_headers:
                     call_kwargs['extra_headers'] = trace_headers
+                thread = thread_body_param()
+                if thread:
+                    call_kwargs['extra_body'] = {**call_kwargs.get('extra_body', {}), **thread}
                 try:
                     response = await asyncio.wait_for(
                         self._client.responses.create(**call_kwargs),

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -597,6 +597,11 @@ async def _simulate_core(
 
     target_callback_resolved, target_agent, target_kind_hint = _resolve_target(target, target_callback)
 
+    # One run id per run; each conversation's Orq thread id is f"{run_id}:{index}".
+    # Persisted on SimulationRun / SimulationResult so the dashboard can deep-link
+    # to the run's (or a single conversation's) traces in Orq observability.
+    run_id = uuid.uuid4().hex
+
     sim_datapoints = await _resolve_or_generate_datapoints(
         caller=caller,
         datapoints=datapoints,
@@ -677,6 +682,7 @@ async def _simulate_core(
             exit_on_failure=exit_on_failure,
             pipeline_span=pipeline_span,
             hooks=resolved_hooks,
+            run_id=run_id,
         )
         # Fire on_evaluator_complete here — AFTER results is assigned and
         # OUTSIDE evaluatorq's per-scorer try/except — so an unguarded hook
@@ -723,6 +729,7 @@ async def _simulate_core(
                 agent_info=agent_info,
                 evaluator_names=resolved_evaluator_names,
                 results=results,
+                run_id=run_id,
             )
             if run_output is not None:
                 write_report(run, Path(run_output))
@@ -942,6 +949,7 @@ def _build_simulation_job_and_cache(
     judge: BaseAgent | None,
     generation_client: AsyncOpenAI | None,
     hooks: SimulationHooks | None,
+    run_id: str | None = None,
 ) -> tuple[
     Callable[[DataPoint, int], Awaitable[dict[str, Any]]],
     dict[int, SimulationResult],
@@ -1008,7 +1016,11 @@ def _build_simulation_job_and_cache(
             await await_maybe(resolved_hooks.on_datapoint_error(sim_dp, start_err))
             await await_maybe(resolved_hooks.on_datapoint_complete(err))
             raise
-        result = await runner.run(datapoint=sim_dp, max_turns=max_turns)
+        # Deterministic, run-scoped thread id groups this conversation's turns in
+        # Orq observability and powers the dashboard's per-conversation deep link.
+        # _row is the datapoint's index (stable across the run).
+        thread_id = f'{run_id}:{_row}' if run_id else None
+        result = await runner.run(datapoint=sim_dp, max_turns=max_turns, thread_id=thread_id)
         result.metadata['datapoint_id'] = sim_dp.id
         result_cache[id(data)] = result
         if result.terminated_by in (TerminatedBy.error, TerminatedBy.timeout):
@@ -1086,6 +1098,7 @@ async def _simulate_via_evaluatorq(
     exit_on_failure: bool,
     pipeline_span: Span | None,
     hooks: SimulationHooks,
+    run_id: str | None = None,
 ) -> list[SimulationResult]:
     """Wrap simulation Datapoints as evaluatorq DataPoints and run."""
     from datetime import datetime, timezone
@@ -1115,6 +1128,7 @@ async def _simulate_via_evaluatorq(
         judge=judge,
         generation_client=generation_client,
         hooks=hooks,
+        run_id=run_id,
     )
 
     evaluators = [_adapt_simulation_scorer(name, fn, result_cache) for name, fn in scorers]

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from evaluatorq.common.llm_client import resolve_results_base_url
+from evaluatorq.common.thread_context import build_thread_id
 from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, DEFAULT_MODEL
 from evaluatorq.simulation.utils.run_store import auto_save_run, build_simulation_run, fetch_agent_info, write_report
 
@@ -1019,7 +1020,7 @@ def _build_simulation_job_and_cache(
         # Deterministic, run-scoped thread id groups this conversation's turns in
         # Orq observability and powers the dashboard's per-conversation deep link.
         # _row is the datapoint's index (stable across the run).
-        thread_id = f'{run_id}:{_row}' if run_id else None
+        thread_id = build_thread_id(run_id, _row)
         result = await runner.run(datapoint=sim_dp, max_turns=max_turns, thread_id=thread_id)
         result.metadata['datapoint_id'] = sim_dp.id
         result_cache[id(data)] = result

--- a/src/evaluatorq/simulation/reports/sections.py
+++ b/src/evaluatorq/simulation/reports/sections.py
@@ -390,6 +390,7 @@ def individual_entries(results: list[SimulationResult]) -> list[SimulationEntry]
                 error=_error_message(r),
                 evaluator_scores=_evaluator_scores(r),
                 transcript=[TranscriptMessage(role=m.role, content=coerce_content_text(m.content)) for m in r.messages],
+                thread_id=r.thread_id,
             )
         )
     return entries

--- a/src/evaluatorq/simulation/runner/simulation.py
+++ b/src/evaluatorq/simulation/runner/simulation.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from evaluatorq.common.async_utils import await_maybe
+from evaluatorq.common.thread_context import conversation_thread
 from evaluatorq.common.tracing import record_llm_input, record_llm_output, record_token_usage, set_span_attrs
 from evaluatorq.contracts import TokenUsage
 from evaluatorq.simulation.agents.judge import JudgeAgent, JudgeAgentConfig
@@ -310,8 +311,15 @@ class SimulationRunner:
         datapoint: SimulationDatapoint | None = None,
         max_turns: int | None = None,
         first_message: str | None = None,
+        thread_id: str | None = None,
     ) -> SimulationResult:
-        """Run a single simulation. Never throws -- returns error SimulationResult on failure."""
+        """Run a single simulation. Never throws -- returns error SimulationResult on failure.
+
+        ``thread_id`` binds a deterministic, run-scoped Orq observability thread id
+        (``f"{run_id}:{index}"``) so every turn of this conversation groups under one
+        id in Orq. When ``None`` a fresh uuid is minted. The resolved id is stamped
+        onto the returned :class:`SimulationResult` so the dashboard can deep-link to it.
+        """
         # Resolve datapoint
         if datapoint:
             persona = datapoint.persona
@@ -332,55 +340,67 @@ class SimulationRunner:
         # Holder so the outer except can read partial token usage from agents
         # created inside _run_inner (mirrors TS getTotalUsage closure).
         usage_holder: dict[str, Callable[[], TokenUsage]] = {}
+        # Captured for the error path below (out of the `with` scope), so error
+        # results still carry the thread id for the dashboard deep-link.
+        bound_thread_id: str | None = None
 
         try:
-            async with with_simulation_span(
-                'orq.simulation.run',
-                {
-                    'orq.simulation.persona': persona.name if persona else None,
-                    'orq.simulation.scenario': scenario.name if scenario else None,
-                    'orq.simulation.max_turns': effective_max_turns,
-                    'orq.simulation.model': self._model,
-                },
-            ) as run_span:
-                try:
-                    return await self._run_inner(
-                        persona=persona,
-                        scenario=scenario,
-                        datapoint_id=datapoint_id,
-                        first_message=first_message,
-                        effective_max_turns=effective_max_turns,
-                        messages=messages,
-                        turn_metrics_list=turn_metrics_list,
-                        run_span=run_span,
-                        usage_holder=usage_holder,
-                    )
-                except BaseException:
-                    get_total_usage = usage_holder.get('get_total_usage')
+            # One Orq thread per simulation groups all its turns (target + user
+            # simulator + judge) under one id in Orq observability. ContextVar
+            # scoping keeps concurrent datapoints isolated. A run-scoped thread_id
+            # (f"{run_id}:{index}") is passed in when available; else one is minted.
+            with conversation_thread(thread_id) as thread_id:
+                bound_thread_id = thread_id
+                async with with_simulation_span(
+                    'orq.simulation.run',
+                    {
+                        'orq.simulation.persona': persona.name if persona else None,
+                        'orq.simulation.scenario': scenario.name if scenario else None,
+                        'orq.simulation.max_turns': effective_max_turns,
+                        'orq.simulation.model': self._model,
+                        'orq.thread_id': thread_id,
+                    },
+                ) as run_span:
                     try:
-                        usage = get_total_usage() if get_total_usage else ZERO_USAGE.model_copy()
-                    except Exception as usage_err:
-                        logger.error(
-                            'Failed to collect token usage during error path: %s',
-                            usage_err,
-                            exc_info=True,
+                        result = await self._run_inner(
+                            persona=persona,
+                            scenario=scenario,
+                            datapoint_id=datapoint_id,
+                            first_message=first_message,
+                            effective_max_turns=effective_max_turns,
+                            messages=messages,
+                            turn_metrics_list=turn_metrics_list,
+                            run_span=run_span,
+                            usage_holder=usage_holder,
                         )
-                        usage = ZERO_USAGE.model_copy()
-                    record_token_usage(
-                        run_span,
-                        prompt_tokens=usage.prompt_tokens,
-                        completion_tokens=usage.completion_tokens,
-                        total_tokens=usage.total_tokens,
-                    )
-                    set_span_attrs(
-                        run_span,
-                        {
-                            'orq.simulation.terminated_by': 'error',
-                            'orq.simulation.goal_achieved': False,
-                            'orq.simulation.turn_count': sum(1 for m in messages if m.role == 'assistant'),
-                        },
-                    )
-                    raise
+                        result.thread_id = thread_id
+                        return result
+                    except BaseException:
+                        get_total_usage = usage_holder.get('get_total_usage')
+                        try:
+                            usage = get_total_usage() if get_total_usage else ZERO_USAGE.model_copy()
+                        except Exception as usage_err:
+                            logger.error(
+                                'Failed to collect token usage during error path: %s',
+                                usage_err,
+                                exc_info=True,
+                            )
+                            usage = ZERO_USAGE.model_copy()
+                        record_token_usage(
+                            run_span,
+                            prompt_tokens=usage.prompt_tokens,
+                            completion_tokens=usage.completion_tokens,
+                            total_tokens=usage.total_tokens,
+                        )
+                        set_span_attrs(
+                            run_span,
+                            {
+                                'orq.simulation.terminated_by': 'error',
+                                'orq.simulation.goal_achieved': False,
+                                'orq.simulation.turn_count': sum(1 for m in messages if m.role == 'assistant'),
+                            },
+                        )
+                        raise
         except Exception as e:
             logger.error('SimulationRunner.run() failed: %s', e, exc_info=True)
             error_msg = str(e)
@@ -401,6 +421,7 @@ class SimulationRunner:
             result.turn_count = sum(1 for m in messages if m.role == 'assistant')
             result.turn_metrics = turn_metrics_list
             result.token_usage = usage
+            result.thread_id = bound_thread_id
             return result
 
     async def _run_inner(

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -310,6 +310,11 @@ class SimulationResult(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     criteria_results: dict[str, bool] | None = None
     total_turns: int | None = None
+    thread_id: str | None = Field(
+        default=None,
+        description='Orq observability thread id for this conversation (deterministic: f"{run_id}:{index}"). '
+        'None for runs saved before thread grouping existed.',
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +360,9 @@ class SimulationRun(BaseModel):
     total_results: int
     scorer_averages: dict[str, float]
     results: list[SimulationResult]
+    run_id: str | None = None
+    """Run-scoped Orq id shared by every conversation's ``thread_id`` (``{run_id}:{index}``).
+    Powers the dashboard's 'View all run traces' deep link. None for older runs."""
 
 
 # ---------------------------------------------------------------------------
@@ -408,3 +416,4 @@ class SimulationEntry(BaseModel):
     error: str | None
     evaluator_scores: dict[str, float]
     transcript: list[TranscriptMessage]
+    thread_id: str | None = None

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -361,8 +361,9 @@ class SimulationRun(BaseModel):
     scorer_averages: dict[str, float]
     results: list[SimulationResult]
     run_id: str | None = None
-    """Run-scoped Orq id shared by every conversation's ``thread_id`` (``{run_id}:{index}``).
-    Powers the dashboard's 'View all run traces' deep link. None for older runs."""
+    """Client-minted run-grouping id (uuid hex, not an Orq-side run id) shared by every
+    conversation's ``thread_id`` (``{run_id}:{index}``). Powers the dashboard's
+    'View all run traces' deep link. None for older runs."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -113,6 +113,7 @@ def build_simulation_run(
     target_model: str | None = None,
     max_turns: int | None = None,
     agent_info: dict[str, Any] | None = None,
+    run_id: str | None = None,
 ) -> SimulationRun:
     """Build the full ``SimulationRun`` report model from results.
 
@@ -142,6 +143,7 @@ def build_simulation_run(
         target_model=target_model,
         max_turns=max_turns,
         agent_info=agent_info,
+        run_id=run_id,
         evaluator_names=evaluator_names,
         total_results=len(results),
         scorer_averages=scorer_averages,

--- a/tests/integration/test_sim_redteam_target_roundtrip.py
+++ b/tests/integration/test_sim_redteam_target_roundtrip.py
@@ -28,10 +28,13 @@ def _make_response(text: str) -> MagicMock:
     usage = MagicMock()
     usage.input_tokens = 5
     usage.output_tokens = 3
+    telemetry = MagicMock()
+    telemetry.trace_id = None
     response = MagicMock()
     response.id = "resp"
     response.usage = usage
     response.output = [msg_item]
+    response.telemetry = telemetry
     return response
 
 

--- a/tests/redteam/test_dynamic_job.py
+++ b/tests/redteam/test_dynamic_job.py
@@ -319,6 +319,55 @@ class TestTemplateSingleTurnPath:
         assert parsed.n_turns == 1
         assert parsed.error is None
 
+    @pytest.mark.asyncio
+    @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
+    @patch(_PATCH_SET_SPAN_ATTRS)
+    @patch(_PATCH_ATTACK_SPAN_ATTRS)
+    async def test_thread_id_flows_from_run_id_to_result_and_report(
+        self, _attrs, _set_attrs, _span
+    ):
+        """run_id -> job dict thread_id -> JobOutputPayload -> RedTeamResult, and
+        run_id -> RedTeamReport."""
+        from evaluatorq.redteam.adaptive.pipeline import create_dynamic_redteam_job
+        from evaluatorq.redteam.contracts import RedTeamReport, RedTeamResult
+        from evaluatorq.redteam.reports.converters import _coerce_job_output_payload
+
+        strategy = _make_strategy(
+            turn_type=TurnType.SINGLE,
+            prompt_template="Static attack prompt for {agent_name}.",
+        )
+        target = _make_target()
+        factory = _make_target_factory(target)
+        agent_context = _make_agent_context()
+        datapoint = _make_datapoint(strategy=strategy)
+
+        job_fn = create_dynamic_redteam_job(
+            agent_key="test-agent",
+            agent_context=agent_context,
+            backend=factory,
+            run_id="abc123",
+        )
+
+        with patch(
+            "evaluatorq.redteam.adaptive.orchestrator._get_active_progress",
+            return_value=None,
+        ):
+            output = await _call_dynamic_job(job_fn, datapoint, row=7)
+
+        # job dict -> JobOutputPayload survives coercion
+        assert output["thread_id"] == "abc123:test-agent:7"
+        payload = _coerce_job_output_payload(output)
+        assert payload.thread_id == "abc123:test-agent:7"
+
+        # thread_id lands on RedTeamResult; run_id lands on RedTeamReport
+        result = RedTeamResult.model_construct(thread_id=payload.thread_id)
+        assert result.thread_id == "abc123:test-agent:7"
+        assert result.model_dump()["thread_id"] == "abc123:test-agent:7"
+
+        report = RedTeamReport.model_construct(run_id="abc123")
+        assert report.run_id == "abc123"
+        assert report.model_dump()["run_id"] == "abc123"
+
 
 # ===========================================================================
 # 2. Dynamic multi-turn path (orchestrator used)

--- a/tests/redteam/test_orq_agent_target_respond.py
+++ b/tests/redteam/test_orq_agent_target_respond.py
@@ -18,7 +18,9 @@ from evaluatorq.contracts import AgentResponse, Message
 from evaluatorq.redteam.backends.orq import ORQAgentTarget
 
 
-def _make_orq_response(text: str = "ok", task_id: str = "task-1") -> MagicMock:
+def _make_orq_response(
+    text: str = "ok", task_id: str = "task-1", trace_id: str | None = None
+) -> MagicMock:
     usage = MagicMock()
     usage.prompt_tokens = 5
     usage.completion_tokens = 3
@@ -34,6 +36,10 @@ def _make_orq_response(text: str = "ok", task_id: str = "task-1") -> MagicMock:
     response.output = [item]
     response.pending_tool_calls = []
     response.model = None
+    # The agents endpoint returns the root trace id in the body under telemetry.
+    telemetry = MagicMock()
+    telemetry.trace_id = trace_id
+    response.telemetry = telemetry
     return response
 
 
@@ -87,6 +93,65 @@ async def test_respond_forwards_only_last_user_message():
         "role": "user",
         "parts": [{"kind": "text", "text": "LATEST USER"}],
     }
+
+
+@pytest.mark.asyncio
+async def test_respond_captures_trace_id_from_telemetry():
+    """The agents endpoint returns the trace id in the body (telemetry.trace_id);
+    respond must surface it on AgentResponse.trace_id so it links back to Orq."""
+    target = ORQAgentTarget(agent_key="a", orq_client=MagicMock())
+
+    async def fake_to_thread(fn: Any, **kwargs: Any) -> Any:
+        return _make_orq_response(trace_id="trace-xyz-789")
+
+    with (
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+        patch("evaluatorq.redteam.tracing.get_tracer", return_value=None),
+    ):
+        result = await target.respond([Message(role="user", content="hi")])
+
+    assert result.trace_id == "trace-xyz-789"
+
+
+@pytest.mark.asyncio
+async def test_respond_sends_thread_param_when_conversation_active():
+    """Inside a conversation_thread, respond puts thread={'id': ...} into the SDK
+    kwargs so the agent turns group under one Orq thread."""
+    from evaluatorq.common.thread_context import conversation_thread
+
+    target = ORQAgentTarget(agent_key="a", orq_client=MagicMock())
+    captured: dict[str, Any] = {}
+
+    async def fake_to_thread(fn: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_orq_response()
+
+    with (
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+        patch("evaluatorq.redteam.tracing.get_tracer", return_value=None),
+        conversation_thread("thread-abc"),
+    ):
+        await target.respond([Message(role="user", content="hi")])
+
+    assert captured["thread"] == {"id": "thread-abc"}
+
+
+@pytest.mark.asyncio
+async def test_respond_omits_thread_param_when_no_conversation():
+    target = ORQAgentTarget(agent_key="a", orq_client=MagicMock())
+    captured: dict[str, Any] = {}
+
+    async def fake_to_thread(fn: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_orq_response()
+
+    with (
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+        patch("evaluatorq.redteam.tracing.get_tracer", return_value=None),
+    ):
+        await target.respond([Message(role="user", content="hi")])
+
+    assert "thread" not in captured
 
 
 def test_send_prompt_shim_removed():

--- a/tests/simulation/reports/test_individual_entries.py
+++ b/tests/simulation/reports/test_individual_entries.py
@@ -37,6 +37,7 @@ EXPECTED_KEY_ORDER = [
     'error',
     'evaluator_scores',
     'transcript',
+    'thread_id',
 ]
 
 EXPECTED_CRITERIA_KEY_ORDER = ['id', 'description', 'type', 'passed', 'safety']

--- a/tests/simulation/test_hooks.py
+++ b/tests/simulation/test_hooks.py
@@ -676,7 +676,7 @@ async def test_on_run_complete_gets_partial_results_when_a_row_is_dropped(datapo
             turn_metrics=[],
         )
 
-    async def fake_run(self, *, datapoint, max_turns):
+    async def fake_run(self, *, datapoint, max_turns, thread_id=None):
         # 'dp-bad' raises uncaught so its job is recorded with no cached result
         # (a dropped row); 'dp-good' returns a real result.
         if datapoint.id == 'dp-bad':

--- a/tests/simulation/test_orq_responses_target.py
+++ b/tests/simulation/test_orq_responses_target.py
@@ -36,6 +36,7 @@ def _make_response(
     response_id: str = "resp-123",
     input_tokens: int = 10,
     output_tokens: int = 5,
+    trace_id: str | None = None,
 ) -> MagicMock:
     """Build a mock Responses API response object."""
     usage = MagicMock()
@@ -50,10 +51,14 @@ def _make_response(
     msg_item.type = "message"
     msg_item.content = [part]
 
+    telemetry = MagicMock()
+    telemetry.trace_id = trace_id
+
     response = MagicMock()
     response.id = response_id
     response.usage = usage
     response.output = [msg_item]
+    response.telemetry = telemetry
     return response
 
 
@@ -109,6 +114,42 @@ class TestOrqResponsesTargetRespond:
 
         assert isinstance(result, AgentResponse)
         assert result.text == "world"
+
+    @pytest.mark.asyncio
+    async def test_respond_captures_trace_id_from_body(self):
+        client = _make_client()
+        client.responses.create = AsyncMock(
+            return_value=_make_response(text="world", trace_id="trace-abc123")
+        )
+        target = _make_target(client=client)
+
+        result = await target.respond(_make_messages())
+
+        assert result.trace_id == "trace-abc123"
+
+    @pytest.mark.asyncio
+    async def test_respond_sends_thread_param_when_conversation_active(self):
+        from evaluatorq.common.thread_context import conversation_thread
+
+        client = _make_client()
+        client.responses.create = AsyncMock(return_value=_make_response())
+        target = _make_target(client=client)
+
+        with conversation_thread("thread-xyz"):
+            await target.respond(_make_messages())
+
+        call_kwargs = client.responses.create.call_args.kwargs
+        assert call_kwargs["extra_body"]["thread"] == {"id": "thread-xyz"}
+
+    @pytest.mark.asyncio
+    async def test_respond_omits_thread_param_when_no_conversation(self):
+        client = _make_client()
+        client.responses.create = AsyncMock(return_value=_make_response())
+        target = _make_target(client=client)
+
+        await target.respond(_make_messages())
+
+        assert "extra_body" not in client.responses.create.call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_respond_passes_full_message_list_as_input(self):

--- a/tests/unit/test_thread_context.py
+++ b/tests/unit/test_thread_context.py
@@ -1,0 +1,54 @@
+"""Thread-context ContextVar isolation — the load-bearing property is that
+concurrent conversations (asyncio tasks) don't leak thread ids into each other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from evaluatorq.common.thread_context import (
+    conversation_thread,
+    current_thread_id,
+    thread_body_param,
+)
+
+
+def test_unset_is_none_and_empty() -> None:
+    assert current_thread_id() is None
+    assert thread_body_param() == {}
+
+
+def test_bind_and_restore() -> None:
+    with conversation_thread('t1') as tid:
+        assert tid == 't1'
+        assert current_thread_id() == 't1'
+        assert thread_body_param() == {'thread': {'id': 't1'}}
+    assert current_thread_id() is None  # restored on exit
+
+
+def test_generated_id_when_omitted() -> None:
+    with conversation_thread() as tid:
+        assert tid and current_thread_id() == tid
+
+
+def test_concurrent_tasks_are_isolated() -> None:
+    async def convo(name: str, seen: dict[str, str | None]) -> None:
+        with conversation_thread(name):
+            await asyncio.sleep(0.01)  # yield so tasks interleave
+            seen[name] = current_thread_id()
+
+    async def main() -> dict[str, str | None]:
+        seen: dict[str, str | None] = {}
+        await asyncio.gather(*(convo(f't{i}', seen) for i in range(5)))
+        return seen
+
+    seen = asyncio.run(main())
+    assert seen == {f't{i}': f't{i}' for i in range(5)}
+
+
+if __name__ == '__main__':
+    test_unset_is_none_and_empty()
+    test_bind_and_restore()
+    test_generated_id_when_omitted()
+    test_concurrent_tasks_are_isolated()
+    print('ok')

--- a/tests/unit/test_thread_context.py
+++ b/tests/unit/test_thread_context.py
@@ -7,10 +7,25 @@ from __future__ import annotations
 import asyncio
 
 from evaluatorq.common.thread_context import (
+    build_thread_id,
     conversation_thread,
     current_thread_id,
     thread_body_param,
 )
+
+
+def test_build_thread_id_sim_and_redteam_shapes() -> None:
+    # Sim: {run_id}:{index}; redteam: {run_id}:{agent_key}:{index}. Both share the
+    # run_id prefix so `contains:{run_id}` matches every conversation in the run.
+    assert build_thread_id('run1', 3) == 'run1:3'
+    assert build_thread_id('run1', 'agent-a', 7) == 'run1:agent-a:7'
+    assert build_thread_id('run1', 3).startswith('run1')
+    assert build_thread_id('run1', 'agent-a', 7).startswith('run1')
+
+
+def test_build_thread_id_none_without_run() -> None:
+    assert build_thread_id(None, 3) is None
+    assert build_thread_id('', 3) is None
 
 
 def test_unset_is_none_and_empty() -> None:

--- a/tests/unit/test_thread_context.py
+++ b/tests/unit/test_thread_context.py
@@ -19,8 +19,10 @@ def test_build_thread_id_sim_and_redteam_shapes() -> None:
     # run_id prefix so `contains:{run_id}` matches every conversation in the run.
     assert build_thread_id('run1', 3) == 'run1:3'
     assert build_thread_id('run1', 'agent-a', 7) == 'run1:agent-a:7'
-    assert build_thread_id('run1', 3).startswith('run1')
-    assert build_thread_id('run1', 'agent-a', 7).startswith('run1')
+    sim_thread_id = build_thread_id('run1', 3)
+    redteam_thread_id = build_thread_id('run1', 'agent-a', 7)
+    assert sim_thread_id is not None and sim_thread_id.startswith('run1')
+    assert redteam_thread_id is not None and redteam_thread_id.startswith('run1')
 
 
 def test_build_thread_id_none_without_run() -> None:

--- a/tests/unit/test_trace_buttons.py
+++ b/tests/unit/test_trace_buttons.py
@@ -1,0 +1,150 @@
+"""Dashboard trace-link buttons — the three remaining insertions
+(``_sim_hero``, ``_redteam_hero``, ``redteam_transcripts._render_result_detail``).
+
+Confirms the deep-link anchor appears in real rendered HTML when
+``ORQ_WORKSPACE_SLUG`` is configured, and is absent when it isn't (so
+older reports without ids, or unconfigured deployments, render fine).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from evaluatorq.dashboard.redteam_transcripts import _render_result_detail
+from evaluatorq.dashboard.report_tabs import _redteam_hero, _sim_hero
+from evaluatorq.dashboard.trace_links import run_trace_url, thread_trace_url, trace_link_button
+from evaluatorq.redteam.contracts import (
+    AgentInfo,
+    AttackInfo,
+    AttackTechnique,
+    DeliveryMethod,
+    Framework,
+    Pipeline,
+    RedTeamReport,
+    RedTeamResult,
+    Severity,
+    TurnType,
+    UnifiedEvaluationResult,
+)
+from evaluatorq.redteam.reports.converters import compute_report_summary
+from evaluatorq.simulation.types import SimulationRun
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ('ORQ_UI_BASE_URL', 'ORQ_BASE_URL', 'ORQ_WORKSPACE_SLUG', 'ORQ_WORKSPACE'):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_run(run_id: str | None) -> SimulationRun:
+    return SimulationRun(
+        run_name='test-run',
+        created_at=datetime.now(tz=timezone.utc),
+        mode='run',
+        target_kind='openai_model',
+        evaluator_names=[],
+        total_results=0,
+        scorer_averages={},
+        results=[],
+        run_id=run_id,
+    )
+
+
+def _make_result(thread_id: str | None) -> RedTeamResult:
+    return RedTeamResult(
+        attack=AttackInfo(
+            id='ASI01-test-001',
+            category='ASI01',
+            framework=Framework.OWASP_ASI,
+            attack_technique=AttackTechnique.INDIRECT_INJECTION,
+            delivery_methods=[DeliveryMethod.DIRECT_REQUEST],
+            turn_type=TurnType.SINGLE,
+            severity=Severity.MEDIUM,
+            source='test',
+        ),
+        agent=AgentInfo(key='agent-a'),
+        messages=[],
+        vulnerable=False,
+        evaluation=UnifiedEvaluationResult(passed=True, explanation='test'),
+        thread_id=thread_id,
+    )
+
+
+def _make_report(run_id: str | None) -> RedTeamReport:
+    results = [_make_result('run1:0')]
+    return RedTeamReport(
+        created_at=datetime.now(tz=timezone.utc),
+        pipeline=Pipeline.DYNAMIC,
+        framework=Framework.OWASP_ASI,
+        categories_tested=['ASI01'],
+        tested_agents=['agent-a'],
+        total_results=len(results),
+        results=results,
+        summary=compute_report_summary(results),
+        run_id=run_id,
+    )
+
+
+class TestSimHeroTraceButton:
+    def test_button_absent_without_workspace_slug(self) -> None:
+        html = _sim_hero(None, _make_run('run1'))
+        assert 'trace-link' not in html
+        assert 'View all run traces' not in html
+
+    def test_button_absent_without_run_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+        html = _sim_hero(None, _make_run(None))
+        assert 'trace-link' not in html
+
+    def test_button_present_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+        html = _sim_hero(None, _make_run('run1'))
+        assert 'class="btn-secondary trace-link"' in html
+        assert 'View all run traces' in html
+        assert f'href="{run_trace_url("run1")}"' in html
+
+
+class TestRedteamHeroTraceButton:
+    def test_button_absent_without_workspace_slug(self) -> None:
+        html = _redteam_hero(None, _make_report('run1'))
+        assert 'trace-link' not in html
+
+    def test_button_present_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+        html = _redteam_hero(None, _make_report('run1'))
+        assert 'class="btn-secondary trace-link"' in html
+        assert 'View all run traces' in html
+        assert f'href="{run_trace_url("run1")}"' in html
+
+
+class TestRedteamConversationTraceButton:
+    def test_button_absent_without_workspace_slug(self) -> None:
+        html = _render_result_detail(_make_result('run1:0'))
+        assert 'trace-link' not in html
+
+    def test_button_absent_without_thread_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+        html = _render_result_detail(_make_result(None))
+        assert 'trace-link' not in html
+
+    def test_button_present_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+        html = _render_result_detail(_make_result('run1:0'))
+        assert 'class="btn-secondary trace-link"' in html
+        assert 'View conversation traces' in html
+        assert f'href="{thread_trace_url("run1:0")}"' in html
+
+
+def test_button_helper_smoke() -> None:
+    # Sanity: trace_link_button itself is exercised transitively above; this
+    # locks in the '' fallback contract the callers depend on.
+    assert trace_link_button(None, 'x') == ''
+
+
+if __name__ == '__main__':
+    import subprocess
+    import sys
+
+    raise SystemExit(subprocess.call([sys.executable, '-m', 'pytest', __file__, '-q']))

--- a/tests/unit/test_trace_buttons.py
+++ b/tests/unit/test_trace_buttons.py
@@ -1,5 +1,5 @@
 """Dashboard trace-link buttons — the three remaining insertions
-(``_sim_hero``, ``_redteam_hero``, ``redteam_transcripts._render_result_detail``).
+(``_sim_hero``, ``_redteam_hero``, ``redteam_transcripts.render_attack_fragment``).
 
 Confirms the deep-link anchor appears in real rendered HTML when
 ``ORQ_WORKSPACE_SLUG`` is configured, and is absent when it isn't (so
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from evaluatorq.dashboard.redteam_transcripts import _render_result_detail
+from evaluatorq.dashboard.redteam_transcripts import render_attack_fragment
 from evaluatorq.dashboard.report_tabs import _redteam_hero, _sim_hero
 from evaluatorq.dashboard.trace_links import run_trace_url, thread_trace_url, trace_link_button
 from evaluatorq.redteam.contracts import (
@@ -89,18 +89,18 @@ def _make_report(run_id: str | None) -> RedTeamReport:
 
 class TestSimHeroTraceButton:
     def test_button_absent_without_workspace_slug(self) -> None:
-        html = _sim_hero(None, _make_run('run1'))
+        html = _sim_hero(_make_run('run1'))
         assert 'trace-link' not in html
         assert 'View all run traces' not in html
 
     def test_button_absent_without_run_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
-        html = _sim_hero(None, _make_run(None))
+        html = _sim_hero(_make_run(None))
         assert 'trace-link' not in html
 
     def test_button_present_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
-        html = _sim_hero(None, _make_run('run1'))
+        html = _sim_hero(_make_run('run1'))
         assert 'class="btn-secondary trace-link"' in html
         assert 'View all run traces' in html
         assert f'href="{run_trace_url("run1")}"' in html
@@ -121,17 +121,17 @@ class TestRedteamHeroTraceButton:
 
 class TestRedteamConversationTraceButton:
     def test_button_absent_without_workspace_slug(self) -> None:
-        html = _render_result_detail(_make_result('run1:0'))
+        html = render_attack_fragment(_make_result('run1:0'))
         assert 'trace-link' not in html
 
     def test_button_absent_without_thread_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
-        html = _render_result_detail(_make_result(None))
+        html = render_attack_fragment(_make_result(None))
         assert 'trace-link' not in html
 
     def test_button_present_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
-        html = _render_result_detail(_make_result('run1:0'))
+        html = render_attack_fragment(_make_result('run1:0'))
         assert 'class="btn-secondary trace-link"' in html
         assert 'View conversation traces' in html
         assert f'href="{thread_trace_url("run1:0")}"' in html

--- a/tests/unit/test_trace_buttons.py
+++ b/tests/unit/test_trace_buttons.py
@@ -9,6 +9,7 @@ older reports without ids, or unconfigured deployments, render fine).
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 

--- a/tests/unit/test_trace_buttons.py
+++ b/tests/unit/test_trace_buttons.py
@@ -133,8 +133,54 @@ class TestRedteamConversationTraceButton:
         monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
         html = render_attack_fragment(_make_result('run1:0'))
         assert 'class="btn-secondary trace-link"' in html
-        assert 'View conversation traces' in html
+        assert 'View Traces' in html
         assert f'href="{thread_trace_url("run1:0")}"' in html
+
+
+def _make_entry(thread_id: str | None) -> Any:
+    from evaluatorq.simulation.types import SimulationEntry
+
+    return SimulationEntry(
+        index=0,
+        persona='p',
+        scenario='s',
+        model='m',
+        target_model=None,
+        terminated_by='judge',
+        goal_achieved=False,
+        goal_completion_score=0.0,
+        rules_broken=[],
+        criteria=[],
+        turn_count=2,
+        total_tokens=0,
+        judge_reason='',
+        error=None,
+        evaluator_scores={},
+        transcript=[],
+        thread_id=thread_id,
+    )
+
+
+class TestSimRowTraceButton:
+    """The conversation trace button lives on the summary row (next to the
+    outcome badge), not in the expanded transcript fragment."""
+
+    def test_button_absent_without_workspace_slug(self) -> None:
+        from evaluatorq.dashboard.sim_views import render_sim_row_list
+
+        html = render_sim_row_list('rid', [_make_entry('run1:0')])
+        assert 'trace-link' not in html
+
+    def test_button_present_on_row_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from evaluatorq.dashboard.sim_views import render_sim_row_list
+
+        monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+        html = render_sim_row_list('rid', [_make_entry('run1:0')])
+        assert 'class="btn-secondary trace-link"' in html
+        assert 'View Traces' in html
+        assert f'href="{thread_trace_url("run1:0")}"' in html
+        # stopPropagation so clicking the link doesn't toggle the <details> row.
+        assert 'event.stopPropagation()' in html
 
 
 def test_button_helper_smoke() -> None:

--- a/tests/unit/test_trace_links.py
+++ b/tests/unit/test_trace_links.py
@@ -1,0 +1,61 @@
+"""Orq traces deep-link builders — URL formatting and the hide-when-unconfigured
+rule (no workspace slug ⇒ no button, never a broken link)."""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.dashboard import trace_links
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ('ORQ_UI_BASE_URL', 'ORQ_BASE_URL', 'ORQ_WORKSPACE_SLUG', 'ORQ_WORKSPACE'):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_urls_none_without_workspace_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No slug configured → both builders return None so no button renders.
+    assert trace_links.thread_trace_url('run1:0') is None
+    assert trace_links.run_trace_url('run1') is None
+    assert trace_links.trace_link_button(None, 'x') == ''
+
+
+def test_thread_url_is_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+    url = trace_links.thread_trace_url('run1:3')
+    assert url == 'https://my.orq.ai/orq-research/traces?query=thread_id%3Ais%3Arun1%3A3'
+
+
+def test_run_url_contains_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+    url = trace_links.run_trace_url('run1')
+    assert url == 'https://my.orq.ai/orq-research/traces?query=thread_id%3Acontains%3Arun1'
+
+
+def test_ui_base_falls_back_to_orq_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('ORQ_BASE_URL', 'https://acme.orq.ai/')
+    monkeypatch.setenv('ORQ_WORKSPACE', 'acme')
+    url = trace_links.thread_trace_url('t:0')
+    assert url is not None and url.startswith('https://acme.orq.ai/acme/traces?query=')
+
+
+def test_empty_ids_return_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('ORQ_WORKSPACE_SLUG', 'orq-research')
+    assert trace_links.thread_trace_url(None) is None
+    assert trace_links.thread_trace_url('') is None
+    assert trace_links.run_trace_url(None) is None
+
+
+def test_button_renders_anchor(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = trace_links.trace_link_button('https://x/y?query=a%3Ab', 'View traces')
+    assert 'href="https://x/y?query=a%3Ab"' in html
+    assert 'View traces' in html
+    assert 'target="_blank"' in html
+
+
+if __name__ == '__main__':
+    import subprocess
+    import sys
+
+    raise SystemExit(subprocess.call([sys.executable, '-m', 'pytest', __file__, '-q']))


### PR DESCRIPTION
## Summary
- capture Orq trace IDs and group conversations with run-scoped thread IDs
- add conversation and run trace links in simulation and red-team dashboards
- document `ORQ_WORKSPACE` for dashboard trace links

## Verification
- `uv run pytest tests/unit/test_trace_links.py tests/unit/test_trace_buttons.py tests/dashboard/test_orq_links.py tests/dashboard/test_report_tabs.py tests/simulation/test_agent_info.py tests/simulation/test_generation_injection.py -q`
- `uv run ruff check src`

Stacked on #70.