### PR TITLE
refactor: shared call_target_with_retry helper across red-team + simulation

### DIFF
--- a/src/evaluatorq/common/target_call.py
+++ b/src/evaluatorq/common/target_call.py
@@ -95,6 +95,7 @@ async def call_target_with_retry(
     max_target_retries: int,
     map_error: Callable[[Exception], tuple[str, str] | None] = default_map_error,
     on_attempt: Callable[[int], AbstractAsyncContextManager[Any]] | None = None,
+    on_attempt_response: Callable[[Any, AgentResponse], None] | None = None,
 ) -> TargetCallResult:
     """Call ``target.respond(messages)`` with bounded retry + per-call timeout.
 
@@ -102,7 +103,9 @@ async def call_target_with_retry(
     timeout, or a generic ``Exception``. ``asyncio.CancelledError`` is NOT
     caught (it is a ``BaseException``) so an outer-ceiling cancellation
     propagates cleanly. ``on_attempt(i)`` wraps each attempt in a
-    caller-supplied span (0-based index). Returns a uniform
+    caller-supplied span (0-based index). ``on_attempt_response`` receives the
+    caller-supplied context value and each returned response while that context
+    is still open, so callers can annotate per-attempt spans. Returns a uniform
     :class:`TargetCallResult`.
     """
     timeout_s = target_agent_timeout_ms / 1000.0
@@ -114,9 +117,11 @@ async def call_target_with_retry(
     for attempt in range(max_attempts):
         ctx = on_attempt(attempt) if on_attempt is not None else nullcontext()
         try:
-            async with ctx:
+            async with ctx as attempt_context:
                 raw = await asyncio.wait_for(target.respond(messages), timeout=timeout_s)
                 resp = _coerce_to_agent_response(raw)
+                if on_attempt_response is not None:
+                    on_attempt_response(attempt_context, resp)
             if resp.error is None:
                 return TargetCallResult(
                     response=resp, succeeded=True, attempts=attempt + 1, error=None, error_details=None

--- a/src/evaluatorq/common/target_call.py
+++ b/src/evaluatorq/common/target_call.py
@@ -1,0 +1,154 @@
+"""Neutral target-call helper shared by red-team and simulation.
+
+Owns bounded retry, per-call timeout, error-marker detection, exception
+mapping, and per-attempt tracing for any ``AgentTarget.respond()`` call.
+MUST NOT import from ``evaluatorq.redteam`` or ``evaluatorq.simulation`` —
+those depend on this module, not the reverse.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from contextlib import AbstractAsyncContextManager, nullcontext
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from evaluatorq.contracts import AgentResponse, AgentResponseError, Message, TextOutputItem
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_ERROR_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r'content[_ ]filter|content management policy'), 'content_filter'),
+    (re.compile(r'rate limit|(?<!\d)429(?!\d)'), 'rate_limit'),
+    (re.compile(r'timed out|timeout'), 'timeout'),
+    (re.compile(r'status[ _]?5\d\d'), 'server_error'),
+    (re.compile(r'status[ _]?4\d\d'), 'client_error'),
+    (re.compile(r'connection'), 'network_error'),
+]
+
+
+def classify_error_type(error: str | None, *, existing_type: str | None = None) -> str | None:
+    """Infer a coarse ``error_type`` from a raw error string when not already set.
+
+    Returns ``existing_type`` unchanged when provided, ``None`` for an empty
+    error, the first matching pattern's type, or ``'unknown'`` when nothing
+    matches. Shared by the orchestrator (per-response ``AgentResponseError``)
+    and report converters (run-level rollup) so both classify identically.
+    """
+    if existing_type:
+        return existing_type
+    if not error:
+        return None
+    lower = error.lower()
+    for pattern, etype in _ERROR_PATTERNS:
+        if pattern.search(lower):
+            return etype
+    return 'unknown'
+
+
+def default_map_error(exc: Exception) -> tuple[str, str]:
+    """Fallback (code, message) mapping; identical to ``Backend.map_error`` base."""
+    return 'target_error', f'{type(exc).__name__}: {exc}'
+
+
+def _coerce_to_agent_response(raw: Any) -> AgentResponse:
+    """Wrap a plain ``str`` return into ``AgentResponse`` for legacy targets."""
+    if isinstance(raw, AgentResponse):
+        return raw
+    text_item = TextOutputItem(text=str(raw) if raw is not None else '', annotations=[])
+    return AgentResponse(output=[text_item])
+
+
+@dataclass(slots=True)
+class TargetCallResult:
+    """In-process control-flow value returned by :func:`call_target_with_retry`.
+
+    ``response`` is always populated: the target's real ``AgentResponse`` on
+    success or a returned-error attempt, or a synthetic one on timeout/exception.
+    ``error`` is ``None`` iff ``succeeded``. ``error_details`` carries the raw
+    exception info callers persist into ``AttackOutput.error_details``.
+    """
+
+    response: AgentResponse
+    succeeded: bool
+    attempts: int
+    error: AgentResponseError | None
+    error_details: dict[str, object] | None
+
+
+def _synthetic(text: str, *, error_type: str, code: str) -> AgentResponse:
+    return AgentResponse(
+        output=[TextOutputItem(text=text, annotations=[])],
+        error=AgentResponseError(message=text, error_type=error_type, code=code),
+    )
+
+
+async def call_target_with_retry(
+    target: Any,
+    messages: list[Message],
+    *,
+    target_agent_timeout_ms: float,
+    max_target_retries: int,
+    map_error: Callable[[Exception], tuple[str, str]] = default_map_error,
+    on_attempt: Callable[[int], AbstractAsyncContextManager[Any]] | None = None,
+) -> TargetCallResult:
+    """Call ``target.respond(messages)`` with bounded retry + per-call timeout.
+
+    Retries the SAME exchange on a returned ``.error`` marker, a per-call
+    timeout, or a generic ``Exception``. ``asyncio.CancelledError`` is NOT
+    caught (it is a ``BaseException``) so an outer-ceiling cancellation
+    propagates cleanly. ``on_attempt(i)`` wraps each attempt in a
+    caller-supplied span (0-based index). Returns a uniform
+    :class:`TargetCallResult`.
+    """
+    timeout_s = target_agent_timeout_ms / 1000.0
+    max_attempts = max(1, max_target_retries + 1)
+    last_response: AgentResponse = AgentResponse()
+    last_error: AgentResponseError | None = None
+    last_details: dict[str, object] | None = None
+
+    for attempt in range(max_attempts):
+        ctx = on_attempt(attempt) if on_attempt is not None else nullcontext()
+        try:
+            async with ctx:
+                raw = await asyncio.wait_for(target.respond(messages), timeout=timeout_s)
+                resp = _coerce_to_agent_response(raw)
+            if resp.error is None:
+                return TargetCallResult(
+                    response=resp, succeeded=True, attempts=attempt + 1, error=None, error_details=None
+                )
+            last_response = resp
+            last_error = resp.error
+            last_details = {
+                'response_error_type': resp.error.error_type,
+                'raw_message': resp.error.message,
+                'attempts': attempt + 1,
+            }
+        except asyncio.TimeoutError:
+            text = f'[ERROR: Target agent timed out after {timeout_s:.0f}s]'
+            last_response = _synthetic(text, error_type='timeout', code='target.timeout')
+            last_error = last_response.error
+            last_details = {'timeout_ms': target_agent_timeout_ms, 'attempts': attempt + 1}
+        except Exception as exc:
+            mapped = map_error(exc)
+            code, msg = mapped if mapped is not None else default_map_error(exc)
+            classified = classify_error_type(msg)
+            text = f'[ERROR: {msg}]'
+            last_response = _synthetic(
+                text,
+                error_type=classified if classified and classified != 'unknown' else 'target_error',
+                code=code,
+            )
+            last_error = last_response.error
+            last_details = {'exception_type': type(exc).__name__, 'raw_message': str(exc), 'attempts': attempt + 1}
+
+        if attempt + 1 < max_attempts:
+            logger.warning(f'Target call failed (attempt {attempt + 1}/{max_attempts}); retrying same exchange')
+
+    return TargetCallResult(
+        response=last_response, succeeded=False, attempts=max_attempts, error=last_error, error_details=last_details
+    )

--- a/src/evaluatorq/common/target_call.py
+++ b/src/evaluatorq/common/target_call.py
@@ -93,7 +93,7 @@ async def call_target_with_retry(
     *,
     target_agent_timeout_ms: float,
     max_target_retries: int,
-    map_error: Callable[[Exception], tuple[str, str]] = default_map_error,
+    map_error: Callable[[Exception], tuple[str, str] | None] = default_map_error,
     on_attempt: Callable[[int], AbstractAsyncContextManager[Any]] | None = None,
 ) -> TargetCallResult:
     """Call ``target.respond(messages)`` with bounded retry + per-call timeout.

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -644,7 +644,7 @@ class AgentResponseError(BaseModel):
     error's *presence*, not its value, so the field is intentionally not an
     enum. The orchestrator sets ``"timeout"`` on the timeout path and otherwise
     classifies the failure via
-    :func:`evaluatorq.redteam.contracts.classify_error_type`, which yields one
+    :func:`evaluatorq.common.target_call.classify_error_type`, which yields one
     of ``content_filter``, ``rate_limit``, ``timeout``, ``network_error``,
     ``server_error``, ``client_error``, or ``target_error`` (fallback for an
     unmatched error). Other producers may set their own values.

--- a/src/evaluatorq/integrations/callable_integration/target.py
+++ b/src/evaluatorq/integrations/callable_integration/target.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -140,6 +141,8 @@ class CallableTarget(AgentTarget):
                 result = await fn(messages)
             else:
                 result = await asyncio.to_thread(fn, messages)
+                if inspect.isawaitable(result):
+                    result = await result
         except (asyncio.CancelledError, asyncio.TimeoutError):
             raise
         except Exception as exc:

--- a/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -9,6 +9,8 @@ import asyncio
 import contextvars
 import logging
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from inspect import signature
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +26,7 @@ from evaluatorq.common.content_filter import (
     regenerate_on_content_filter,
 )
 from evaluatorq.common.sanitize import xml_escape
+from evaluatorq.common.target_call import call_target_with_retry, default_map_error
 from evaluatorq.common.tracing import record_llm_response, set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentResponse, AgentResponseError, AgentTarget, Message, TextOutputItem
 from evaluatorq.redteam.adaptive.tool_chaining import (
@@ -31,7 +34,7 @@ from evaluatorq.redteam.adaptive.tool_chaining import (
     ToolChainingVerifier,
     format_plan_for_prompt,
 )
-from evaluatorq.redteam.backends.base import Backend, _coerce_to_agent_response
+from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     PIPELINE_CONFIG,
@@ -41,20 +44,13 @@ from evaluatorq.redteam.contracts import (
     OrchestratorResult,
     TokenUsage,
     Turn,
-    classify_error_type,
     turns_to_messages,
 )
-from evaluatorq.redteam.exceptions import TargetResponseError
 from evaluatorq.redteam.tracing import with_llm_span, with_redteam_span
 from evaluatorq.redteam.utils import safe_substitute
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletionMessageParam
-
-
-def _default_map_error(exc: Exception) -> tuple[str, str]:
-    """Fallback error mapping for the no-backend path; mirrors ``Backend.map_error``."""
-    return 'target_error', f'{type(exc).__name__}: {exc}'
 
 
 _ui_console = Console(stderr=True)
@@ -905,138 +901,79 @@ class MultiTurnOrchestrator:
                             break
 
                     # Send attack to target agent. The transcript is derived from
-                    # the recorded turns BEFORE the try: it is a pure local op, so a
-                    # bug here must not be misattributed to the target by the except.
-                    target_timeout_s = self._cfg.target_agent_timeout_ms / 1000.0
-                    transcript = turns_to_messages(turns_record, skip_errors=True)
+                    # the recorded turns BEFORE the call: it is a pure local op, so a
+                    # bug here must not be misattributed to the target by the retry helper.
                     # A failed target exchange is retried with the exact same prompt and
                     # transcript. Advancing the adversarial conversation after dropping
                     # an error response would splice the evidence, so exhausted retries
                     # end the run as unscorable instead.
-                    turn_usage: TokenUsage | None = None
-                    agent_response = ''
-                    max_target_attempts = max(1, self._cfg.max_target_retries + 1)
-                    target_failed = False
-                    target_error: str | None = None
-                    target_error_type: str | None = None
-                    target_error_stage: str | None = None
-                    target_error_code: str | None = None
-                    target_error_details: dict[str, Any] | None = None
-                    target_finish_reason: str | None = None
-                    for target_attempt in range(max_target_attempts):
-                        try:
-                            async with with_redteam_span(
-                                'orq.redteam.target_call',
-                                {
-                                    'orq.redteam.turn': turn + 1,
-                                    'orq.redteam.strategy_name': strategy.name,
-                                    'orq.redteam.target_attempt': target_attempt + 1,
-                                    'input': truncate_for_span(attack_prompt),
-                                    'orq.redteam.input': truncate_for_span(attack_prompt),
-                                },
-                            ) as tgt_span:
-                                raw_response = await asyncio.wait_for(
-                                    target.respond([*transcript, Message(role='user', content=attack_prompt)]),
-                                    timeout=target_timeout_s,
-                                )
-                                tgt_result = _coerce_to_agent_response(raw_response)
-                                if tgt_result.error is not None:
-                                    raise TargetResponseError(tgt_result)
-                                agent_response = tgt_result.text
-                                resp_text = truncate_for_span(agent_response or '')
-                                set_span_attrs(
-                                    tgt_span,
-                                    {
-                                        'output': resp_text,
-                                        'orq.redteam.output': resp_text,
-                                    },
-                                )
-                                turn_usage = tgt_result.usage
-                            break
-                        except TargetResponseError as e:
-                            tgt_result = e.response
-                            agent_response = tgt_result.text
-                            response_error = e.error
-                            target_error = (
-                                f'Target agent returned error after {max_target_attempts} attempt(s) '
-                                f'on turn {turn + 1}/{max_turns}, '
-                                f'code={response_error.code or "target_error"}, details={response_error.message}'
-                            )
-                            target_error_type = 'target_error'
-                            target_error_stage = 'target_call'
-                            target_error_code = response_error.code or 'target_error'
-                            target_error_details = {
-                                'response_error_type': response_error.error_type,
-                                'raw_message': response_error.message,
-                                'attempts': target_attempt + 1,
-                            }
-                            target_finish_reason = 'target_error'
-                        except asyncio.TimeoutError:
-                            agent_response = f'[ERROR: Target agent timed out after {target_timeout_s:.0f}s]'
-                            tgt_result = AgentResponse(
-                                output=[TextOutputItem(text=agent_response, annotations=[])],
-                                error=AgentResponseError(
-                                    message=agent_response, error_type='timeout', code='target.timeout'
-                                ),
-                            )
-                            target_error = (
-                                f'Target agent timed out after {max_target_attempts} attempt(s) '
-                                f'on turn {turn + 1}/{max_turns}'
-                            )
-                            target_error_type = 'target_error'
-                            target_error_stage = 'target_call'
-                            target_error_code = 'target.timeout'
-                            target_error_details = {
-                                'timeout_ms': self._cfg.target_agent_timeout_ms,
-                                'attempts': target_attempt + 1,
-                            }
-                            target_finish_reason = 'target_timeout'
-                        except Exception as e:
-                            mapped_code, error_msg = (
-                                self._backend.map_error(e) if self._backend is not None else _default_map_error(e)
-                            )
-                            agent_response = f'[ERROR: {error_msg}]'
-                            classified = classify_error_type(error_msg)
-                            tgt_result = AgentResponse(
-                                output=[TextOutputItem(text=agent_response, annotations=[])],
-                                error=AgentResponseError(
-                                    message=agent_response,
-                                    error_type=classified if classified and classified != 'unknown' else 'target_error',
-                                    code=mapped_code,
-                                ),
-                            )
-                            target_error = (
-                                f'Target agent failed after {max_target_attempts} attempt(s) '
-                                f'on turn {turn + 1}/{max_turns}, code={mapped_code}, details={error_msg}'
-                            )
-                            target_error_type = 'target_error'
-                            target_error_stage = 'target_call'
-                            target_error_code = mapped_code
-                            target_error_details = {
-                                'exception_type': type(e).__name__,
-                                'raw_message': str(e),
-                                'attempts': target_attempt + 1,
-                            }
-                            target_finish_reason = 'target_error'
+                    transcript = turns_to_messages(turns_record, skip_errors=True)
+                    messages_to_send = [*transcript, Message(role='user', content=attack_prompt)]
 
-                        if target_attempt + 1 < max_target_attempts:
-                            logger.warning(
-                                f'Target agent {target_finish_reason} on turn {turn + 1}/{max_turns}; '
-                                f'retrying same exchange ({target_attempt + 2}/{max_target_attempts})'
-                            )
-                            continue
-                        target_failed = True
+                    @asynccontextmanager
+                    async def _attempt_span(
+                        attempt_index: int,
+                        _prompt: str = attack_prompt,
+                        _turn: int = turn,
+                        _strategy_name: str = strategy.name,
+                    ) -> AsyncIterator[Any]:
+                        async with with_redteam_span(
+                            'orq.redteam.target_call',
+                            {
+                                'orq.redteam.turn': _turn + 1,
+                                'orq.redteam.strategy_name': _strategy_name,
+                                'orq.redteam.target_attempt': attempt_index + 1,
+                                'input': truncate_for_span(_prompt),
+                                'orq.redteam.input': truncate_for_span(_prompt),
+                            },
+                        ) as span:
+                            yield span
 
-                    if target_failed:
-                        error = target_error
-                        error_type = target_error_type
-                        error_stage = target_error_stage
-                        error_code = target_error_code
-                        error_details = target_error_details
+                    result = await call_target_with_retry(
+                        target,
+                        messages_to_send,
+                        target_agent_timeout_ms=self._cfg.target_agent_timeout_ms,
+                        max_target_retries=self._cfg.max_target_retries,
+                        map_error=self._backend.map_error if self._backend is not None else default_map_error,
+                        on_attempt=_attempt_span,
+                    )
+
+                    tgt_result = result.response
+                    agent_response = tgt_result.text
+                    turn_usage: TokenUsage | None = tgt_result.usage if result.succeeded else None
+
+                    if result.succeeded:
+                        # The per-attempt span closes inside the helper, so record the
+                        # target output on the surrounding turn-level span instead.
+                        set_span_attrs(
+                            turn_span,
+                            {
+                                'output': truncate_for_span(agent_response or ''),
+                                'orq.redteam.output': truncate_for_span(agent_response or ''),
+                            },
+                        )
+
+                    if not result.succeeded:
+                        # The helper guarantees a non-None error on the failure path;
+                        # fall back defensively so a None can never crash attribute access.
+                        err = result.error or AgentResponseError(
+                            message='target call failed', error_type='target_error', code='target_error'
+                        )
+                        error = (
+                            f'Target agent failed after {result.attempts} attempt(s) '
+                            f'on turn {turn + 1}/{max_turns}, code={err.code or "target_error"}, details={err.message}'
+                        )
+                        # error_stage = where (target_call); error_type = what
+                        # (timeout/network_error/rate_limit/... classified by the helper).
+                        error_type = err.error_type
+                        error_stage = 'target_call'
+                        error_code = err.code or 'target_error'
+                        error_details = result.error_details
                         error_turn = turn + 1
                         turns_record.append(Turn(attacker=current_attacker, target=tgt_result))
                         if progress is not None and task_id is not None:
                             await progress.update_attack(task_id, completed=turn + 1)
+                        finish_reason = 'target_timeout' if err.error_type == 'timeout' else 'target_error'
                         set_span_attrs(
                             turn_span,
                             {
@@ -1044,7 +981,7 @@ class MultiTurnOrchestrator:
                                 if usage is not None
                                 else 0,
                                 'orq.redteam.error_type': error_type,
-                                'orq.redteam.finish_reason': target_finish_reason,
+                                'orq.redteam.finish_reason': finish_reason,
                             },
                         )
                         break

--- a/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -44,6 +44,7 @@ from evaluatorq.redteam.contracts import (
     classify_error_type,
     turns_to_messages,
 )
+from evaluatorq.redteam.exceptions import TargetResponseError
 from evaluatorq.redteam.tracing import with_llm_span, with_redteam_span
 from evaluatorq.redteam.utils import safe_substitute
 
@@ -54,18 +55,6 @@ if TYPE_CHECKING:
 def _default_map_error(exc: Exception) -> tuple[str, str]:
     """Fallback error mapping for the no-backend path; mirrors ``Backend.map_error``."""
     return 'target_error', f'{type(exc).__name__}: {exc}'
-
-
-class _TargetResponseError(Exception):
-    """Wrap a target-returned error marker so it follows the retry path."""
-
-    def __init__(self, response: AgentResponse) -> None:
-        self.response = response
-        response_error = response.error
-        if response_error is None:
-            raise ValueError('TargetResponseError requires an AgentResponse.error marker')
-        self.error = response_error
-        super().__init__(response_error.message)
 
 
 _ui_console = Console(stderr=True)
@@ -952,7 +941,7 @@ class MultiTurnOrchestrator:
                                 )
                                 tgt_result = _coerce_to_agent_response(raw_response)
                                 if tgt_result.error is not None:
-                                    raise _TargetResponseError(tgt_result)
+                                    raise TargetResponseError(tgt_result)
                                 agent_response = tgt_result.text
                                 resp_text = truncate_for_span(agent_response or '')
                                 set_span_attrs(
@@ -964,7 +953,7 @@ class MultiTurnOrchestrator:
                                 )
                                 turn_usage = tgt_result.usage
                             break
-                        except _TargetResponseError as e:
+                        except TargetResponseError as e:
                             tgt_result = e.response
                             agent_response = tgt_result.text
                             response_error = e.error

--- a/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -929,6 +929,16 @@ class MultiTurnOrchestrator:
                         ) as span:
                             yield span
 
+                    def _record_attempt_response(span: Any, response: AgentResponse) -> None:
+                        response_text = truncate_for_span(response.text or '')
+                        set_span_attrs(
+                            span,
+                            {
+                                'output': response_text,
+                                'orq.redteam.output': response_text,
+                            },
+                        )
+
                     result = await call_target_with_retry(
                         target,
                         messages_to_send,
@@ -936,6 +946,7 @@ class MultiTurnOrchestrator:
                         max_target_retries=self._cfg.max_target_retries,
                         map_error=self._backend.map_error if self._backend is not None else default_map_error,
                         on_attempt=_attempt_span,
+                        on_attempt_response=_record_attempt_response,
                     )
 
                     tgt_result = result.response

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -472,8 +472,6 @@ def create_dynamic_redteam_job(
                             'attempts': target_attempt + 1,
                         }
                     except Exception as e:
-                        if isinstance(e, (TypeError, AttributeError, ImportError, NameError)):
-                            raise
                         mapped_code, mapped_msg = resolved_backend.map_error(e)
                         response = f'[ERROR: {mapped_msg}]'
                         agent_resp = AgentResponse(

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -17,12 +17,14 @@ import contextlib
 import inspect
 import time
 import traceback
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from evaluatorq import DataPoint, EvaluationResult, Job, job
 from evaluatorq.common.jury import append_jury_summary
+from evaluatorq.common.target_call import call_target_with_retry
 from evaluatorq.common.thread_context import build_thread_id, conversation_thread
 from evaluatorq.common.tracing import set_span_attrs, truncate_for_span
 from evaluatorq.contracts import AgentResponse, AgentResponseError, Message
@@ -33,7 +35,6 @@ from evaluatorq.redteam.adaptive.strategy_planner import (
     plan_strategies_for_categories,
     plan_strategies_for_vulnerabilities,
 )
-from evaluatorq.redteam.backends.base import Backend, _coerce_to_agent_response
 from evaluatorq.redteam.backends.registry import create_async_llm_client, resolve_backend
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
@@ -65,6 +66,7 @@ if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
     from evaluatorq.redteam.adaptive.capability_classifier import AgentCapabilities
+    from evaluatorq.redteam.backends.base import Backend
     from evaluatorq.redteam.contracts import AgentContext
     from evaluatorq.types import ScorerParameter
 
@@ -407,101 +409,47 @@ def create_dynamic_redteam_job(
                 error_code = None
                 error_details = None
                 token_usage = None
-                agent_resp: AgentResponse = AgentResponse()
-                target_timeout_s = cfg.target_agent_timeout_ms / 1000.0
-                response = ''
-                max_target_attempts = max(1, cfg.max_target_retries + 1)
-                target_succeeded = False
-                target_error: str | None = None
-                target_error_code: str | None = None
-                target_error_details: dict[str, Any] | None = None
-                for target_attempt in range(max_target_attempts):
-                    try:
-                        async with with_redteam_span(
-                            'orq.redteam.target_call',
-                            {
-                                'orq.redteam.category': category,
-                                'orq.redteam.strategy_name': strategy.name,
-                                'orq.redteam.turn': 1,
-                                'orq.redteam.target_attempt': target_attempt + 1,
-                                'input': truncate_for_span(prompt),
-                                'orq.redteam.input': truncate_for_span(prompt),
-                            },
-                        ) as tgt_span:
-                            with conversation_thread(thread_id) as thread_id:
-                                raw = await asyncio.wait_for(
-                                    target.respond([Message(role='user', content=prompt)]),
-                                    timeout=target_timeout_s,
-                                )
-                            agent_resp = _coerce_to_agent_response(raw)
-                            response = agent_resp.text
-                            if agent_resp.error is None:
-                                token_usage = agent_resp.usage
-                                resp_text = truncate_for_span(response or '')
-                                set_span_attrs(
-                                    tgt_span,
-                                    {
-                                        'output': resp_text,
-                                        'orq.redteam.output': resp_text,
-                                    },
-                                )
-                                target_succeeded = True
-                                break
 
-                            response_error = agent_resp.error
-                            target_error = (
-                                f'Target agent returned error after {max_target_attempts} attempt(s), '
-                                f'code={response_error.code or "target_error"}, details={response_error.message}'
-                            )
-                            target_error_code = response_error.code or 'target_error'
-                            target_error_details = {
-                                'response_error_type': response_error.error_type,
-                                'raw_message': response_error.message,
-                                'attempts': target_attempt + 1,
-                            }
-                    except asyncio.TimeoutError:
-                        response = f'[ERROR: Target agent timed out after {target_timeout_s:.0f}s]'
-                        agent_resp = AgentResponse(
-                            output=[TextOutputItem(text=response, annotations=[])],
-                            error=AgentResponseError(message=response, error_type='timeout', code='target.timeout'),
-                        )
-                        target_error = f'Target agent timed out after {max_target_attempts} attempt(s)'
-                        target_error_code = 'target.timeout'
-                        target_error_details = {
-                            'timeout_ms': cfg.target_agent_timeout_ms,
-                            'attempts': target_attempt + 1,
-                        }
-                    except Exception as e:
-                        mapped_code, mapped_msg = resolved_backend.map_error(e)
-                        response = f'[ERROR: {mapped_msg}]'
-                        agent_resp = AgentResponse(
-                            output=[TextOutputItem(text=response, annotations=[])],
-                            error=AgentResponseError(
-                                message=response,
-                                error_type='target_error',
-                                code=mapped_code,
-                            ),
-                        )
-                        target_error = f'Target agent failed after {max_target_attempts} attempt(s): {mapped_msg}'
-                        target_error_code = mapped_code
-                        target_error_details = {
-                            'exception_type': type(e).__name__,
-                            'raw_message': str(e),
-                            'attempts': target_attempt + 1,
-                        }
+                @asynccontextmanager
+                async def _attempt_span(i: int):
+                    async with with_redteam_span(
+                        'orq.redteam.target_call',
+                        {
+                            'orq.redteam.category': category,
+                            'orq.redteam.strategy_name': strategy.name,
+                            'orq.redteam.turn': 1,
+                            'orq.redteam.target_attempt': i + 1,
+                            'input': truncate_for_span(prompt),
+                            'orq.redteam.input': truncate_for_span(prompt),
+                        },
+                    ) as span:
+                        yield span
 
-                    if target_attempt + 1 < max_target_attempts:
-                        logger.warning(
-                            f'Single-turn target call failed for {category}/{strategy.name}; '
-                            f'retrying same exchange ({target_attempt + 2}/{max_target_attempts})'
-                        )
+                with conversation_thread(thread_id) as thread_id:
+                    result = await call_target_with_retry(
+                        target,
+                        [Message(role='user', content=prompt)],
+                        target_agent_timeout_ms=cfg.target_agent_timeout_ms,
+                        max_target_retries=cfg.max_target_retries,
+                        map_error=resolved_backend.map_error,
+                        on_attempt=_attempt_span,
+                    )
 
-                if not target_succeeded:
-                    error = target_error
-                    error_type = 'target_error'
+                agent_resp = result.response
+                response = agent_resp.text
+                token_usage = agent_resp.usage if result.succeeded else None
+                if not result.succeeded:
+                    # The helper guarantees a non-None error on the failure path;
+                    # fall back defensively so a None can never crash attribute access.
+                    err = result.error or AgentResponseError(
+                        message='target call failed', error_type='target_error', code='target_error'
+                    )
+                    error = f'Target agent failed after {result.attempts} attempt(s): {err.message}'
+                    # error_stage = where (target_call); error_type = what (timeout/network_error/rate_limit/... classified by the helper)
+                    error_type = err.error_type
                     error_stage = 'target_call'
-                    error_code = target_error_code
-                    error_details = target_error_details
+                    error_code = err.code or 'target_error'
+                    error_details = result.error_details
                 result_dict = AttackOutput(
                     turns=[
                         Turn(

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -425,6 +425,16 @@ def create_dynamic_redteam_job(
                     ) as span:
                         yield span
 
+                def _record_attempt_response(span: Any, response: AgentResponse) -> None:
+                    response_text = truncate_for_span(response.text or '')
+                    set_span_attrs(
+                        span,
+                        {
+                            'output': response_text,
+                            'orq.redteam.output': response_text,
+                        },
+                    )
+
                 with conversation_thread(thread_id) as thread_id:
                     result = await call_target_with_retry(
                         target,
@@ -433,6 +443,7 @@ def create_dynamic_redteam_job(
                         max_target_retries=cfg.max_target_retries,
                         map_error=resolved_backend.map_error,
                         on_attempt=_attempt_span,
+                        on_attempt_response=_record_attempt_response,
                     )
 
                 agent_resp = result.response

--- a/src/evaluatorq/redteam/backends/base.py
+++ b/src/evaluatorq/redteam/backends/base.py
@@ -10,30 +10,16 @@ independently.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from evaluatorq.contracts import AgentResponse
+from evaluatorq.common.target_call import _coerce_to_agent_response as _coerce_to_agent_response
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from evaluatorq.contracts import AgentContext, AgentTarget
-
-
-def _coerce_to_agent_response(raw: Any) -> AgentResponse:
-    """Wrap a plain str return into AgentResponse for backward-compat with legacy targets.
-
-    Any target that still returns ``str`` from ``respond`` will be transparently
-    wrapped here at the orchestrator call site.
-    """
-    from evaluatorq.redteam.contracts import OutputMessage, TextOutputItem
-
-    if isinstance(raw, AgentResponse):
-        return raw
-    text_item: OutputMessage = TextOutputItem(text=str(raw) if raw is not None else '', annotations=[])
-    return AgentResponse(output=[text_item])
 
 
 def validate_agent_target(obj: object) -> None:

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -9,7 +9,6 @@ Semantic convention:
     ``passed=False`` → the agent is VULNERABLE (attack succeeded)
 """
 
-import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypedDict
 
@@ -21,6 +20,7 @@ from pydantic import (
     model_validator,
 )
 
+from evaluatorq.common.target_call import classify_error_type as classify_error_type
 from evaluatorq.contracts import StrEnum
 
 if TYPE_CHECKING:
@@ -848,39 +848,10 @@ class RunError(BaseModel):
     turn: int | None = None
 
 
-# Regex patterns matched (case-insensitively) against the error string to infer
-# a coarse error_type. Ordered most-specific first; the first match wins, so an
-# explicit HTTP status must precede the generic 'connection' fallback (otherwise
-# "Status 503 connection reset" would misclassify as network_error). HTTP codes
-# require three digits and 429 is digit-bounded so stray numbers (request ids,
-# byte counts) do not trigger false rate_limit/status matches.
-_ERROR_PATTERNS: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r'content[_ ]filter|content management policy'), 'content_filter'),
-    (re.compile(r'rate limit|(?<!\d)429(?!\d)'), 'rate_limit'),
-    (re.compile(r'timed out|timeout'), 'timeout'),
-    (re.compile(r'status[ _]?5\d\d'), 'server_error'),
-    (re.compile(r'status[ _]?4\d\d'), 'client_error'),
-    (re.compile(r'connection'), 'network_error'),
-]
-
-
-def classify_error_type(error: str | None, *, existing_type: str | None = None) -> str | None:
-    """Infer a coarse ``error_type`` from a raw error string when not already set.
-
-    Returns ``existing_type`` unchanged when provided, ``None`` for an empty
-    error, the first matching pattern's type, or ``'unknown'`` when nothing
-    matches. Shared by the orchestrator (per-response :class:`AgentResponseError`)
-    and report converters (run-level rollup) so both classify identically.
-    """
-    if existing_type:
-        return existing_type
-    if not error:
-        return None
-    lower = error.lower()
-    for pattern, etype in _ERROR_PATTERNS:
-        if pattern.search(lower):
-            return etype
-    return 'unknown'
+# classify_error_type is defined in evaluatorq.common.target_call and
+# re-exported above so evaluatorq.redteam.contracts.classify_error_type
+# stays a valid dotted path (see docstring reference below and
+# reports/converters.py, which imports it from here).
 
 
 # ---------------------------------------------------------------------------

--- a/src/evaluatorq/redteam/exceptions.py
+++ b/src/evaluatorq/redteam/exceptions.py
@@ -1,5 +1,7 @@
 """Domain-specific exceptions for the evaluatorq.redteam package."""
 
+from evaluatorq.contracts import AgentResponse
+
 
 class RedTeamError(Exception):
     """Base exception for all red teaming errors."""
@@ -19,3 +21,15 @@ class DatasetError(RedTeamError):
 
 class CancelledError(RedTeamError):
     """Pipeline run was cancelled by the user via hooks."""
+
+
+class TargetResponseError(RedTeamError):
+    """Wrap a target-returned error marker so it follows target retry handling."""
+
+    def __init__(self, response: AgentResponse) -> None:
+        self.response = response
+        response_error = response.error
+        if response_error is None:
+            raise ValueError('TargetResponseError requires an AgentResponse.error marker')
+        self.error = response_error
+        super().__init__(response_error.message)

--- a/src/evaluatorq/redteam/exceptions.py
+++ b/src/evaluatorq/redteam/exceptions.py
@@ -1,7 +1,5 @@
 """Domain-specific exceptions for the evaluatorq.redteam package."""
 
-from evaluatorq.contracts import AgentResponse
-
 
 class RedTeamError(Exception):
     """Base exception for all red teaming errors."""
@@ -21,15 +19,3 @@ class DatasetError(RedTeamError):
 
 class CancelledError(RedTeamError):
     """Pipeline run was cancelled by the user via hooks."""
-
-
-class TargetResponseError(RedTeamError):
-    """Wrap a target-returned error marker so it follows target retry handling."""
-
-    def __init__(self, response: AgentResponse) -> None:
-        self.response = response
-        response_error = response.error
-        if response_error is None:
-            raise ValueError('TargetResponseError requires an AgentResponse.error marker')
-        self.error = response_error
-        super().__init__(response_error.message)

--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -261,6 +261,12 @@ def create_owasp_evaluator(
             logger.warning(f'No evaluator found for category {category}')
             return _error_result(f'No evaluator found for category {category}')
 
+        if isinstance(output, dict):
+            target_error = output.get('error')
+            if target_error is not None:
+                msg = getattr(target_error, 'message', str(target_error))
+                return _error_result(f'Target agent error — not scored: {msg}')
+
         output_messages = _adapt_static_output(output)
 
         eval_replacements = build_eval_replacements(

--- a/src/evaluatorq/redteam/reports/converters.py
+++ b/src/evaluatorq/redteam/reports/converters.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from loguru import logger as _converters_logger
 from pydantic import ValidationError
 
+from evaluatorq.common.target_call import classify_error_type
 from evaluatorq.redteam.contracts import (
     JURY_RAW_OUTPUT_KEY,
     OWASP_CATEGORY_NAMES,
@@ -40,7 +41,6 @@ from evaluatorq.redteam.contracts import (
     UnifiedEvaluationResult,
     Vulnerability,
     VulnerabilitySummary,
-    classify_error_type,
     infer_framework,
     normalize_category,
 )
@@ -53,8 +53,8 @@ from evaluatorq.redteam.vulnerability_registry import (
     resolve_category_safe,
 )
 
-# Error classification lives in evaluatorq.redteam.contracts so the orchestrator
-# can share it without importing the report layer. Alias kept for call sites here.
+# Error classification lives in the shared common layer, so red-team execution
+# and report conversion use exactly the same mapping. Alias kept for call sites here.
 _classify_error = classify_error_type
 
 

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -23,6 +23,7 @@ from evaluatorq.common.async_utils import await_maybe, warn_if_sync_hooks
 from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.common.messages import coerce_content_text
 from evaluatorq.common.run_store_dir import get_store_dir
+from evaluatorq.common.target_call import call_target_with_retry
 from evaluatorq.common.tracing import set_span_attrs
 from evaluatorq.contracts import AgentTarget, Message
 from evaluatorq.redteam.adaptive.capability_classifier import AgentCapabilities, classify_agent_capabilities
@@ -44,7 +45,6 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
 from evaluatorq.redteam.backends.base import (
     Backend,
     BareTargetBackend,
-    _coerce_to_agent_response,
 )
 from evaluatorq.redteam.backends.registry import create_async_llm_client, make_agent_backend, resolve_backend
 from evaluatorq.redteam.contracts import (
@@ -841,7 +841,9 @@ def _extract_static_prompt(data: DataPoint) -> str:
     return '\n\n'.join(p for p in user_parts if p)
 
 
-def _create_static_job_for_agent_target(target_factory: Callable[[], Any], label: str) -> Any:
+def _create_static_job_for_agent_target(
+    target_factory: Callable[[], Any], label: str, cfg: LLMConfig | None = None
+) -> Any:
     """Create an evaluatorq static job that drives an :class:`AgentTarget`.
 
     ``target_factory`` mints a fresh, isolated target per attack; the job closes
@@ -851,14 +853,20 @@ def _create_static_job_for_agent_target(target_factory: Callable[[], Any], label
     target (and its unused HTTP client) is left dangling.
     """
     safe = _sanitize_job_name(label)
+    cfg = cfg or PIPELINE_CONFIG
 
     @job(f'redteam:static:{safe}')
     async def agent_target_job(data: DataPoint, _row: int) -> dict[str, Any]:
         prompt = _extract_static_prompt(data)
         target = target_factory()
         try:
-            raw_response = await target.respond([Message(role='user', content=prompt)])
-            result = _coerce_to_agent_response(raw_response)
+            call = await call_target_with_retry(
+                target,
+                [Message(role='user', content=prompt)],
+                target_agent_timeout_ms=cfg.target_agent_timeout_ms,
+                max_target_retries=cfg.max_target_retries,
+            )
+            result = call.response
 
             active_progress = _get_active_progress()
             if active_progress is not None:
@@ -866,6 +874,7 @@ def _create_static_job_for_agent_target(target_factory: Callable[[], Any], label
 
             return {
                 'response': result.text,
+                'error': call.error,
                 'tool_calls': result.tool_calls,
                 'token_usage': result.usage,
                 'finish_reason': result.finish_reason,
@@ -928,7 +937,7 @@ def _create_job_for_target(
         backend = make_agent_backend(target_config=tcfg, pipeline_config=cfg)
         # Build a fresh owned target per row (composite prefixes -> model
         # "agent/<value>"); no long-lived parent target/client is left dangling.
-        return _create_static_job_for_agent_target(lambda: backend.create_target(value), label=value)
+        return _create_static_job_for_agent_target(lambda: backend.create_target(value), label=value, cfg=cfg)
     if kind == TargetKind.DEPLOYMENT:
         return create_model_job(deployment_key=value, **common)
     return create_model_job(model=value, **common)
@@ -1892,13 +1901,21 @@ async def _run_dynamic_or_hybrid(
                                 f'produced an empty prompt ({len(messages)} messages, none with user content).'
                             )
                         target_instance = _backend.create_target(_label)
-                        raw = await target_instance.respond([Message(role='user', content=prompt)])
-                        result = _coerce_to_agent_response(raw)
+                        resolved_cfg = pipeline_config or PIPELINE_CONFIG
+                        call = await call_target_with_retry(
+                            target_instance,
+                            [Message(role='user', content=prompt)],
+                            target_agent_timeout_ms=resolved_cfg.target_agent_timeout_ms,
+                            max_target_retries=resolved_cfg.max_target_retries,
+                            map_error=_backend.map_error,
+                        )
+                        result = call.response
                         active_progress = _get_active_progress()
                         if active_progress is not None:
                             await active_progress.finish_attack(None)
                         return {
                             'response': result.text,
+                            'error': call.error,
                             'tool_calls': result.tool_calls,
                             'token_usage': result.usage,
                             'finish_reason': result.finish_reason,
@@ -2425,7 +2442,8 @@ async def _run_static(
         _create_job_for_target(t, llm_client, sys_prompt, pipeline_config=pipeline_config) for t in targets
     ]
     jobs.extend(
-        _create_static_job_for_agent_target(at.new, agent_target_labels[id(at)]) for at in resolved_agent_targets
+        _create_static_job_for_agent_target(at.new, agent_target_labels[id(at)], cfg=pipeline_config)
+        for at in resolved_agent_targets
     )
 
     from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import create_owasp_evaluator

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -23,7 +23,7 @@ from evaluatorq.common.async_utils import await_maybe, warn_if_sync_hooks
 from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.common.messages import coerce_content_text
 from evaluatorq.common.run_store_dir import get_store_dir
-from evaluatorq.common.target_call import call_target_with_retry
+from evaluatorq.common.target_call import call_target_with_retry, default_map_error
 from evaluatorq.common.tracing import set_span_attrs
 from evaluatorq.contracts import AgentTarget, Message
 from evaluatorq.redteam.adaptive.capability_classifier import AgentCapabilities, classify_agent_capabilities
@@ -841,6 +841,38 @@ def _extract_static_prompt(data: DataPoint) -> str:
     return '\n\n'.join(p for p in user_parts if p)
 
 
+async def _run_static_target_call(
+    target: Any,
+    prompt: str,
+    *,
+    target_agent_timeout_ms: int,
+    max_target_retries: int,
+    map_error: Callable[[Exception], tuple[str, str] | None] = default_map_error,
+) -> dict[str, Any]:
+    """Call a static target and return the scorer-facing output shape."""
+    call = await call_target_with_retry(
+        target,
+        [Message(role='user', content=prompt)],
+        target_agent_timeout_ms=target_agent_timeout_ms,
+        max_target_retries=max_target_retries,
+        map_error=map_error,
+    )
+    result = call.response
+
+    active_progress = _get_active_progress()
+    if active_progress is not None:
+        await active_progress.finish_attack(None)
+
+    return {
+        'response': result.text,
+        'error': call.error,
+        'tool_calls': result.tool_calls,
+        'token_usage': result.usage,
+        'finish_reason': result.finish_reason,
+        'model': result.model,
+    }
+
+
 def _create_static_job_for_agent_target(
     target_factory: Callable[[], Any], label: str, cfg: LLMConfig | None = None
 ) -> Any:
@@ -860,26 +892,12 @@ def _create_static_job_for_agent_target(
         prompt = _extract_static_prompt(data)
         target = target_factory()
         try:
-            call = await call_target_with_retry(
+            return await _run_static_target_call(
                 target,
-                [Message(role='user', content=prompt)],
+                prompt,
                 target_agent_timeout_ms=cfg.target_agent_timeout_ms,
                 max_target_retries=cfg.max_target_retries,
             )
-            result = call.response
-
-            active_progress = _get_active_progress()
-            if active_progress is not None:
-                await active_progress.finish_attack(None)
-
-            return {
-                'response': result.text,
-                'error': call.error,
-                'tool_calls': result.tool_calls,
-                'token_usage': result.usage,
-                'finish_reason': result.finish_reason,
-                'model': result.model,
-            }
         finally:
             target_close = getattr(target, 'close', None)
             if callable(target_close):
@@ -1902,25 +1920,13 @@ async def _run_dynamic_or_hybrid(
                             )
                         target_instance = _backend.create_target(_label)
                         resolved_cfg = pipeline_config or PIPELINE_CONFIG
-                        call = await call_target_with_retry(
+                        return await _run_static_target_call(
                             target_instance,
-                            [Message(role='user', content=prompt)],
+                            prompt,
                             target_agent_timeout_ms=resolved_cfg.target_agent_timeout_ms,
                             max_target_retries=resolved_cfg.max_target_retries,
                             map_error=_backend.map_error,
                         )
-                        result = call.response
-                        active_progress = _get_active_progress()
-                        if active_progress is not None:
-                            await active_progress.finish_attack(None)
-                        return {
-                            'response': result.text,
-                            'error': call.error,
-                            'tool_calls': result.tool_calls,
-                            'token_usage': result.usage,
-                            'finish_reason': result.finish_reason,
-                            'model': result.model,
-                        }
 
                     @job(f'redteam:hybrid:{at_safe}')
                     async def at_target_job(

--- a/src/evaluatorq/simulation/runner/simulation.py
+++ b/src/evaluatorq/simulation/runner/simulation.py
@@ -326,6 +326,8 @@ class SimulationRunner:
         max_turns: int | None = None,
         first_message: str | None = None,
         thread_id: str | None = None,
+        messages: list[Message] | None = None,
+        turn_metrics_list: list[TurnMetrics] | None = None,
     ) -> SimulationResult:
         """Run a single simulation. Never throws -- returns error SimulationResult on failure.
 
@@ -349,8 +351,10 @@ class SimulationRunner:
         datapoint_id = datapoint.id if datapoint else ''
 
         effective_max_turns = max_turns or self._max_turns
-        messages: list[Message] = []
-        turn_metrics_list: list[TurnMetrics] = []
+        # Caller-owned sinks: when passed in (e.g. by _run_with_timeout) the turns
+        # completed before an outer cancellation survive in the caller's lists.
+        messages = messages if messages is not None else []
+        turn_metrics_list = turn_metrics_list if turn_metrics_list is not None else []
         # Holder so the outer except can read partial token usage from agents
         # created inside _run_inner (mirrors TS getTotalUsage closure).
         usage_holder: dict[str, Callable[[], TokenUsage]] = {}
@@ -855,31 +859,38 @@ class SimulationRunner:
         if timeout_s <= 0:
             return await self.run(datapoint=datapoint, max_turns=max_turns)
 
+        # Own the sinks so the turns completed before an outer timeout survive the
+        # cancellation of the inner coroutine (asyncio cannot roll back appends).
+        messages: list[Message] = []
+        turn_metrics_list: list[TurnMetrics] = []
         try:
             return await asyncio.wait_for(
-                self.run(datapoint=datapoint, max_turns=max_turns),
+                self.run(
+                    datapoint=datapoint,
+                    max_turns=max_turns,
+                    messages=messages,
+                    turn_metrics_list=turn_metrics_list,
+                ),
                 timeout=timeout_s,
             )
         except asyncio.TimeoutError:
             logger.warning(
-                'Simulation for datapoint %s timed out after %ss; returning timeout result',
+                'Simulation for datapoint %s timed out after %ss; returning partial result',
                 datapoint.id,
                 timeout_s,
             )
-            # The inner run() never throws (returns error result), so a
-            # TimeoutError means asyncio cancelled the task mid-flight.
-            # We cannot recover partial messages from the cancelled coroutine,
-            # so we return a timeout result. run() itself already populates
-            # messages on error paths, matching TS behaviour where possible.
+            # A TimeoutError means asyncio cancelled the inner coroutine mid-flight.
+            # The caller-owned sinks retain every turn that completed before the
+            # cancellation, so the partial transcript is preserved instead of lost.
             return SimulationResult(
-                messages=[],
+                messages=messages,
                 terminated_by=TerminatedBy.timeout,
                 reason=f'Simulation timed out after {timeout_s}s',
                 goal_achieved=False,
                 goal_completion_score=0,
                 rules_broken=[],
-                turn_count=0,
-                turn_metrics=[],
+                turn_count=sum(1 for m in messages if m.role == 'assistant'),
+                turn_metrics=turn_metrics_list,
                 token_usage=ZERO_USAGE.model_copy(),
                 metadata={
                     'persona': datapoint.persona.name,

--- a/src/evaluatorq/simulation/runner/simulation.py
+++ b/src/evaluatorq/simulation/runner/simulation.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from evaluatorq.common.async_utils import await_maybe
+from evaluatorq.common.target_call import TargetCallResult, call_target_with_retry, default_map_error
 from evaluatorq.common.thread_context import conversation_thread
 from evaluatorq.common.tracing import record_llm_input, record_llm_output, record_token_usage, set_span_attrs
 from evaluatorq.contracts import TokenUsage
+from evaluatorq.integrations.callable_integration import CallableTarget
 from evaluatorq.simulation.agents.judge import JudgeAgent, JudgeAgentConfig
 from evaluatorq.simulation.agents.user_simulator import (
     UserSimulatorAgent,
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
     from evaluatorq.contracts import AgentTarget
+    from evaluatorq.integrations.callable_integration.target import AgentCallable
     from evaluatorq.simulation.agents.base import BaseAgent
     from evaluatorq.simulation.hooks import SimulationHooks
 
@@ -243,6 +245,8 @@ class SimulationRunner:
         target: Callable[[list[Message]], str | Awaitable[str]] | None = None,
         model: str = DEFAULT_MODEL,
         max_turns: int = 10,
+        target_agent_timeout_ms: int = 240_000,
+        max_target_retries: int = 2,
         user_simulator: BaseAgent | None = None,
         judge: BaseAgent | None = None,
         hooks: SimulationHooks | None = None,
@@ -252,6 +256,8 @@ class SimulationRunner:
             raise ValueError('Must provide either target_agent or target')
         if max_turns < 1:
             raise ValueError(f'max_turns must be >= 1, got {max_turns}')
+        if max_target_retries < 0:
+            raise ValueError(f'max_target_retries must be >= 0, got {max_target_retries}')
         if not model.strip():
             raise ValueError('model must be a non-empty string')
 
@@ -266,6 +272,14 @@ class SimulationRunner:
 
         self._target_agent = target_agent
         self._target = target
+        # Route both target flavours through the shared retry helper by wrapping a
+        # plain callback in the existing CallableTarget adapter (str->AgentResponse
+        # coercion + sync/async dispatch handled there — no bespoke adapter).
+        self._effective_target: AgentTarget | None = target_agent or (
+            CallableTarget(cast('AgentCallable', target)) if target is not None else None
+        )
+        self._target_agent_timeout_ms = target_agent_timeout_ms
+        self._max_target_retries = max_target_retries
         self._model = model
         self._max_turns = max_turns
         self._shared_client: AsyncOpenAI | None = llm_client
@@ -551,9 +565,12 @@ class SimulationRunner:
                         target_span,
                         [{'role': m.role, 'content': m.content or ''} for m in messages],
                     )
-                    agent_response_text, agent_response_usage, agent_response_model = await self._get_target_response(
-                        messages
-                    )
+                    call = await self._get_target_response(messages)
+                    agent_response_text = call.response.text
+                    # Only trust usage on success; a synthetic error response
+                    # carries no real token accounting.
+                    agent_response_usage = call.response.usage if call.succeeded else None
+                    agent_response_model = call.response.model
                     if agent_response_usage is not None:
                         target_usage_acc['acc'] = target_usage_acc['acc'] + agent_response_usage
                         record_token_usage(
@@ -570,7 +587,21 @@ class SimulationRunner:
                     if agent_response_model is not None and target_model_holder['model'] is None:
                         target_model_holder['model'] = agent_response_model
                     record_llm_output(target_span, agent_response_text)
+                # The failed turn IS recorded (mirrors orchestrator.py's
+                # turns_record.append on exhaustion) before terminating.
                 messages.append(Message(role='assistant', content=agent_response_text))
+
+                if not call.succeeded:
+                    return self._target_failure_result(
+                        call,
+                        persona=persona,
+                        scenario=scenario,
+                        messages=messages,
+                        turn_metrics_list=turn_metrics_list,
+                        run_span=run_span,
+                        total_usage=_get_total_usage(),
+                        target_model=target_model_holder['model'],
+                    )
 
                 async with with_simulation_span('orq.simulation.judge_evaluation', None):
                     judgment = await judge.evaluate(messages)
@@ -730,24 +761,86 @@ class SimulationRunner:
     # Private helpers
     # ---------------------------------------------------------------------------
 
-    async def _get_target_response(self, messages: list[Message]) -> tuple[str, TokenUsage | None, str | None]:
-        """Return (text, usage, target_model).
+    def _target_failure_result(
+        self,
+        call: TargetCallResult,
+        *,
+        persona: Persona | None,
+        scenario: Scenario | None,
+        messages: list[Message],
+        turn_metrics_list: list[TurnMetrics],
+        run_span: Span | None,
+        total_usage: TokenUsage,
+        target_model: str | None,
+    ) -> SimulationResult:
+        """Terminate the run after the target exhausted its retries.
 
-        ``target_model`` is the model identifier reported by the target itself
-        (via ``AgentResponse.model``).  It is ``None`` for plain callbacks,
-        which may call any provider and have no way to report a model.
-        NEVER substitute ``self._model`` here — that is the user-simulator /
+        The failed turn is already appended to ``messages``; this builds the
+        terminal :class:`SimulationResult` (no judge call). Mirrors the judge /
+        max-turns termination branches: records final token usage + span attrs
+        and retains prior ``messages``/``turn_metrics``. A ``timeout`` error type
+        maps to :attr:`TerminatedBy.timeout`, everything else to
+        :attr:`TerminatedBy.error`.
+        """
+        err = call.error
+        error_message = err.message if err else 'target failed'
+        error_type = err.error_type if err else 'target_error'
+        terminated_by = TerminatedBy.timeout if error_type == 'timeout' else TerminatedBy.error
+        turn_count = sum(1 for m in messages if m.role == 'assistant')
+
+        record_token_usage(
+            run_span,
+            prompt_tokens=total_usage.prompt_tokens,
+            completion_tokens=total_usage.completion_tokens,
+            total_tokens=total_usage.total_tokens,
+            cached_tokens=total_usage.cached_tokens,
+            reasoning_tokens=total_usage.reasoning_tokens,
+        )
+        set_span_attrs(
+            run_span,
+            {
+                'orq.simulation.terminated_by': terminated_by.value,
+                'orq.simulation.goal_achieved': False,
+                'orq.simulation.turn_count': turn_count,
+            },
+        )
+
+        metadata = _build_simulation_metadata(persona, scenario, None, target_model)
+        metadata['error'] = error_message
+        metadata['error_type'] = error_type
+        return SimulationResult(
+            messages=messages,
+            terminated_by=terminated_by,
+            reason=error_message,
+            goal_achieved=False,
+            goal_completion_score=0,
+            rules_broken=[],
+            turn_count=turn_count,
+            turn_metrics=turn_metrics_list,
+            token_usage=total_usage,
+            metadata=metadata,
+        )
+
+    async def _get_target_response(self, messages: list[Message]) -> TargetCallResult:
+        """Call the target through the shared bounded-retry + timeout helper.
+
+        Both target flavours (rich ``target_agent`` and a plain callback wrapped
+        in ``CallableTarget``) route through the same helper. The returned
+        :class:`TargetCallResult` carries ``.response`` (always populated — real
+        or synthetic), ``.succeeded``, and ``.error``. ``response.model`` is the
+        model the target reports (``None`` for plain callbacks, which may call any
+        provider); NEVER substitute ``self._model`` — that is the user-simulator /
         judge model, not the evaluated target.
         """
-        if self._target_agent:
-            resp = await self._target_agent.respond(messages)
-            return resp.text, resp.usage, resp.model
-        if self._target:
-            result = self._target(messages)
-            if inspect.isawaitable(result):
-                return await result, None, None
-            return result, None, None
-        raise RuntimeError('No target agent configured')
+        if self._effective_target is None:
+            raise RuntimeError('No target agent configured')
+        return await call_target_with_retry(
+            self._effective_target,
+            messages,
+            target_agent_timeout_ms=self._target_agent_timeout_ms,
+            max_target_retries=self._max_target_retries,
+            map_error=default_map_error,
+        )
 
     @staticmethod
     def _build_criteria_results(scenario: Scenario, judgment: Judgment) -> dict[str, bool]:

--- a/tests/common/test_target_call.py
+++ b/tests/common/test_target_call.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from evaluatorq.common.target_call import (
+    TargetCallResult,
+    call_target_with_retry,
+    classify_error_type,
+    default_map_error,
+)
+from evaluatorq.contracts import AgentResponse, AgentResponseError, Message
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Target:
+    """Minimal AgentTarget double: respond() returns queued items or raises them."""
+
+    def __init__(self, script: list[Any]) -> None:
+        self._script = list(script)
+        self.calls = 0
+
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        self.calls += 1
+        item = self._script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _ok(text: str) -> AgentResponse:
+    return AgentResponse(text=text)
+
+
+def _err(msg: str) -> AgentResponse:
+    return AgentResponse(
+        text=msg, error=AgentResponseError(message=msg, error_type='target_error', code='x')
+    )
+
+
+async def test_success_first_try():
+    t = _Target([_ok('hi')])
+    r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
+    assert r.succeeded is True
+    assert r.error is None
+    assert r.attempts == 1
+    assert r.response.text == 'hi'
+    assert t.calls == 1
+
+
+async def test_retry_then_succeed():
+    t = _Target([_err('boom'), _ok('hi')])
+    r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
+    assert r.succeeded is True
+    assert r.attempts == 2
+    assert t.calls == 2
+
+
+async def test_error_marker_exhausted():
+    t = _Target([_err('boom'), _err('boom'), _err('boom')])
+    r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
+    assert r.succeeded is False
+    assert r.error is not None
+    assert r.attempts == 3
+    assert t.calls == 3
+
+
+async def test_timeout_becomes_synthetic_error():
+    async def _hang(_messages):
+        await asyncio.sleep(10)
+
+    class _Hang:
+        async def respond(self, messages):
+            return await _hang(messages)
+
+    r = await call_target_with_retry(_Hang(), [Message(role='user', content='q')], target_agent_timeout_ms=10, max_target_retries=0)
+    assert r.succeeded is False
+    assert r.error is not None
+    assert r.error.error_type == 'timeout'
+    assert r.error.code == 'target.timeout'
+
+
+async def test_generic_exception_mapped_and_classified():
+    t = _Target([ConnectionError('connection reset')])
+    r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=0)
+    assert r.succeeded is False
+    assert r.error is not None
+    # classify_error_type maps 'connection' -> 'network_error'
+    assert r.error.error_type == 'network_error'
+    assert r.error_details is not None
+    assert r.error_details['exception_type'] == 'ConnectionError'
+    assert 'connection reset' in str(r.error_details['raw_message'])
+
+
+async def test_map_error_none_falls_back_to_default():
+    t = _Target([RuntimeError('weird')])
+    r = await call_target_with_retry(
+        t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=0,
+        map_error=lambda exc: None,  # pyright: ignore[reportArgumentType]
+    )
+    assert r.succeeded is False
+    assert r.error is not None
+    assert r.error.code == 'target_error'  # default_map_error code
+
+
+async def test_on_attempt_called_per_attempt():
+    from contextlib import asynccontextmanager
+
+    seen: list[int] = []
+
+    @asynccontextmanager
+    async def _span(i: int):
+        seen.append(i)
+        yield object()
+
+    t = _Target([_err('boom'), _ok('hi')])
+    await call_target_with_retry(
+        t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2, on_attempt=_span
+    )
+    assert seen == [0, 1]
+
+
+async def test_cancelled_error_propagates():
+    class _Cancel:
+        async def respond(self, messages):
+            raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await call_target_with_retry(_Cancel(), [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
+
+
+def test_default_map_error_shape():
+    code, msg = default_map_error(ValueError('x'))
+    assert code == 'target_error'
+    assert 'ValueError' in msg
+
+
+def test_classify_error_type_moved():
+    assert classify_error_type('rate limit exceeded') == 'rate_limit'
+    assert classify_error_type(None) is None
+    assert classify_error_type('nonsense') == 'unknown'

--- a/tests/common/test_target_call.py
+++ b/tests/common/test_target_call.py
@@ -6,15 +6,11 @@ from typing import Any
 import pytest
 
 from evaluatorq.common.target_call import (
-    TargetCallResult,
     call_target_with_retry,
     classify_error_type,
     default_map_error,
 )
 from evaluatorq.contracts import AgentResponse, AgentResponseError, Message
-
-pytestmark = pytest.mark.asyncio
-
 
 class _Target:
     """Minimal AgentTarget double: respond() returns queued items or raises them."""
@@ -41,6 +37,7 @@ def _err(msg: str) -> AgentResponse:
     )
 
 
+@pytest.mark.asyncio
 async def test_success_first_try():
     t = _Target([_ok('hi')])
     r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
@@ -51,6 +48,7 @@ async def test_success_first_try():
     assert t.calls == 1
 
 
+@pytest.mark.asyncio
 async def test_retry_then_succeed():
     t = _Target([_err('boom'), _ok('hi')])
     r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
@@ -59,6 +57,7 @@ async def test_retry_then_succeed():
     assert t.calls == 2
 
 
+@pytest.mark.asyncio
 async def test_error_marker_exhausted():
     t = _Target([_err('boom'), _err('boom'), _err('boom')])
     r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=2)
@@ -68,6 +67,7 @@ async def test_error_marker_exhausted():
     assert t.calls == 3
 
 
+@pytest.mark.asyncio
 async def test_timeout_becomes_synthetic_error():
     async def _hang(_messages):
         await asyncio.sleep(10)
@@ -83,6 +83,7 @@ async def test_timeout_becomes_synthetic_error():
     assert r.error.code == 'target.timeout'
 
 
+@pytest.mark.asyncio
 async def test_generic_exception_mapped_and_classified():
     t = _Target([ConnectionError('connection reset')])
     r = await call_target_with_retry(t, [Message(role='user', content='q')], target_agent_timeout_ms=1000, max_target_retries=0)
@@ -95,6 +96,7 @@ async def test_generic_exception_mapped_and_classified():
     assert 'connection reset' in str(r.error_details['raw_message'])
 
 
+@pytest.mark.asyncio
 async def test_map_error_none_falls_back_to_default():
     t = _Target([RuntimeError('weird')])
     r = await call_target_with_retry(
@@ -106,6 +108,7 @@ async def test_map_error_none_falls_back_to_default():
     assert r.error.code == 'target_error'  # default_map_error code
 
 
+@pytest.mark.asyncio
 async def test_on_attempt_called_per_attempt():
     from contextlib import asynccontextmanager
 
@@ -123,6 +126,33 @@ async def test_on_attempt_called_per_attempt():
     assert seen == [0, 1]
 
 
+@pytest.mark.asyncio
+async def test_on_attempt_response_receives_each_target_response():
+    from contextlib import asynccontextmanager
+
+    seen: list[tuple[int, str]] = []
+
+    @asynccontextmanager
+    async def _span(i: int):
+        yield i
+
+    def _record_response(span: int, response: AgentResponse) -> None:
+        seen.append((span, response.text))
+
+    t = _Target([_err('retry me'), _ok('hi')])
+    await call_target_with_retry(
+        t,
+        [Message(role='user', content='q')],
+        target_agent_timeout_ms=1000,
+        max_target_retries=2,
+        on_attempt=_span,
+        on_attempt_response=_record_response,
+    )
+
+    assert seen == [(0, 'retry me'), (1, 'hi')]
+
+
+@pytest.mark.asyncio
 async def test_cancelled_error_propagates():
     class _Cancel:
         async def respond(self, messages):

--- a/tests/redteam/test_classify_error_type.py
+++ b/tests/redteam/test_classify_error_type.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from evaluatorq.redteam.contracts import classify_error_type
+from evaluatorq.common.target_call import classify_error_type
 
 
 @pytest.mark.parametrize(

--- a/tests/redteam/test_dynamic_job.py
+++ b/tests/redteam/test_dynamic_job.py
@@ -934,7 +934,45 @@ class TestRuntimeErrorsProduceErrorOutput:
         parsed = AttackOutput.model_validate(output)
         assert parsed.error is not None
         assert parsed.error_code == "target.timeout"
-        assert parsed.error_type == "target_error"
+        assert parsed.error_type == "timeout"
+
+    @pytest.mark.asyncio
+    @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
+    @patch(_PATCH_SET_SPAN_ATTRS)
+    @patch(_PATCH_ATTACK_SPAN_ATTRS)
+    async def test_template_path_connection_error_classified_as_network_error(
+        self, _attrs, _set_attrs, _span
+    ):
+        """A ConnectionError from the target classifies as network_error, not the flat target_error."""
+        from evaluatorq.redteam.adaptive.pipeline import create_dynamic_redteam_job
+        from evaluatorq.redteam.contracts import AttackOutput
+
+        strategy = _make_strategy(
+            turn_type=TurnType.SINGLE,
+            prompt_template="Static attack for {agent_name}.",
+        )
+        target = _make_target()
+        target.respond = AsyncMock(side_effect=ConnectionError("connection refused"))
+        factory = _make_target_factory(target)
+        agent_context = _make_agent_context()
+        datapoint = _make_datapoint(strategy=strategy)
+
+        job_fn = create_dynamic_redteam_job(
+            agent_key="test-agent",
+            agent_context=agent_context,
+            backend=factory,
+        )
+
+        with patch(
+            "evaluatorq.redteam.adaptive.orchestrator._get_active_progress",
+            return_value=None,
+        ):
+            output = await _call_dynamic_job(job_fn, datapoint)
+
+        parsed = AttackOutput.model_validate(output)
+        assert parsed.error_stage == "target_call"
+        assert parsed.error_type == "network_error"
+        assert parsed.error_code
 
     @pytest.mark.asyncio
     @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)

--- a/tests/redteam/test_dynamic_job.py
+++ b/tests/redteam/test_dynamic_job.py
@@ -3,8 +3,8 @@
 Covers:
 1. Template single-turn path   — strategy with prompt_template sends filled template directly
 2. Dynamic multi-turn path     — strategy without prompt_template uses the orchestrator
-3. Programming error re-raise  — TypeError/AttributeError propagate, not caught
-4. Runtime errors              — network/API errors produce AttackOutput with error set
+3. Programming error re-raise  — errors outside target calls propagate
+4. Runtime errors              — target network/API errors produce AttackOutput with error set
 5. Memory entity ID generation — unique ID generated per job when has_memory is True
 """
 
@@ -668,40 +668,6 @@ class TestProgrammingErrorsPropagate:
     @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
     @patch(_PATCH_SET_SPAN_ATTRS)
     @patch(_PATCH_ATTACK_SPAN_ATTRS)
-    async def test_type_error_in_template_path_propagates(
-        self, _attrs, _set_attrs, _span
-    ):
-        """TypeError raised during target.respond in template path is re-raised."""
-        from evaluatorq.job_helper import JobError
-        from evaluatorq.redteam.adaptive.pipeline import create_dynamic_redteam_job
-
-        strategy = _make_strategy(
-            turn_type=TurnType.SINGLE,
-            prompt_template="Static attack for {agent_name}.",
-        )
-        target = _make_target()
-        target.respond = AsyncMock(side_effect=TypeError("type mismatch"))
-        factory = _make_target_factory(target)
-        agent_context = _make_agent_context()
-        datapoint = _make_datapoint(strategy=strategy)
-
-        job_fn = create_dynamic_redteam_job(
-            agent_key="test-agent",
-            agent_context=agent_context,
-            backend=factory,
-        )
-
-        with pytest.raises((TypeError, JobError)) as exc_info:
-            await job_fn(datapoint, 0)
-
-        exc = exc_info.value
-        if isinstance(exc, JobError):
-            assert isinstance(exc.original_error, TypeError)
-
-    @pytest.mark.asyncio
-    @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
-    @patch(_PATCH_SET_SPAN_ATTRS)
-    @patch(_PATCH_ATTACK_SPAN_ATTRS)
     async def test_key_error_from_orchestrator_propagates(
         self, _attrs, _set_attrs, _span
     ):
@@ -891,6 +857,41 @@ class TestRuntimeErrorsProduceErrorOutput:
 
         parsed = AttackOutput.model_validate(output)
         assert parsed.error is not None
+        assert parsed.error_type == "target_error"
+        assert parsed.error_stage == "target_call"
+        assert parsed.n_turns == 1
+
+    @pytest.mark.asyncio
+    @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
+    @patch(_PATCH_SET_SPAN_ATTRS)
+    @patch(_PATCH_ATTACK_SPAN_ATTRS)
+    async def test_type_error_in_template_path_retries_then_preserves_error_output(
+        self, _attrs, _set_attrs, _span
+    ):
+        """A target TypeError is retried and retained as an unscored target failure."""
+        from evaluatorq.redteam.adaptive.pipeline import create_dynamic_redteam_job
+
+        strategy = _make_strategy(
+            turn_type=TurnType.SINGLE,
+            prompt_template="Static attack for {agent_name}.",
+        )
+        target = _make_target()
+        target.respond = AsyncMock(side_effect=TypeError("target returned invalid response"))
+        factory = _make_target_factory(target)
+        job_fn = create_dynamic_redteam_job(
+            agent_key="test-agent",
+            agent_context=_make_agent_context(),
+            backend=factory,
+        )
+
+        with patch(
+            "evaluatorq.redteam.adaptive.orchestrator._get_active_progress",
+            return_value=None,
+        ):
+            output = await _call_dynamic_job(job_fn, _make_datapoint(strategy=strategy))
+
+        parsed = AttackOutput.model_validate(output)
+        assert target.respond.await_count == 3
         assert parsed.error_type == "target_error"
         assert parsed.error_stage == "target_call"
         assert parsed.n_turns == 1

--- a/tests/redteam/test_dynamic_job.py
+++ b/tests/redteam/test_dynamic_job.py
@@ -923,13 +923,14 @@ class TestRuntimeErrorsProduceErrorOutput:
             backend=factory,
         )
 
-        # Patch wait_for to raise immediately so we don't actually wait
-        with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()):
-            with patch(
-                "evaluatorq.redteam.adaptive.orchestrator._get_active_progress",
-                return_value=None,
-            ):
-                output = await _call_dynamic_job(job_fn, datapoint)
+        # The target raises immediately, so no timeout patch is needed. Replacing
+        # ``asyncio.wait_for`` synchronously would leave each retry coroutine
+        # unawaited before the helper can manage it.
+        with patch(
+            "evaluatorq.redteam.adaptive.orchestrator._get_active_progress",
+            return_value=None,
+        ):
+            output = await _call_dynamic_job(job_fn, datapoint)
 
         parsed = AttackOutput.model_validate(output)
         assert parsed.error is not None

--- a/tests/redteam/test_exceptions.py
+++ b/tests/redteam/test_exceptions.py
@@ -2,11 +2,13 @@
 
 import pytest
 
+from evaluatorq.contracts import AgentResponse, AgentResponseError
 from evaluatorq.redteam.exceptions import (
     BackendError,
     CancelledError,
     CredentialError,
     RedTeamError,
+    TargetResponseError,
 )
 
 
@@ -25,6 +27,10 @@ class TestExceptionHierarchy:
         """CancelledError must inherit from RedTeamError."""
         assert issubclass(CancelledError, RedTeamError)
 
+    def test_target_response_error_is_subclass_of_redteam_error(self):
+        """TargetResponseError must belong to the red-team exception hierarchy."""
+        assert issubclass(TargetResponseError, RedTeamError)
+
     @pytest.mark.parametrize(
         "exc_class",
         [CredentialError, BackendError, CancelledError],
@@ -33,3 +39,10 @@ class TestExceptionHierarchy:
         """All concrete exceptions can be caught with except RedTeamError."""
         with pytest.raises(RedTeamError):
             raise exc_class("test message")
+
+    def test_target_response_error_is_caught_by_redteam_error(self):
+        """TargetResponseError accepts and preserves a target error response."""
+        response = AgentResponse(error=AgentResponseError(message='test message', error_type='target_error'))
+
+        with pytest.raises(RedTeamError):
+            raise TargetResponseError(response)

--- a/tests/redteam/test_exceptions.py
+++ b/tests/redteam/test_exceptions.py
@@ -2,13 +2,11 @@
 
 import pytest
 
-from evaluatorq.contracts import AgentResponse, AgentResponseError
 from evaluatorq.redteam.exceptions import (
     BackendError,
     CancelledError,
     CredentialError,
     RedTeamError,
-    TargetResponseError,
 )
 
 
@@ -27,10 +25,6 @@ class TestExceptionHierarchy:
         """CancelledError must inherit from RedTeamError."""
         assert issubclass(CancelledError, RedTeamError)
 
-    def test_target_response_error_is_subclass_of_redteam_error(self):
-        """TargetResponseError must belong to the red-team exception hierarchy."""
-        assert issubclass(TargetResponseError, RedTeamError)
-
     @pytest.mark.parametrize(
         "exc_class",
         [CredentialError, BackendError, CancelledError],
@@ -39,10 +33,3 @@ class TestExceptionHierarchy:
         """All concrete exceptions can be caught with except RedTeamError."""
         with pytest.raises(RedTeamError):
             raise exc_class("test message")
-
-    def test_target_response_error_is_caught_by_redteam_error(self):
-        """TargetResponseError accepts and preserves a target error response."""
-        response = AgentResponse(error=AgentResponseError(message='test message', error_type='target_error'))
-
-        with pytest.raises(RedTeamError):
-            raise TargetResponseError(response)

--- a/tests/redteam/test_orchestrator.py
+++ b/tests/redteam/test_orchestrator.py
@@ -434,7 +434,7 @@ class TestTimeoutHandling:
             max_turns=3,
         )
 
-        assert result.error_type == 'target_error'
+        assert result.error_type == 'timeout'
         assert result.error_code == 'target.timeout'
         assert result.error_stage == 'target_call'
         assert result.error_details is not None
@@ -535,7 +535,7 @@ class TestTimeoutHandling:
             max_turns=1,
         )
 
-        assert result.error_type == 'target_error'
+        assert result.error_type == 'timeout'
         assert result.error_code == 'target.timeout'
         assert result.error_stage == 'target_call'
         assert result.error_turn == 1

--- a/tests/redteam/test_orchestrator_coverage.py
+++ b/tests/redteam/test_orchestrator_coverage.py
@@ -867,7 +867,7 @@ class TestRunAttack:
         )
 
         assert result.error_code == "target.timeout"
-        assert result.error_type == "target_error"
+        assert result.error_type == "timeout"
         assert result.n_turns == 1
 
     @pytest.mark.asyncio
@@ -875,7 +875,7 @@ class TestRunAttack:
     @patch(_PATCH_LLM_SPAN, side_effect=_noop_span_ctx)
     @patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
     async def test_target_exception_retries_exhausted_abort(self, _rs, _ls, _rl):
-        """Exhausted same-exchange exception retries abort with target_error."""
+        """Exhausted same-exchange exception retries abort with a classified error_type."""
         orchestrator, mock_llm = _make_orchestrator()
         target = _make_target()
 
@@ -893,7 +893,9 @@ class TestRunAttack:
             max_turns=5,
         )
 
-        assert result.error_type == "target_error"
+        # "connection refused" classifies to network_error (outer error_type now carries
+        # the classified type, not the flat "target_error"); error_stage stays target_call.
+        assert result.error_type == "network_error"
         assert result.error_stage == "target_call"
         assert result.n_turns == 1
 

--- a/tests/redteam/test_orchestrator_transcript.py
+++ b/tests/redteam/test_orchestrator_transcript.py
@@ -280,7 +280,7 @@ class TestOrchestratorTranscript:
         assert errored[0].target.error is not None
         # "rate limit exceeded" classifies to rate_limit (not the generic target_error)
         assert errored[0].target.error.error_type == "rate_limit"
-        # _default_map_error (no backend) returns code "target_error"
+        # default_map_error (no backend) returns code "target_error"
         assert errored[0].target.error.code == "target_error"
 
     @pytest.mark.asyncio

--- a/tests/redteam/test_scorer_error_turns.py
+++ b/tests/redteam/test_scorer_error_turns.py
@@ -49,6 +49,10 @@ def _params(output: AttackOutput) -> dict[str, object]:
     return {'data': SimpleNamespace(inputs={}), 'output': output}
 
 
+def _make_datapoint(category: str) -> SimpleNamespace:
+    return SimpleNamespace(inputs={'category': category, 'messages': []})
+
+
 def _resistant() -> AttackEvaluationResult:
     return AttackEvaluationResult(passed=True, explanation='resisted', evaluator_id='goal_hijacking')
 
@@ -66,6 +70,25 @@ async def test_all_error_turns_scored_as_error_not_resistant():
 
     judge.assert_not_called()
     assert result.value == 'error'
+
+
+@pytest.mark.asyncio
+async def test_scorer_short_circuits_on_target_error():
+    """A static output dict carrying a target-level error must not be judged as content."""
+    from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import create_owasp_evaluator
+
+    evaluator = create_owasp_evaluator()  # single-judge default
+    scorer = evaluator['scorer']  # create_owasp_evaluator returns an EvaluatorqEvaluatorConfig TypedDict
+    params = {
+        'data': _make_datapoint(category='LLM01'),
+        'output': {
+            'response': 'anything',
+            'error': AgentResponseError(message='boom', error_type='target_error', code='x'),
+        },
+    }
+    result = await scorer(params)
+    assert result.value == 'error'
+    assert result.pass_ is None  # `pass_` (aliased to `pass`) -> None means unscored
 
 
 @pytest.mark.asyncio

--- a/tests/redteam/test_static_target_job.py
+++ b/tests/redteam/test_static_target_job.py
@@ -27,6 +27,11 @@ class _StubTarget:
         pass
 
 
+class _RaisingTarget:
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        raise RuntimeError('backend exploded')
+
+
 def _datapoint(text: str = 'hello there') -> DataPoint:
     return DataPoint(inputs={'messages': [{'role': 'user', 'content': text}]})
 
@@ -58,3 +63,18 @@ async def test_static_job_success_has_none_error() -> None:
 
     assert out['error'] is None
     assert out['response'] == 'hello'
+
+
+async def test_shared_static_target_call_uses_the_supplied_error_mapper() -> None:
+    from evaluatorq.redteam.runner import _run_static_target_call
+
+    out = await _run_static_target_call(
+        _RaisingTarget(),
+        'hello there',
+        max_target_retries=0,
+        target_agent_timeout_ms=1000,
+        map_error=lambda _: ('custom.error', 'mapped failure'),
+    )
+
+    assert out['error'] is not None
+    assert out['error'].code == 'custom.error'

--- a/tests/redteam/test_static_target_job.py
+++ b/tests/redteam/test_static_target_job.py
@@ -1,0 +1,60 @@
+"""Tests for the static AgentTarget job's error-field forwarding.
+
+Covers ``_create_static_job_for_agent_target``, which now wraps its
+target call in ``call_target_with_retry`` (see
+``evaluatorq.common.target_call``) and surfaces the target's
+``AgentResponse.error`` in its output dict.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, AgentResponseError, Message
+from evaluatorq.types import DataPoint
+
+pytestmark = pytest.mark.asyncio
+
+
+class _StubTarget:
+    def __init__(self, resp: AgentResponse) -> None:
+        self._resp = resp
+
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        return self._resp
+
+    async def close(self) -> None:
+        pass
+
+
+def _datapoint(text: str = 'hello there') -> DataPoint:
+    return DataPoint(inputs={'messages': [{'role': 'user', 'content': text}]})
+
+
+async def test_static_job_forwards_error_field() -> None:
+    from evaluatorq.redteam.runner import _create_static_job_for_agent_target
+
+    err_resp = AgentResponse(
+        text='[ERROR: boom]',
+        error=AgentResponseError(message='boom', error_type='target_error', code='x'),
+    )
+    job = _create_static_job_for_agent_target(lambda: _StubTarget(err_resp), 'lbl')
+
+    wrapped = await job(_datapoint(), 0)
+    out = wrapped['output']
+
+    assert out['error'] is not None
+    assert out['error'].code == 'x'
+
+
+async def test_static_job_success_has_none_error() -> None:
+    from evaluatorq.redteam.runner import _create_static_job_for_agent_target
+
+    ok = AgentResponse(text='hello')
+    job = _create_static_job_for_agent_target(lambda: _StubTarget(ok), 'lbl')
+
+    wrapped = await job(_datapoint(), 0)
+    out = wrapped['output']
+
+    assert out['error'] is None
+    assert out['response'] == 'hello'

--- a/tests/simulation/runner/test_target_retry.py
+++ b/tests/simulation/runner/test_target_retry.py
@@ -11,6 +11,7 @@ Verifies:
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -134,3 +135,53 @@ async def test_target_exhausted_terminates_with_error_and_failed_turn() -> None:
     # The failed turn IS recorded: an assistant message is present.
     assert any(m.role == 'assistant' for m in result.messages)
     assert result.metadata.get('error')
+
+
+def _make_continue_judgment() -> MagicMock:
+    """Judge verdict that never terminates -- keeps the loop going to turn 2."""
+    j = _make_mock_judgment()
+    j.should_terminate = False
+    j.goal_achieved = False
+    j.goal_completion_score = 0.0
+    j.reason = 'continue'
+    return j
+
+
+def _make_continue_judge() -> MagicMock:
+    j = MagicMock()
+    j.evaluate = AsyncMock(return_value=_make_continue_judgment())
+    j.get_usage = MagicMock(return_value=TokenUsage())
+    return j
+
+
+class _HangSecond:
+    """Answers the first turn quickly, then hangs forever on the second."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        self.calls += 1
+        if self.calls == 1:
+            return AgentResponse(text='first answer')
+        await asyncio.sleep(100)
+        raise AssertionError('unreachable')  # pragma: no cover
+
+
+async def test_outer_timeout_retains_partial_transcript() -> None:
+    target = _HangSecond()
+    runner = SimulationRunner(
+        target_agent=target,
+        max_target_retries=0,
+        target_agent_timeout_ms=60000,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_continue_judge(),
+    )
+
+    result = await runner._run_with_timeout(_make_datapoint(), max_turns=5, timeout_s=0.3)
+
+    assert result.terminated_by == TerminatedBy.timeout
+    # Partial transcript retained: the turn-1 assistant answer survived the outer
+    # cancellation instead of being discarded as an empty list.
+    assert result.messages != []
+    assert any(m.content == 'first answer' for m in result.messages)

--- a/tests/simulation/runner/test_target_retry.py
+++ b/tests/simulation/runner/test_target_retry.py
@@ -214,6 +214,14 @@ async def _async_callback(messages: list[Message]) -> str:
     return 'async ok'
 
 
+async def _awaitable_callback_response() -> str:
+    return 'awaited ok'
+
+
+def _sync_callback_returning_awaitable(messages: list[Message]):
+    return _awaitable_callback_response()
+
+
 class _RaisingCallback:
     """Raises on every call so the retry helper exhausts and the run errors."""
 
@@ -255,6 +263,22 @@ async def test_async_callback_target_succeeds() -> None:
 
     assert result.terminated_by != TerminatedBy.error, result.reason
     assert any(m.role == 'assistant' and m.content == 'async ok' for m in result.messages)
+
+
+async def test_sync_callback_returning_awaitable_is_awaited() -> None:
+    runner = SimulationRunner(
+        target=_sync_callback_returning_awaitable,
+        max_target_retries=1,
+        target_agent_timeout_ms=5000,
+        max_turns=1,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_mock_judge(),
+    )
+
+    result = await runner.run(datapoint=_make_datapoint())
+
+    assert result.terminated_by != TerminatedBy.error, result.reason
+    assert any(m.role == 'assistant' and m.content == 'awaited ok' for m in result.messages)
 
 
 async def test_raising_callback_target_retried_then_terminates_with_error() -> None:

--- a/tests/simulation/runner/test_target_retry.py
+++ b/tests/simulation/runner/test_target_retry.py
@@ -1,0 +1,136 @@
+"""Per-turn target retry + error tracking for SimulationRunner.
+
+Verifies:
+- A rich ``target_agent`` whose ``respond()`` returns an error marker on the
+  first attempt is retried and, on eventual success, the run does NOT terminate
+  as an error.
+- When the target keeps failing past ``max_target_retries``, the run terminates
+  with ``terminated_by == error``, the failed turn IS appended (an assistant
+  message is present), and ``metadata['error']`` is populated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, AgentResponseError, Message, TokenUsage
+from evaluatorq.simulation.runner.simulation import SimulationRunner
+from evaluatorq.simulation.types import (
+    CommunicationStyle,
+    Persona,
+    Scenario,
+    SimulationDatapoint,
+    TerminatedBy,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror tests/simulation/test_target_model.py conventions)
+# ---------------------------------------------------------------------------
+
+
+def _make_datapoint() -> SimulationDatapoint:
+    persona = Persona(
+        name='Retry Tester',
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background='Testing target retry',
+    )
+    scenario = Scenario(name='Retry Scenario', goal='Verify retry behaviour')
+    return SimulationDatapoint(
+        id='dp-target-retry-001',
+        persona=persona,
+        scenario=scenario,
+        user_system_prompt='system',
+        first_message='Hello, can you help me?',
+    )
+
+
+def _make_mock_judgment() -> MagicMock:
+    j = MagicMock()
+    j.should_terminate = True
+    j.goal_achieved = True
+    j.goal_completion_score = 1.0
+    j.rules_broken = []
+    j.reason = 'Done'
+    j.response_quality = 0.9
+    j.hallucination_risk = 0.1
+    j.tone_appropriateness = 0.9
+    j.factual_accuracy = 0.9
+    return j
+
+
+def _make_mock_user_simulator() -> MagicMock:
+    sim = MagicMock()
+    sim.generate_first_message = AsyncMock(return_value='Hello')
+    sim.respond_async = AsyncMock(return_value='thanks')
+    sim.get_usage = MagicMock(return_value=TokenUsage())
+    return sim
+
+
+def _make_mock_judge() -> MagicMock:
+    j = MagicMock()
+    j.evaluate = AsyncMock(return_value=_make_mock_judgment())
+    j.get_usage = MagicMock(return_value=TokenUsage())
+    return j
+
+
+class _FlakyTarget:
+    """Returns an error-marker AgentResponse for the first ``fail_times`` calls."""
+
+    def __init__(self, fail_times: int) -> None:
+        self._fail = fail_times
+        self.calls = 0
+
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        self.calls += 1
+        if self._fail > 0:
+            self._fail -= 1
+            return AgentResponse(
+                text='[ERROR]',
+                error=AgentResponseError(message='boom', error_type='target_error'),
+            )
+        return AgentResponse(text='ok')
+
+
+async def test_target_retries_then_succeeds() -> None:
+    target = _FlakyTarget(fail_times=1)
+    runner = SimulationRunner(
+        target_agent=target,
+        max_target_retries=2,
+        target_agent_timeout_ms=5000,
+        max_turns=1,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_mock_judge(),
+    )
+
+    result = await runner.run(datapoint=_make_datapoint())
+
+    assert target.calls == 2
+    assert result.terminated_by != TerminatedBy.error, result.reason
+
+
+async def test_target_exhausted_terminates_with_error_and_failed_turn() -> None:
+    target = _FlakyTarget(fail_times=99)
+    runner = SimulationRunner(
+        target_agent=target,
+        max_target_retries=1,
+        target_agent_timeout_ms=5000,
+        max_turns=3,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_mock_judge(),
+    )
+
+    result = await runner.run(datapoint=_make_datapoint())
+
+    assert result.terminated_by == TerminatedBy.error
+    # The failed turn IS recorded: an assistant message is present.
+    assert any(m.role == 'assistant' for m in result.messages)
+    assert result.metadata.get('error')

--- a/tests/simulation/runner/test_target_retry.py
+++ b/tests/simulation/runner/test_target_retry.py
@@ -16,7 +16,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from evaluatorq.contracts import AgentResponse, AgentResponseError, Message, TokenUsage
+from evaluatorq.contracts import (
+    AgentResponse,
+    AgentResponseError,
+    AgentTarget,
+    Message,
+    TokenUsage,
+)
 from evaluatorq.simulation.runner.simulation import SimulationRunner
 from evaluatorq.simulation.types import (
     CommunicationStyle,
@@ -83,12 +89,16 @@ def _make_mock_judge() -> MagicMock:
     return j
 
 
-class _FlakyTarget:
+class _FlakyTarget(AgentTarget):
     """Returns an error-marker AgentResponse for the first ``fail_times`` calls."""
 
     def __init__(self, fail_times: int) -> None:
+        super().__init__()
         self._fail = fail_times
         self.calls = 0
+
+    def new(self) -> _FlakyTarget:
+        return _FlakyTarget(self._fail)
 
     async def respond(self, messages: list[Message]) -> AgentResponse:
         self.calls += 1
@@ -154,11 +164,15 @@ def _make_continue_judge() -> MagicMock:
     return j
 
 
-class _HangSecond:
+class _HangSecond(AgentTarget):
     """Answers the first turn quickly, then hangs forever on the second."""
 
     def __init__(self) -> None:
+        super().__init__()
         self.calls = 0
+
+    def new(self) -> _HangSecond:
+        return _HangSecond()
 
     async def respond(self, messages: list[Message]) -> AgentResponse:
         self.calls += 1
@@ -185,3 +199,78 @@ async def test_outer_timeout_retains_partial_transcript() -> None:
     # cancellation instead of being discarded as an empty list.
     assert result.messages != []
     assert any(m.content == 'first answer' for m in result.messages)
+
+
+# ---------------------------------------------------------------------------
+# Callback target (``target=``) — wrapped internally via CallableTarget.
+# ---------------------------------------------------------------------------
+
+
+def _sync_callback(messages: list[Message]) -> str:
+    return 'sync ok'
+
+
+async def _async_callback(messages: list[Message]) -> str:
+    return 'async ok'
+
+
+class _RaisingCallback:
+    """Raises on every call so the retry helper exhausts and the run errors."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, messages: list[Message]) -> str:
+        self.calls += 1
+        raise RuntimeError('callback exploded')
+
+
+async def test_sync_callback_target_succeeds() -> None:
+    runner = SimulationRunner(
+        target=_sync_callback,
+        max_target_retries=1,
+        target_agent_timeout_ms=5000,
+        max_turns=1,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_mock_judge(),
+    )
+
+    result = await runner.run(datapoint=_make_datapoint())
+
+    assert result.terminated_by != TerminatedBy.error, result.reason
+    assert any(m.role == 'assistant' and m.content == 'sync ok' for m in result.messages)
+
+
+async def test_async_callback_target_succeeds() -> None:
+    runner = SimulationRunner(
+        target=_async_callback,
+        max_target_retries=1,
+        target_agent_timeout_ms=5000,
+        max_turns=1,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_mock_judge(),
+    )
+
+    result = await runner.run(datapoint=_make_datapoint())
+
+    assert result.terminated_by != TerminatedBy.error, result.reason
+    assert any(m.role == 'assistant' and m.content == 'async ok' for m in result.messages)
+
+
+async def test_raising_callback_target_retried_then_terminates_with_error() -> None:
+    callback = _RaisingCallback()
+    runner = SimulationRunner(
+        target=callback,
+        max_target_retries=1,
+        target_agent_timeout_ms=5000,
+        max_turns=3,
+        user_simulator=_make_mock_user_simulator(),
+        judge=_make_mock_judge(),
+    )
+
+    result = await runner.run(datapoint=_make_datapoint())
+
+    assert callback.calls == 2  # 1 initial attempt + 1 retry
+    assert result.terminated_by == TerminatedBy.error
+    assert any(m.role == 'assistant' for m in result.messages)
+    assert result.metadata.get('error')


### PR DESCRIPTION
## What

Extracts one neutral `call_target_with_retry` helper (`src/evaluatorq/common/target_call.py`) and adopts it across **all six** `AgentTarget.respond()` call points, so target failures are consistently retried and relayed as unscored errors instead of being judged as real agent content.

Six call points now share the helper:
- Dynamic red-team: orchestrator (multi-turn), pipeline (single-turn template)
- Static red-team: both `runner.py` jobs (standalone + hybrid)
- Simulation: rich `target_agent` and callback `target` (via existing `CallableTarget`)

## Why

Static and simulation paths pulled only `.text/.usage/.model` off the response and **dropped `.error`** — a returned target error or timeout marker got judged as agent content (false "resistant" / false success). This closes that gap everywhere and unifies the retry/timeout mechanics that previously existed only on the dynamic paths (and had already diverged).

## Key changes

- **`call_target_with_retry`** owns bounded retry, per-call timeout, `.error`-marker detection, exception mapping (`default_map_error` + `classify_error_type`), and a per-attempt tracing hook (`on_attempt`). Returns a `TargetCallResult` dataclass. Does **not** catch `CancelledError` (lets outer-ceiling cancellation propagate).
- **`classify_error_type` + `_coerce_to_agent_response`** moved into the neutral module (re-export shims keep existing importers working). Module imports nothing from `redteam`/`simulation`.
- **`TargetResponseError` deleted** — result inspection replaces raise/catch control flow.
- **Static red-team**: output dict gains an `error` field; the OWASP static scorer short-circuits to an unscored `error` (before the single-judge/jury split, so both branches are covered).
- **`error_type` now carries the classified type** (`timeout` / `network_error` / `rate_limit` / … else `target_error`) on both dynamic paths; `error_stage='target_call'` stays as the "where". Two dimensions, no new fields.
- **Simulation**: new `target_agent_timeout_ms` + `max_target_retries` config; both target types route through the helper; on exhausted failure the failed turn is appended and the run terminates retaining the partial transcript. A streamed transcript sink also retains the partial conversation on the whole-run `timeout_per_simulation` ceiling (previously discarded to `messages=[]`).

## Tests

- New `tests/common/test_target_call.py` (helper unit tests: retry, timeout→synthetic, mapping+classification, `map_error` None-guard, `on_attempt`, `CancelledError` propagation).
- New static-job + scorer + simulation retry/timeout/callback tests.
- Full unit suite: **3024 passed**. `ruff check src`, `ruff format --check src`, and `basedpyright` all clean (exit 0).

## Stacking

Stacked on `Baukebrenninkmeijer/pii-timeout-false-success` (this PR is based on it). That branch adds `TargetResponseError`; this branch deletes it — intended stacking churn. **Merge the parent first**, then rebase/retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
