### PR TITLE
feat: support a previous run as an input source for sim + red teaming

### DIFF
--- a/src/evaluatorq/common/replay.py
+++ b/src/evaluatorq/common/replay.py
@@ -38,8 +38,37 @@ MIN_RUN_ID_PREFIX = 8
 _SUGGEST_LIMIT = 5
 
 
+REPLAY_VERSION_KEY = 'replay_version'
+"""Key under which a saved run stamps the format its replay payload is written in."""
+
+REPLAY_VERSION = 1
+"""Format version this build writes and is able to read.
+
+Without a marker, recognising an unreplayable run means sniffing for an absent
+``datapoints`` key — a trick that only works for the one transition from
+pre-replay runs. Stamping the version means the *next* format change can say
+"saved by a newer version of evaluatorq" instead of failing structurally
+somewhere downstream. Runs with no marker are pre-versioning and are read as
+version 1, which is what they are.
+"""
+
+
 class ReplayError(RuntimeError):
     """A previous-run reference could not be resolved or replayed."""
+
+
+def check_replay_version(payload: dict[str, Any], path: Path, *, surface: str) -> None:
+    """Reject a run whose replay payload is newer than this build understands.
+
+    Raises:
+        ReplayError: The run declares a format version above :data:`REPLAY_VERSION`.
+    """
+    stored = payload.get(REPLAY_VERSION_KEY)
+    if isinstance(stored, int) and stored > REPLAY_VERSION:
+        raise ReplayError(
+            f'{path.name} was saved by a newer version of evaluatorq (replay format v{stored}; '
+            f'this build reads v{REPLAY_VERSION}). Upgrade evaluatorq to replay this {surface} run.'
+        )
 
 
 def _reports_newest_first(runs_dir: Path) -> list[Path]:
@@ -151,4 +180,5 @@ def load_run_payload(reference: str, runs_dir: Path, *, surface: str) -> tuple[d
         raise ReplayError(f'Previous {surface} run {path} is not valid JSON: {exc}') from exc
     if not isinstance(payload, dict):
         raise ReplayError(f'Previous {surface} run {path} does not contain a run object.')
+    check_replay_version(payload, path, surface=surface)
     return payload, path

--- a/src/evaluatorq/common/replay.py
+++ b/src/evaluatorq/common/replay.py
@@ -1,0 +1,138 @@
+"""Resolve a "previous run" reference to the JSON payload of a persisted run.
+
+Both surfaces persist their runs under ``.evaluatorq/`` (``runs/`` for red
+teaming, ``sim-runs/`` for agent simulation) and both want the same thing: take
+a handle a user can actually type — the filename shown by ``eq redteam runs`` /
+``eq sim runs``, a run id from a manifest, or just ``latest`` — and turn it into
+the stored record so its cases can be replayed.
+
+Resolution order for a reference, first match wins:
+
+1. ``latest`` — the most recently modified report in the runs dir.
+2. An existing file path (absolute or relative to the cwd).
+3. ``<runs_dir>/<reference>`` and ``<runs_dir>/<reference>.json``.
+4. A manifest ``run_id`` (exact, or an unambiguous prefix of at least 8 chars)
+   whose manifest records a ``report_path``.
+5. A report whose filename stem equals the reference, or whose stem starts with
+   ``<reference>_`` (the ``<run-name>_<timestamp>`` convention) — newest wins.
+
+Anything else raises :class:`ReplayError` naming the runs dir and the most
+recent runs, so a typo is one line away from being fixed.
+"""
+
+from __future__ import annotations
+
+import json
+import operator
+from pathlib import Path
+from typing import Any
+
+MIN_RUN_ID_PREFIX = 8
+"""Shortest run-id prefix accepted for resolution (uuid4 hex is 32 chars)."""
+
+_SUGGEST_LIMIT = 5
+
+
+class ReplayError(RuntimeError):
+    """A previous-run reference could not be resolved or replayed."""
+
+
+def _reports_newest_first(runs_dir: Path) -> list[Path]:
+    if not runs_dir.is_dir():
+        return []
+    reports: list[tuple[float, Path]] = []
+    for p in runs_dir.glob('*.json'):
+        try:
+            reports.append((p.stat().st_mtime, p))
+        except OSError:  # noqa: PERF203 — best-effort listing, a vanished file is skipped
+            continue
+    reports.sort(key=operator.itemgetter(0), reverse=True)
+    return [p for _, p in reports]
+
+
+def _resolve_via_manifest(reference: str, runs_dir: Path) -> Path | None:
+    """Match *reference* against manifest run ids (exact, then unique prefix)."""
+    from evaluatorq.common.run_manifest import list_manifests
+
+    manifests = [(m.run_id, m.report_path) for m in list_manifests(runs_dir) if m.report_path]
+    for run_id, report_path in manifests:
+        if run_id == reference:
+            return Path(report_path)
+    if len(reference) < MIN_RUN_ID_PREFIX:
+        return None
+    matches = {report_path for run_id, report_path in manifests if run_id.startswith(reference)}
+    if len(matches) == 1:
+        return Path(next(iter(matches)))
+    if len(matches) > 1:
+        raise ReplayError(
+            f'Run reference {reference!r} is ambiguous — it matches {len(matches)} runs. Use a longer id.'
+        )
+    return None
+
+
+def _resolve_via_name(reference: str, runs_dir: Path) -> Path | None:
+    """Match *reference* against report filename stems, newest first."""
+    for p in _reports_newest_first(runs_dir):
+        if p.stem == reference or p.stem.startswith(f'{reference}_'):
+            return p
+    return None
+
+
+def _not_found(reference: str, runs_dir: Path, surface: str) -> ReplayError:
+    recent = [p.name for p in _reports_newest_first(runs_dir)[:_SUGGEST_LIMIT]]
+    hint = f' Recent runs: {", ".join(recent)}.' if recent else f' No runs found in {runs_dir}.'
+    return ReplayError(
+        f'Could not resolve previous {surface} run {reference!r} in {runs_dir}. '
+        f'Pass a run file name, a run id, a path to a saved run, or "latest".{hint}'
+    )
+
+
+def resolve_run_path(reference: str, runs_dir: Path, *, surface: str) -> Path:
+    """Return the report file a previous-run *reference* points at.
+
+    Args:
+        reference: What the user typed — ``latest``, a path, a file name, a run
+            name, or a manifest run id (full or an unambiguous 8+ char prefix).
+        runs_dir: The surface's runs directory (e.g. ``.evaluatorq/runs``).
+        surface: Human-readable surface name used in error messages.
+
+    Raises:
+        ReplayError: The reference is empty, ambiguous, or matches nothing.
+    """
+    ref = reference.strip()
+    if not ref:
+        raise ReplayError(f'Empty previous {surface} run reference.')
+
+    if ref.lower() == 'latest':
+        reports = _reports_newest_first(runs_dir)
+        if not reports:
+            raise ReplayError(f'No saved {surface} runs found in {runs_dir} — nothing to replay.')
+        return reports[0]
+
+    direct = Path(ref)
+    if direct.is_file():
+        return direct
+
+    for candidate in (runs_dir / ref, runs_dir / f'{ref}.json'):
+        if candidate.is_file():
+            return candidate
+
+    resolved = _resolve_via_manifest(ref, runs_dir) or _resolve_via_name(ref, runs_dir)
+    if resolved is not None and resolved.is_file():
+        return resolved
+
+    raise _not_found(ref, runs_dir, surface)
+
+
+def load_run_payload(reference: str, runs_dir: Path, *, surface: str) -> tuple[dict[str, Any], Path]:
+    """Resolve *reference* and read the stored run JSON as a dict."""
+    path = resolve_run_path(reference, runs_dir, surface=surface)
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except OSError as exc:
+        raise ReplayError(f'Could not read previous {surface} run {path}: {exc}') from exc
+    except json.JSONDecodeError as exc:
+        raise ReplayError(f'Previous {surface} run {path} is not valid JSON: {exc}') from exc
+    if not isinstance(payload, dict):
+        raise ReplayError(f'Previous {surface} run {path} does not contain a run object.')
+    return payload, path

--- a/src/evaluatorq/common/replay.py
+++ b/src/evaluatorq/common/replay.py
@@ -117,9 +117,12 @@ def resolve_run_path(reference: str, runs_dir: Path, *, surface: str) -> Path:
         if candidate.is_file():
             return candidate
 
-    resolved = _resolve_via_manifest(ref, runs_dir) or _resolve_via_name(ref, runs_dir)
-    if resolved is not None and resolved.is_file():
-        return resolved
+    # A manifest can outlive the report it points at (deleted, moved). Check the
+    # file exists before accepting it, or a stale manifest would mask a perfectly
+    # good name match and report the run as unresolvable.
+    for resolved in (_resolve_via_manifest(ref, runs_dir), _resolve_via_name(ref, runs_dir)):
+        if resolved is not None and resolved.is_file():
+            return resolved
 
     raise _not_found(ref, runs_dir, surface)
 

--- a/src/evaluatorq/common/replay.py
+++ b/src/evaluatorq/common/replay.py
@@ -12,9 +12,12 @@ Resolution order for a reference, first match wins:
 2. An existing file path (absolute or relative to the cwd).
 3. ``<runs_dir>/<reference>`` and ``<runs_dir>/<reference>.json``.
 4. A manifest ``run_id`` (exact, or an unambiguous prefix of at least 8 chars)
-   whose manifest records a ``report_path``.
+   whose manifest records a ``report_path``. An ambiguous id prefix is an error:
+   ids are opaque, so there is no sensible way to pick one.
 5. A report whose filename stem equals the reference, or whose stem starts with
    ``<reference>_`` (the ``<run-name>_<timestamp>`` convention) — newest wins.
+   Names are *expected* to repeat across runs, so ambiguity here resolves to the
+   most recent (logged) rather than raising.
 
 Anything else raises :class:`ReplayError` naming the runs dir and the most
 recent runs, so a typo is one line away from being fixed.
@@ -26,6 +29,8 @@ import json
 import operator
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 MIN_RUN_ID_PREFIX = 8
 """Shortest run-id prefix accepted for resolution (uuid4 hex is 32 chars)."""
@@ -71,11 +76,19 @@ def _resolve_via_manifest(reference: str, runs_dir: Path) -> Path | None:
 
 
 def _resolve_via_name(reference: str, runs_dir: Path) -> Path | None:
-    """Match *reference* against report filename stems, newest first."""
-    for p in _reports_newest_first(runs_dir):
-        if p.stem == reference or p.stem.startswith(f'{reference}_'):
-            return p
-    return None
+    """Match *reference* against report filename stems, newest first.
+
+    Newest-wins rather than raising on ambiguity (unlike run ids): a run *name*
+    is expected to repeat — ``--from-run nightly`` picking the latest nightly is
+    the point. When it is ambiguous the chosen file is logged, so the pick is
+    never silent even though it is not an error.
+    """
+    matches = [p for p in _reports_newest_first(runs_dir) if p.stem == reference or p.stem.startswith(f'{reference}_')]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        logger.info(f'Run name {reference!r} matches {len(matches)} runs; using the most recent: {matches[0].name}')
+    return matches[0]
 
 
 def _not_found(reference: str, runs_dir: Path, surface: str) -> ReplayError:

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -124,7 +124,8 @@ Because it fixes the data, `previous_run` cannot be combined with `mode`,
 `dataset`, `categories`, `vulnerabilities`, `strategies`, `delivery_methods`, or
 the `max_*_datapoints` caps — passing one raises rather than silently ignoring
 it. Runs saved before this shipped carry no datapoints and are rejected with an
-explanatory error.
+explanatory error, as are runs stamped with a replay format newer than the
+installed version understands.
 
 ## `red_team()` parameters
 

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -90,7 +90,7 @@ a fixed set of attacks for reproducible regression (`static` mode);
 | Local dataset file (`dataset="<path>"`, JSON/JSONL) | ✅ | — |
 | Orq dataset (`dataset="orq:<dataset_id>"`) | ✅ | — |
 | Agent capability context (tools, memory, knowledge bases, system prompt) | — | ✅ |
-| Previous run (`previous_run="<id>"` / `--from-run`) | ✅ | — |
+| Previous run (`previous_run="<id>"` / `--from-run`) | ✅ | ⚠️ manual (re-select a `generated_*` strategy by name via `--strategy`) |
 
 Legend: ✅ built-in · ⚠️ possible but manual · ❌ not supported yet.
 
@@ -111,12 +111,14 @@ eq redteam run --target agent:my-agent-v2 --from-run latest
 report = await red_team(target='agent:my-agent-v2', previous_run='latest')
 ```
 
-`--from-run` accepts `latest`, a run file name, a run id (or an unambiguous 8+
-character prefix), or a path to a saved run JSON — the same handles
-`eq redteam runs` prints. The stored attacks are replayed verbatim: no strategy
-planning, no attack generation, no dataset load, and the original pipeline mode
-is restored. That makes version-to-version regression on an identical case bank
-a single command; only the target and the model configuration change.
+`--from-run` accepts `latest`, the run name or file name `eq redteam runs`
+prints, a run id (or an unambiguous 8+ character prefix), or a path to a saved
+run JSON. The stored attacks are replayed verbatim: no strategy planning, no
+attack generation, no dataset load. The original pipeline mode, turn budget, and
+attacker instructions are restored too, since the datapoints alone don't pin
+those down — pass `--max-turns` / `attacker_instructions=` explicitly to
+override. That makes version-to-version regression on an identical case bank a
+single command; the target and the model configuration are what you vary.
 
 Because it fixes the data, `previous_run` cannot be combined with `mode`,
 `dataset`, `categories`, `vulnerabilities`, `strategies`, `delivery_methods`, or

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -90,16 +90,39 @@ a fixed set of attacks for reproducible regression (`static` mode);
 | Local dataset file (`dataset="<path>"`, JSON/JSONL) | ✅ | — |
 | Orq dataset (`dataset="orq:<dataset_id>"`) | ✅ | — |
 | Agent capability context (tools, memory, knowledge bases, system prompt) | — | ✅ |
-| Previous runs (`generated_*` strategies / captured datapoints) | ⚠️ manual | ⚠️ manual |
+| Previous run (`previous_run="<id>"` / `--from-run`) | ✅ | — |
 
 Legend: ✅ built-in · ⚠️ possible but manual · ❌ not supported yet.
 
 Static sources feed `mode="static"`/`"hybrid"` via the `dataset=` parameter
 (`--dataset` on the CLI). Dynamic generation is driven by the target's own
-capability context — no dataset needed. To replay a prior run, capture its
-datapoints to a dataset (e.g. an Orq dataset) and pass it back via `dataset=`;
-a `generated_*` strategy from a prior run can be re-selected by name via
-`--strategies`. There is no one-command "re-run that exact run" yet.
+capability context — no dataset needed.
+
+### Replaying a previous run
+
+Every saved run records the exact datapoints it executed, so it can be re-run
+as-is:
+
+```bash
+eq redteam run --target agent:my-agent-v2 --from-run latest
+```
+
+```python
+report = await red_team(target='agent:my-agent-v2', previous_run='latest')
+```
+
+`--from-run` accepts `latest`, a run file name, a run id (or an unambiguous 8+
+character prefix), or a path to a saved run JSON — the same handles
+`eq redteam runs` prints. The stored attacks are replayed verbatim: no strategy
+planning, no attack generation, no dataset load, and the original pipeline mode
+is restored. That makes version-to-version regression on an identical case bank
+a single command; only the target and the model configuration change.
+
+Because it fixes the data, `previous_run` cannot be combined with `mode`,
+`dataset`, `categories`, `vulnerabilities`, `strategies`, `delivery_methods`, or
+the `max_*_datapoints` caps — passing one raises rather than silently ignoring
+it. Runs saved before this shipped carry no datapoints and are rejected with an
+explanatory error.
 
 ## `red_team()` parameters
 

--- a/src/evaluatorq/redteam/__init__.py
+++ b/src/evaluatorq/redteam/__init__.py
@@ -13,6 +13,7 @@ Semantic convention throughout this package:
 
 from __future__ import annotations
 
+from evaluatorq.common.replay import ReplayError
 from evaluatorq.contracts import AgentTarget
 from evaluatorq.openresponses import (
     append_assistant_turn,
@@ -176,6 +177,7 @@ __all__ = [
     # Core public types
     'RedTeamReport',
     'RedTeamResult',
+    'ReplayError',
     'ReportSnapshot',
     'ReportSummary',
     'RichHooks',

--- a/src/evaluatorq/redteam/cli.py
+++ b/src/evaluatorq/redteam/cli.py
@@ -261,9 +261,14 @@ def run(
         ),
     ] = None,
     max_turns: Annotated[
-        int,
-        typer.Option(help='Maximum conversation turns for multi-turn attacks.'),
-    ] = 5,
+        int | None,
+        typer.Option(
+            help=(
+                'Maximum conversation turns for multi-turn attacks. '
+                "Defaults to 5, or to the replayed run's turn budget with --from-run."
+            )
+        ),
+    ] = None,
     max_per_category: Annotated[
         int | None,
         typer.Option(help='Cap strategies per category.'),

--- a/src/evaluatorq/redteam/cli.py
+++ b/src/evaluatorq/redteam/cli.py
@@ -37,6 +37,8 @@ _RUN_EPILOG = examples(
     'eq redteam run -t agent:my-agent --mode hybrid',
     '# scope to one OWASP category, machine-readable later via `eq redteam runs --json`',
     'eq redteam run -t agent:my-agent -c ASI01',
+    '# replay the last run against a new agent version (same attacks, new target)',
+    'eq redteam run -t agent:my-agent-v2 --from-run latest',
 )
 
 
@@ -312,6 +314,19 @@ def run(
         str | None,
         typer.Option(help='Dataset source: local path, "hf:org/repo", or "hf:org/repo/file.json".'),
     ] = None,
+    from_run: Annotated[
+        str | None,
+        typer.Option(
+            '--from-run',
+            help=(
+                'Replay a previous run instead of generating data: pass its file name, '
+                'run id, path, or "latest". Re-runs the exact same attacks, so only the '
+                'target and models may differ. Cannot be combined with --mode, --dataset, '
+                '--category, --vulnerability, --strategy, --delivery-method, or the '
+                '--max-*-datapoints caps.'
+            ),
+        ),
+    ] = None,
     artifacts_dir: Annotated[
         Path | None,
         typer.Option('--artifacts-dir', help='Directory for saved JSON files. Required with --save detail.'),
@@ -374,6 +389,7 @@ def run(
         verbose = -1
     _configure_logging(verbose)
 
+    from evaluatorq.common.replay import ReplayError
     from evaluatorq.redteam import red_team
     from evaluatorq.redteam.contracts import EvaluatorConfig, LLMCallConfig, LLMConfig, TargetConfig
     from evaluatorq.redteam.exceptions import CancelledError, RedTeamError
@@ -455,6 +471,7 @@ def run(
                 max_static_datapoints=max_static_datapoints,
                 cleanup_memory=not no_cleanup_memory,
                 dataset=dataset,
+                previous_run=from_run,
                 hooks=RichHooks(skip_confirm=should_skip_confirm(yes)),
                 artifacts_dir=artifacts_dir,
                 save=save,
@@ -470,7 +487,7 @@ def run(
     except KeyboardInterrupt:
         typer.echo('\nInterrupted.')
         raise typer.Exit(code=130)
-    except RedTeamError as e:
+    except (RedTeamError, ReplayError) as e:
         typer.echo(f'Error: {e}', err=True)
         raise typer.Exit(code=1)
     except ValueError as e:

--- a/src/evaluatorq/redteam/hooks.py
+++ b/src/evaluatorq/redteam/hooks.py
@@ -128,6 +128,10 @@ class ConfirmPayload(TypedDict, total=False):
     vulnerabilities: list[str] | None
     """Vulnerability labels loaded from dataset (static mode)."""
 
+    replay_of: str | None
+    """Name of the run being replayed (``previous_run=``). None for a fresh run.
+    When set, no datapoints were generated — they come from that run verbatim."""
+
 
 # ---------------------------------------------------------------------------
 # PipelineHooks Protocol
@@ -459,6 +463,12 @@ class RichHooks:
 
         table.add_row('Target', str(target))
         table.add_row('Mode', str(mode))
+
+        # A replay runs stored cases verbatim — say so up front, or the plan is
+        # indistinguishable from a fresh run that generated its own datapoints.
+        replay_of = payload.get('replay_of')
+        if replay_of:
+            table.add_row('Replay Of', str(replay_of))
 
         # Compute target count from agent_contexts or comma-separated target string
         agent_contexts_raw = payload.get('agent_contexts') or {}

--- a/src/evaluatorq/redteam/replay.py
+++ b/src/evaluatorq/redteam/replay.py
@@ -29,6 +29,10 @@ SURFACE = 'red team'
 DATAPOINTS_KEY = 'datapoints'
 """Key under which a saved run stores the raw inputs of every datapoint it ran."""
 
+RUN_CONFIG_KEY = 'run_config'
+"""Key under which a saved run stores the execution knobs the datapoints don't
+carry (turn budget, attacker steering), so a replay can restore them."""
+
 
 @dataclass(frozen=True)
 class RedTeamReplay:
@@ -39,6 +43,39 @@ class RedTeamReplay:
     categories: list[str]
     run_name: str
     path: Path
+    max_turns: int | None = None
+    """Turn budget the original run used. Restored unless the caller overrides
+    it — the datapoints alone don't pin it down, and replaying a 10-turn run at
+    the 5-turn default would not be the same run."""
+    attacker_instructions: str | None = None
+    """Domain steering the original run used, restored for the same reason."""
+
+
+def _looks_like_a_simulation_run(payload: dict[str, Any], rows: list[Any]) -> bool:
+    """Detect a sim run file handed to the red-team replay path.
+
+    Both surfaces store a top-level ``datapoints`` key, and a raw path is an
+    accepted reference, so the mix-up is easy to make. ``mode`` is the same
+    discriminator the dashboard uses to tell the two run kinds apart.
+    """
+    if payload.get('mode') in {'run', 'simulate', 'generate'}:
+        return True
+    return any(isinstance(row, dict) and 'persona' in row and 'scenario' in row for row in rows)
+
+
+def _validate_datapoint(inputs: dict[str, Any], index: int, run_name: str) -> None:
+    """Reject rows that could not drive an attack.
+
+    A dynamic case needs its ``strategy``; a static one needs its ``messages``.
+    Without one of the two the run would reach the orchestrator and die per-row
+    on a KeyError, long after the confirm prompt.
+    """
+    if 'strategy' in inputs or inputs.get('messages'):
+        return
+    raise ReplayError(
+        f'Previous red team run {run_name}: datapoint {index} ({inputs.get("id", "unnamed")!r}) has neither '
+        "a 'strategy' (dynamic attack) nor 'messages' (static attack), so it cannot be replayed."
+    )
 
 
 def _infer_pipeline(datapoints: list[DataPoint], stored: Any) -> Pipeline:
@@ -65,18 +102,30 @@ def load_redteam_replay(reference: str, runs_dir: Path) -> RedTeamReplay:
     raw = payload.get(DATAPOINTS_KEY)
     if not isinstance(raw, list) or not raw:
         raise ReplayError(
-            f'Previous red team run {path.name} stores no datapoints, so it cannot be replayed. '
-            'Only runs saved by evaluatorq 1.4.0+ record the cases they ran; re-run the original '
-            'configuration once to produce a replayable run.'
+            f'{path.name} records no red team datapoints, so it cannot be replayed. Replay needs the '
+            'cases themselves, which only the auto-saved run in the runs directory carries — not a '
+            '--save detail summary report, and not runs saved before replay support existed. Re-run '
+            'the original configuration once to produce a replayable run.'
+        )
+
+    if _looks_like_a_simulation_run(payload, raw):
+        raise ReplayError(
+            f'{path.name} is an agent simulation run, not a red team run. '
+            f'Replay it with: eq sim simulate --from-run {path.name} --target <target>'
         )
 
     datapoints: list[DataPoint] = []
     for i, inputs in enumerate(raw):
         if not isinstance(inputs, dict):
             raise ReplayError(f'Previous red team run {path.name}: datapoint {i} is not an object.')
+        _validate_datapoint(inputs, i, path.name)
         datapoints.append(DataPoint(inputs=dict(inputs)))
 
     categories = list(dict.fromkeys(str(c) for dp in datapoints if (c := dp.inputs.get('category'))))
+    stored_config = payload.get(RUN_CONFIG_KEY)
+    config = stored_config if isinstance(stored_config, dict) else {}
+    max_turns = config.get('max_turns')
+    instructions = config.get('attacker_instructions')
 
     return RedTeamReplay(
         datapoints=datapoints,
@@ -84,4 +133,6 @@ def load_redteam_replay(reference: str, runs_dir: Path) -> RedTeamReplay:
         categories=categories,
         run_name=str(payload.get('run_name') or path.stem),
         path=path,
+        max_turns=max_turns if isinstance(max_turns, int) else None,
+        attacker_instructions=instructions if isinstance(instructions, str) else None,
     )

--- a/src/evaluatorq/redteam/replay.py
+++ b/src/evaluatorq/redteam/replay.py
@@ -1,0 +1,87 @@
+"""Rebuild a prior red-team run's datapoints so it can be replayed verbatim.
+
+Saved runs carry a ``datapoints`` key (the exact ``DataPoint.inputs`` fed to the
+pipeline, written by ``_auto_save_run``). Replaying reads them back and hands
+them to the runner as pre-built datapoints, so no strategy planning, attack
+generation, or dataset load happens: the same attacks run again, against
+whatever target and evaluators the new invocation specifies.
+
+Runs saved before this existed have no ``datapoints`` key and cannot be
+replayed — the report alone does not carry the dynamic strategy definitions the
+orchestrator needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from evaluatorq.common.replay import ReplayError, load_run_payload
+from evaluatorq.redteam.contracts import Pipeline
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from evaluatorq.types import DataPoint
+
+SURFACE = 'red team'
+
+DATAPOINTS_KEY = 'datapoints'
+"""Key under which a saved run stores the raw inputs of every datapoint it ran."""
+
+
+@dataclass(frozen=True)
+class RedTeamReplay:
+    """A prior run's cases, ready to be re-run."""
+
+    datapoints: list[DataPoint]
+    pipeline: Pipeline
+    categories: list[str]
+    run_name: str
+    path: Path
+
+
+def _infer_pipeline(datapoints: list[DataPoint], stored: Any) -> Pipeline:
+    """Trust the stored pipeline; fall back to the datapoints' hybrid tags."""
+    try:
+        return Pipeline(stored)
+    except ValueError:
+        sources = {dp.inputs.get('hybrid_source') for dp in datapoints}
+        if sources == {'static'}:
+            return Pipeline.STATIC
+        return Pipeline.HYBRID if 'static' in sources else Pipeline.DYNAMIC
+
+
+def load_redteam_replay(reference: str, runs_dir: Path) -> RedTeamReplay:
+    """Resolve *reference* to a saved run and rebuild its datapoints.
+
+    Raises:
+        ReplayError: The run cannot be found, read, or has no stored datapoints.
+    """
+    from evaluatorq.types import DataPoint
+
+    payload, path = load_run_payload(reference, runs_dir, surface=SURFACE)
+
+    raw = payload.get(DATAPOINTS_KEY)
+    if not isinstance(raw, list) or not raw:
+        raise ReplayError(
+            f'Previous red team run {path.name} stores no datapoints, so it cannot be replayed. '
+            'Only runs saved by evaluatorq 1.4.0+ record the cases they ran; re-run the original '
+            'configuration once to produce a replayable run.'
+        )
+
+    datapoints: list[DataPoint] = []
+    for i, inputs in enumerate(raw):
+        if not isinstance(inputs, dict):
+            raise ReplayError(f'Previous red team run {path.name}: datapoint {i} is not an object.')
+        datapoints.append(DataPoint(inputs=dict(inputs)))
+
+    categories = list(dict.fromkeys(str(c) for dp in datapoints if (c := dp.inputs.get('category'))))
+
+    return RedTeamReplay(
+        datapoints=datapoints,
+        pipeline=_infer_pipeline(datapoints, payload.get('pipeline')),
+        categories=categories,
+        run_name=str(payload.get('run_name') or path.stem),
+        path=path,
+    )

--- a/src/evaluatorq/redteam/replay.py
+++ b/src/evaluatorq/redteam/replay.py
@@ -79,14 +79,31 @@ def _validate_datapoint(inputs: dict[str, Any], index: int, run_name: str) -> No
 
 
 def _infer_pipeline(datapoints: list[DataPoint], stored: Any) -> Pipeline:
-    """Trust the stored pipeline; fall back to the datapoints' hybrid tags."""
+    """Resolve the pipeline to replay under, preferring the datapoints' own tags.
+
+    The stored label can under-report: ``merge_reports`` derives a report's
+    pipeline from the sub-reports that actually produced rows, so a hybrid run
+    whose static leg yields no results is saved as ``'dynamic'`` even though its
+    datapoints still carry ``hybrid_source='static'``. Replaying that as dynamic
+    would route ``messages``-only rows into the attack-generation job. Where the
+    tags contradict the label, the tags win — they describe the cases in hand.
+
+    Untagged datapoints (pure dynamic, or a static-mode run, neither of which
+    tags anything) carry no signal, so the stored label stands.
+    """
     try:
-        return Pipeline(stored)
+        stored_pipeline: Pipeline | None = Pipeline(stored)
     except ValueError:
-        sources = {dp.inputs.get('hybrid_source') for dp in datapoints}
-        if sources == {'static'}:
-            return Pipeline.STATIC
-        return Pipeline.HYBRID if 'static' in sources else Pipeline.DYNAMIC
+        stored_pipeline = None
+
+    sources = {dp.inputs.get('hybrid_source') for dp in datapoints}
+    if 'static' in sources:
+        tagged = Pipeline.HYBRID if sources - {'static'} else Pipeline.STATIC
+        # Only DYNAMIC actually contradicts a static-tagged row; a stored
+        # 'hybrid'/'static' is at least as specific, so leave it alone.
+        return tagged if stored_pipeline in (None, Pipeline.DYNAMIC) else stored_pipeline
+
+    return stored_pipeline if stored_pipeline is not None else Pipeline.DYNAMIC
 
 
 def load_redteam_replay(reference: str, runs_dir: Path) -> RedTeamReplay:

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -74,6 +74,7 @@ from evaluatorq.redteam.hooks import (
     PipelineHooks,
 )
 from evaluatorq.redteam.replay import DATAPOINTS_KEY as REPLAY_DATAPOINTS_KEY
+from evaluatorq.redteam.replay import RUN_CONFIG_KEY as REPLAY_RUN_CONFIG_KEY
 from evaluatorq.redteam.replay import RedTeamReplay, load_redteam_replay
 from evaluatorq.redteam.reports.recommendations import generate_focus_area_recommendations
 from evaluatorq.redteam.runtime.jobs import _build_messages, _sanitize_job_name, create_model_job
@@ -124,6 +125,12 @@ def _save_report(output_dir: Path | None, filename: str, report: RedTeamReport) 
     logger.debug(f'Saved {filename} to {output_dir}')
 
 
+DEFAULT_MAX_TURNS = 5
+"""Turn budget when the caller names none. ``max_turns`` defaults to ``None``
+rather than to this value so a replay can tell "unset" from "explicitly 5" and
+restore the replayed run's budget only in the former case."""
+
+
 def get_runs_dir() -> Path:
     """Return the red team runs directory (``<store>/runs``)."""
     return get_store_dir('runs')
@@ -133,13 +140,15 @@ def _auto_save_run(
     report: RedTeamReport,
     name: str | None = None,
     datapoints: list[dict[str, Any]] | None = None,
+    run_config: dict[str, Any] | None = None,
 ) -> Path | None:
     """Persist a report to ``.evaluatorq/runs/`` for later listing via ``runs`` CLI.
 
-    ``datapoints`` are the raw ``DataPoint.inputs`` the run executed. They are
-    stored alongside the report (not part of the report model) so the run can
-    later be replayed verbatim via ``previous_run=`` — see
-    :mod:`evaluatorq.redteam.replay`.
+    ``datapoints`` are the raw ``DataPoint.inputs`` the run executed, and
+    ``run_config`` the execution knobs they don't encode (turn budget, attacker
+    steering). Both are stored alongside the report (not part of the report
+    model) so the run can later be replayed verbatim via ``previous_run=`` —
+    see :mod:`evaluatorq.redteam.replay`.
     """
     try:
         runs_dir = get_runs_dir()
@@ -153,6 +162,7 @@ def _auto_save_run(
         data['saved_at'] = datetime.now(tz=timezone.utc).isoformat()
         if datapoints:
             data[REPLAY_DATAPOINTS_KEY] = datapoints
+            data[REPLAY_RUN_CONFIG_KEY] = run_config or {}
         path.write_text(json.dumps(data, indent=2, default=str), encoding='utf-8')
         logger.debug(f'Auto-saved run to {path}')
         return path
@@ -373,7 +383,7 @@ async def red_team(
     vulnerabilities: list[str] | None = None,
     strategies: list[str] | None = None,
     delivery_methods: list[DeliveryMethod | str] | None = None,
-    max_turns: int = 5,
+    max_turns: int | None = None,
     max_per_category: int | None = None,
     parallelism: int = 10,
     generate_strategies: bool = True,
@@ -427,7 +437,9 @@ async def red_team(
             disables the filter. When a supplied filter leaves zero datapoints to
             run, ``red_team`` raises :class:`RedTeamError` rather than silently
             running nothing.
-        max_turns: Maximum conversation turns for multi-turn attacks.
+        max_turns: Maximum conversation turns for multi-turn attacks. Defaults
+            to 5, or — when replaying via ``previous_run`` — to the turn budget
+            the replayed run used. An explicit value always wins.
         max_per_category: Cap strategies per category (None = no cap).
         llm_config: Role-based LLM configuration. Use ``LLMConfig(attacker=LLMCallConfig(...),
             evaluator=LLMCallConfig(...))`` to control model, temperature, and other
@@ -545,9 +557,18 @@ async def red_team(
             raise ValueError(msg)
         replay = load_redteam_replay(previous_run, get_runs_dir())
         mode = replay.pipeline
+        # Restore the knobs the datapoints don't encode. An explicit argument
+        # still wins — replaying at a different turn budget is a legitimate ask,
+        # silently changing it behind the user's back is not.
+        if max_turns is None:
+            max_turns = replay.max_turns
+        if attacker_instructions is None:
+            attacker_instructions = replay.attacker_instructions
         logger.info(
             f'Replaying {len(replay.datapoints)} datapoints from {replay.path.name} ({replay.pipeline.value} pipeline).'
         )
+
+    resolved_max_turns = max_turns if max_turns is not None else DEFAULT_MAX_TURNS
 
     user_output_dir = Path(artifacts_dir) if artifacts_dir is not None else None
     # Inner pipelines (_run_dynamic, _run_static) only write 01/02/03 to their
@@ -770,7 +791,7 @@ async def red_team(
         'orq.redteam.targets': ', '.join(all_target_labels),
         'orq.redteam.mode': resolved_mode,
         'orq.redteam.backend': backend_label,
-        'orq.redteam.max_turns': max_turns,
+        'orq.redteam.max_turns': resolved_max_turns,
         'orq.redteam.parallelism': parallelism,
     }
 
@@ -791,7 +812,7 @@ async def red_team(
                     name=name,
                     categories=resolved_categories,
                     resolved_vulns=resolved_vulns,
-                    max_turns=max_turns,
+                    max_turns=resolved_max_turns,
                     max_per_category=max_per_category,
                     attack_model=attack_model,
                     evaluator_model=evaluator_model,
@@ -814,6 +835,7 @@ async def red_team(
                     resolved_delivery_methods=resolved_delivery_methods,
                     run_id=tracing_context.run_id,
                     replay_datapoints=replay.datapoints if replay is not None else None,
+                    replay_of=replay.path.name if replay is not None else None,
                 )
                 report, metrics = _coerce_run_result(run_result)
             elif resolved_mode == Pipeline.STATIC:
@@ -836,6 +858,7 @@ async def red_team(
                     resolved_delivery_methods=resolved_delivery_methods,
                     run_id=tracing_context.run_id,
                     prefetched_data=replay.datapoints if replay is not None else None,
+                    replay_of=replay.path.name if replay is not None else None,
                 )
                 report, metrics = _coerce_run_result(run_result)
             else:
@@ -934,7 +957,15 @@ async def red_team(
 
             # Index in .evaluatorq/runs/ so the run appears in `evaluatorq redteam runs`.
             if save != 'none':
-                run_path = _auto_save_run(report, name=name, datapoints=metrics.datapoint_inputs)
+                run_path = _auto_save_run(
+                    report,
+                    name=name,
+                    datapoints=metrics.datapoint_inputs,
+                    run_config={
+                        'max_turns': resolved_max_turns,
+                        'attacker_instructions': attacker_instructions,
+                    },
+                )
                 if auto_save_path is None:
                     auto_save_path = run_path
                 if run_path is None:
@@ -1618,6 +1649,7 @@ async def _run_dynamic_or_hybrid(
     resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
     run_id: str | None = None,
     replay_datapoints: list[DataPoint] | None = None,
+    replay_of: str | None = None,
 ) -> tuple[RedTeamReport, RedTeamRunMetrics]:
     """Run dynamic or hybrid red teaming for multiple targets in a single evaluatorq call.
 
@@ -1637,8 +1669,9 @@ async def _run_dynamic_or_hybrid(
         replay_datapoints: Pre-built datapoints from a prior run. When supplied,
             every target reuses them: capability classification, strategy
             planning, attack generation, and the static dataset load are all
-            skipped, and the confirm prompt describes the replay instead of an
-            estimate.
+            skipped.
+        replay_of: Name of the run being replayed, surfaced in the confirm
+            prompt so a replay is not mistaken for a fresh run.
     """
     from evaluatorq import evaluatorq
     from evaluatorq.redteam.reports.converters import (
@@ -1958,6 +1991,7 @@ async def _run_dynamic_or_hybrid(
         'target': ', '.join(all_target_labels),
         'dataset_path': str(dataset) if dataset else None,
         'vulnerabilities': [v.value for v in resolved_vulns] if resolved_vulns else None,
+        'replay_of': replay_of,
     }
 
     if not await await_maybe(resolved_hooks.on_confirm(confirm_payload)):
@@ -2680,6 +2714,7 @@ async def _run_static(
     resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
     run_id: str | None = None,
     prefetched_data: list[DataPoint] | None = None,
+    replay_of: str | None = None,
 ) -> tuple[RedTeamReport, RedTeamRunMetrics]:
     """Run static red teaming for multiple targets in a single ``evaluatorq()`` call.
 
@@ -2689,7 +2724,8 @@ async def _run_static(
     then merged into one unified ``RedTeamReport``.
 
     ``prefetched_data`` replaces the dataset load with a caller-supplied
-    datapoint list (the replay path).
+    datapoint list (the replay path), and ``replay_of`` names the run it came
+    from for the confirm prompt.
     """
     from evaluatorq import evaluatorq
     from evaluatorq.redteam.reports.converters import (
@@ -2817,6 +2853,7 @@ async def _run_static(
         'target': ', '.join(all_target_labels),
         'dataset_path': str(dataset) if dataset else None,
         'vulnerabilities': vulnerabilities,
+        'replay_of': replay_of,
     }
     if not await await_maybe(resolved_hooks.on_confirm(confirm_payload)):
         msg = 'Execution cancelled by confirmation callback'

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -23,6 +23,7 @@ from evaluatorq import DataPoint, EvaluationResult, job
 from evaluatorq.common.async_utils import await_maybe
 from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.common.messages import coerce_content_text
+from evaluatorq.common.replay import REPLAY_VERSION, REPLAY_VERSION_KEY
 from evaluatorq.common.run_store_dir import get_store_dir
 from evaluatorq.common.target_call import call_target_with_retry, default_map_error
 from evaluatorq.common.thread_context import build_static_thread_id, conversation_thread, evaluatorq_pipeline
@@ -163,6 +164,7 @@ def _auto_save_run(
         if datapoints:
             data[REPLAY_DATAPOINTS_KEY] = datapoints
             data[REPLAY_RUN_CONFIG_KEY] = run_config or {}
+            data[REPLAY_VERSION_KEY] = REPLAY_VERSION
         path.write_text(json.dumps(data, indent=2, default=str), encoding='utf-8')
         logger.debug(f'Auto-saved run to {path}')
         return path

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -12,7 +12,7 @@ import uuid
 import warnings
 from collections import Counter, defaultdict
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -73,6 +73,8 @@ from evaluatorq.redteam.hooks import (
     ManifestStageHooks,
     PipelineHooks,
 )
+from evaluatorq.redteam.replay import DATAPOINTS_KEY as REPLAY_DATAPOINTS_KEY
+from evaluatorq.redteam.replay import RedTeamReplay, load_redteam_replay
 from evaluatorq.redteam.reports.recommendations import generate_focus_area_recommendations
 from evaluatorq.redteam.runtime.jobs import _build_messages, _sanitize_job_name, create_model_job
 from evaluatorq.redteam.tracing import with_redteam_span
@@ -127,8 +129,18 @@ def get_runs_dir() -> Path:
     return get_store_dir('runs')
 
 
-def _auto_save_run(report: RedTeamReport, name: str | None = None) -> Path | None:
-    """Persist a report to ``.evaluatorq/runs/`` for later listing via ``runs`` CLI."""
+def _auto_save_run(
+    report: RedTeamReport,
+    name: str | None = None,
+    datapoints: list[dict[str, Any]] | None = None,
+) -> Path | None:
+    """Persist a report to ``.evaluatorq/runs/`` for later listing via ``runs`` CLI.
+
+    ``datapoints`` are the raw ``DataPoint.inputs`` the run executed. They are
+    stored alongside the report (not part of the report model) so the run can
+    later be replayed verbatim via ``previous_run=`` — see
+    :mod:`evaluatorq.redteam.replay`.
+    """
     try:
         runs_dir = get_runs_dir()
         runs_dir.mkdir(parents=True, exist_ok=True)
@@ -139,6 +151,8 @@ def _auto_save_run(report: RedTeamReport, name: str | None = None) -> Path | Non
         data = report.model_dump(mode='json')
         data['run_name'] = resolved_name
         data['saved_at'] = datetime.now(tz=timezone.utc).isoformat()
+        if datapoints:
+            data[REPLAY_DATAPOINTS_KEY] = datapoints
         path.write_text(json.dumps(data, indent=2, default=str), encoding='utf-8')
         logger.debug(f'Auto-saved run to {path}')
         return path
@@ -313,6 +327,9 @@ class RedTeamRunMetrics:
     num_datapoints: int
     num_categories: int
     duration_seconds: float
+    datapoint_inputs: list[dict[str, Any]] = field(default_factory=list)
+    """Raw inputs of every datapoint the run executed, persisted with the saved
+    run so it can be replayed later (``previous_run=``). Not a span metric."""
 
 
 def _coerce_run_result(result: Any) -> tuple[RedTeamReport, RedTeamRunMetrics]:
@@ -368,6 +385,7 @@ async def red_team(
     name: str | None = None,
     description: str | None = None,
     dataset: Path | str | None = None,
+    previous_run: str | None = None,
     hooks: PipelineHooks | None = None,
     artifacts_dir: Path | str | None = None,
     target_config: TargetConfig | None = None,
@@ -428,6 +446,18 @@ async def red_team(
         description: Optional description for the report.
         dataset: Dataset source. Accepts: local file path, ``"hf:org/repo"``,
             ``"hf:org/repo/filename.json"``, or ``None`` for the default HuggingFace dataset.
+        previous_run: Replay a prior run instead of building new datapoints.
+            Accepts a saved run's file name, its run id (full or an unambiguous
+            8+ character prefix), a path to a saved run JSON, or ``"latest"``.
+            The stored datapoints are re-run verbatim: no strategy planning, no
+            attack generation, no dataset load. Only the target, the evaluators,
+            and the LLM configuration are free to change, which is what makes a
+            version-to-version regression on an identical case bank possible.
+            Mutually exclusive with ``mode``, ``dataset``, ``categories``,
+            ``vulnerabilities``, ``strategies``, ``delivery_methods``,
+            ``max_per_category``, ``max_dynamic_datapoints``, and
+            ``max_static_datapoints`` — those all describe data selection, which
+            a replay has already decided.
         hooks: Optional ``PipelineHooks`` implementation. Defaults to
             ``DefaultHooks()`` (loguru output, auto-confirm).
         artifacts_dir: Directory for saved JSON files. Ignored when
@@ -486,6 +516,38 @@ async def red_team(
     elif save not in SaveMode.__members__.values():
         msg = f'Invalid save value {save!r}. Must be one of: {", ".join(SaveMode.__members__.values())}.'
         raise ValueError(msg)
+
+    # Replay short-circuits every data-selection input: the cases are already
+    # decided by the run being replayed, so accepting a conflicting selector
+    # would silently ignore it. Reject the combination instead.
+    replay: RedTeamReplay | None = None
+    if previous_run is not None:
+        conflicting = [
+            label
+            for label, supplied in (
+                ('mode', Pipeline(mode) != Pipeline.DYNAMIC),
+                ('dataset', dataset is not None),
+                ('categories', bool(categories)),
+                ('vulnerabilities', bool(vulnerabilities)),
+                ('strategies', strategies is not None),
+                ('delivery_methods', delivery_methods is not None),
+                ('max_per_category', max_per_category is not None),
+                ('max_dynamic_datapoints', max_dynamic_datapoints is not None),
+                ('max_static_datapoints', max_static_datapoints is not None),
+            )
+            if supplied
+        ]
+        if conflicting:
+            msg = (
+                f'previous_run= replays a stored run and cannot be combined with data-selection '
+                f'arguments: {", ".join(conflicting)}. Drop them, or drop previous_run.'
+            )
+            raise ValueError(msg)
+        replay = load_redteam_replay(previous_run, get_runs_dir())
+        mode = replay.pipeline
+        logger.info(
+            f'Replaying {len(replay.datapoints)} datapoints from {replay.path.name} ({replay.pipeline.value} pipeline).'
+        )
 
     user_output_dir = Path(artifacts_dir) if artifacts_dir is not None else None
     # Inner pipelines (_run_dynamic, _run_static) only write 01/02/03 to their
@@ -555,7 +617,7 @@ async def red_team(
     # need huggingface-hub. Check now rather than deep in the static leg — in
     # hybrid mode that leg runs only after the entire dynamic leg, so a missing
     # dependency would otherwise surface after minutes of (now wasted) work.
-    if resolved_mode in (Pipeline.STATIC, Pipeline.HYBRID):
+    if replay is None and resolved_mode in (Pipeline.STATIC, Pipeline.HYBRID):
         from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import (
             ensure_huggingface_available,
             is_huggingface_source,
@@ -573,7 +635,13 @@ async def red_team(
     )
 
     resolved_vulns: list[Vulnerability] | None
-    if vulnerabilities:
+    if replay is not None:
+        # A replay's scope is whatever it recorded. Resolving vulnerabilities
+        # (and running the evaluability gate below) would re-derive a selection
+        # the stored datapoints have already made.
+        resolved_categories = replay.categories
+        resolved_vulns = None
+    elif vulnerabilities:
         resolved_vulns = resolve_vulnerabilities(vulnerabilities)
         resolved_categories = [get_primary_category(v) for v in resolved_vulns]
     elif categories:
@@ -745,6 +813,7 @@ async def red_team(
                     resolved_strategy_names=resolved_strategy_names,
                     resolved_delivery_methods=resolved_delivery_methods,
                     run_id=tracing_context.run_id,
+                    replay_datapoints=replay.datapoints if replay is not None else None,
                 )
                 report, metrics = _coerce_run_result(run_result)
             elif resolved_mode == Pipeline.STATIC:
@@ -766,6 +835,7 @@ async def red_team(
                     resolved_strategy_names=resolved_strategy_names,
                     resolved_delivery_methods=resolved_delivery_methods,
                     run_id=tracing_context.run_id,
+                    prefetched_data=replay.datapoints if replay is not None else None,
                 )
                 report, metrics = _coerce_run_result(run_result)
             else:
@@ -864,7 +934,7 @@ async def red_team(
 
             # Index in .evaluatorq/runs/ so the run appears in `evaluatorq redteam runs`.
             if save != 'none':
-                run_path = _auto_save_run(report, name=name)
+                run_path = _auto_save_run(report, name=name, datapoints=metrics.datapoint_inputs)
                 if auto_save_path is None:
                     auto_save_path = run_path
                 if run_path is None:
@@ -1547,6 +1617,7 @@ async def _run_dynamic_or_hybrid(
     resolved_strategy_names: set[str] | None = None,
     resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
     run_id: str | None = None,
+    replay_datapoints: list[DataPoint] | None = None,
 ) -> tuple[RedTeamReport, RedTeamRunMetrics]:
     """Run dynamic or hybrid red teaming for multiple targets in a single evaluatorq call.
 
@@ -1563,6 +1634,11 @@ async def _run_dynamic_or_hybrid(
 
     Args:
         mode: ``"dynamic"`` or ``"hybrid"``.
+        replay_datapoints: Pre-built datapoints from a prior run. When supplied,
+            every target reuses them: capability classification, strategy
+            planning, attack generation, and the static dataset load are all
+            skipped, and the confirm prompt describes the replay instead of an
+            estimate.
     """
     from evaluatorq import evaluatorq
     from evaluatorq.redteam.reports.converters import (
@@ -1646,15 +1722,20 @@ async def _run_dynamic_or_hybrid(
     # operator visibility. `create_async_llm_client()` raises BackendError
     # when no credentials are available, which we treat as "classification
     # disabled" rather than a hard error.
-    cap_llm_client = llm_client
-    if cap_llm_client is None and pipeline_config is not None and pipeline_config.attacker.client is not None:
-        cap_llm_client = pipeline_config.attacker.client
-    if cap_llm_client is None:
-        try:
-            cap_llm_client = create_async_llm_client()
-        except Exception as exc:
-            logger.debug(f'No LLM client available for capability classification: {exc}')
-            cap_llm_client = None
+    #
+    # A replay skips classification entirely: it only exists to steer strategy
+    # selection, and a replay selects nothing — its datapoints are already fixed.
+    cap_llm_client: AsyncOpenAI | None = None
+    if replay_datapoints is None:
+        cap_llm_client = llm_client
+        if cap_llm_client is None and pipeline_config is not None and pipeline_config.attacker.client is not None:
+            cap_llm_client = pipeline_config.attacker.client
+        if cap_llm_client is None:
+            try:
+                cap_llm_client = create_async_llm_client()
+            except Exception as exc:
+                logger.debug(f'No LLM client available for capability classification: {exc}')
+                cap_llm_client = None
 
     all_agent_caps: dict[str, AgentCapabilities] = {}
     at_caps: dict[int, AgentCapabilities] = {}
@@ -1773,7 +1854,10 @@ async def _run_dynamic_or_hybrid(
 
     est_dynamic = 0
     strategy_breakdown: dict[str, Any] = {}
-    if resolved_vulns is not None:
+    if replay_datapoints is not None:
+        # Nothing to estimate — the exact case list is already in hand.
+        est_dynamic = sum(1 for dp in replay_datapoints if dp.inputs.get('hybrid_source') != 'static')
+    elif resolved_vulns is not None:
         for vuln in resolved_vulns:
             all_strategies = get_strategies_for_vulnerability(vuln)
             applicable = select_applicable_strategies_for_vulnerability(
@@ -1836,7 +1920,9 @@ async def _run_dynamic_or_hybrid(
 
     est_static: int | None = None
     static_data: list[Any] | None = None
-    if mode == Pipeline.HYBRID:
+    if replay_datapoints is not None:
+        est_static = sum(1 for dp in replay_datapoints if dp.inputs.get('hybrid_source') == 'static')
+    elif mode == Pipeline.HYBRID:
         from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
 
         # The delivery-method filter is applied inside the loader (before the
@@ -1911,6 +1997,9 @@ async def _run_dynamic_or_hybrid(
     if targets:
         first_target = await _prepare_target(
             target=targets[0],
+            # On a replay the first target is not special: it reuses the stored
+            # datapoints exactly like every subsequent target does.
+            shared_datapoints=replay_datapoints,
             prefetched_agent_context=first_agent_context,
             prefetched_agent_capabilities=all_agent_caps.get(targets[0]),
             prefetched_static_data=static_data,
@@ -1958,8 +2047,11 @@ async def _run_dynamic_or_hybrid(
     if resolved_agent_targets:
         at_llm_client = _resolve_attacker_llm_client(llm_client, pipeline_config, create_if_missing=True)
 
-        # If no string targets prepared yet, generate datapoints from first AgentTarget's context
-        shared_at_dps: list[Any] | None = prepared_targets[0].all_datapoints if prepared_targets else None
+        # If no string targets prepared yet, generate datapoints from first AgentTarget's
+        # context — unless this is a replay, which supplies them for every target.
+        shared_at_dps: list[Any] | None = replay_datapoints
+        if shared_at_dps is None and prepared_targets:
+            shared_at_dps = prepared_targets[0].all_datapoints
 
         for at in resolved_agent_targets:
             at_label = agent_target_labels[id(at)]
@@ -2047,8 +2139,15 @@ async def _run_dynamic_or_hybrid(
 
             # Build the appropriate job based on mode (hybrid vs dynamic-only)
             at_static_dps: list[Any] = []
-            if mode == Pipeline.HYBRID and static_data is not None:
-                at_static_dps = list(static_data)
+            if mode == Pipeline.HYBRID:
+                # Shared/replayed datapoints already carry both legs tagged, so
+                # split them back out rather than appending the static set twice.
+                tagged_static = [dp for dp in at_dps if dp.inputs.get('hybrid_source') == 'static']
+                if tagged_static:
+                    at_static_dps = tagged_static
+                    at_dps = [dp for dp in at_dps if dp.inputs.get('hybrid_source') != 'static']
+                elif static_data is not None:
+                    at_static_dps = list(static_data)
                 # Tag datapoints with hybrid_source
                 for dp in at_dps:
                     dp.inputs['hybrid_source'] = 'dynamic'
@@ -2552,6 +2651,7 @@ async def _run_dynamic_or_hybrid(
         num_datapoints=len(all_datapoints),
         num_categories=len(resolved_categories),
         duration_seconds=pipeline_duration,
+        datapoint_inputs=[dict(dp.inputs) for dp in all_datapoints],
     )
 
 
@@ -2579,6 +2679,7 @@ async def _run_static(
     resolved_strategy_names: set[str] | None = None,
     resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
     run_id: str | None = None,
+    prefetched_data: list[DataPoint] | None = None,
 ) -> tuple[RedTeamReport, RedTeamRunMetrics]:
     """Run static red teaming for multiple targets in a single ``evaluatorq()`` call.
 
@@ -2586,6 +2687,9 @@ async def _run_static(
     The shared dataset is used as-is; each job processes every datapoint.
     Results are split by ``job_name`` into per-target reports, which are
     then merged into one unified ``RedTeamReport``.
+
+    ``prefetched_data`` replaces the dataset load with a caller-supplied
+    datapoint list (the replay path).
     """
     from evaluatorq import evaluatorq
     from evaluatorq.redteam.reports.converters import (
@@ -2602,15 +2706,18 @@ async def _run_static(
     resolved_hooks: PipelineHooks = hooks or DefaultHooks()
     pipeline_start = datetime.now(tz=timezone.utc).astimezone()
 
-    # Load the shared dataset once for all targets
-    from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
+    # Load the shared dataset once for all targets (a replay brings its own)
+    if prefetched_data is not None:
+        data: list[Any] = list(prefetched_data)
+    else:
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
 
-    data = load_owasp_agentic_dataset(
-        dataset=dataset,
-        num_samples=max_static_datapoints,
-        categories=categories,
-        delivery_methods=_delivery_method_values(resolved_delivery_methods),
-    )
+        data = load_owasp_agentic_dataset(
+            dataset=dataset,
+            num_samples=max_static_datapoints,
+            categories=categories,
+            delivery_methods=_delivery_method_values(resolved_delivery_methods),
+        )
 
     # Filter out datapoints whose category has no registered evaluator
     if data:
@@ -2646,6 +2753,8 @@ async def _run_static(
         # carries — surfacing spelling/format drift instead of a bare "zero datapoints".
         present_methods: list[str] | None = None
         if resolved_delivery_methods is not None and not data:
+            from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
+
             present_rows = load_owasp_agentic_dataset(dataset=dataset, categories=categories)
             present_methods = sorted({m for dp in present_rows if (m := dp.inputs.get('delivery_method'))})
         _check_filter_results(data, None, resolved_delivery_methods, names_apply=False, present_methods=present_methods)
@@ -2855,4 +2964,5 @@ async def _run_static(
         num_datapoints=len(data) if isinstance(data, list) else 0,
         num_categories=len(vulnerabilities),
         duration_seconds=pipeline_duration,
+        datapoint_inputs=[dict(dp.inputs) for dp in data] if isinstance(data, list) else [],
     )

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -107,7 +107,7 @@ personas/scenarios (extends the dataset).
 | Inline `personas` + `scenarios` | ✅ | — (they *are* the new cases) |
 | JSONL datapoints (`--datapoints` / `load_datapoints_from_jsonl()`) | ✅ | ⚠️ manual (hand-pick seeds) |
 | Orq dataset (`dataset_id=`) | ✅ | ⚠️ manual |
-| Previous run (`previous_run="<id>"` / `--from-run`) | ✅ | ⚠️ manual |
+| Previous run (`previous_run="<id>"` / `--from-run`, or export to JSONL via `eq sim generate --datapoints`) | ✅ | ⚠️ manual |
 | Orq experiment | ❌ no importer | ⚠️ manual (read run rows → seed phrases) |
 | Production traces | ❌ no importer | ⚠️ manual (read traces → seed phrases) |
 
@@ -129,13 +129,14 @@ eq sim simulate --from-run latest --target agent:my-agent-v2
 results = await simulate(target='agent:my-agent-v2', previous_run='latest')
 ```
 
-`--from-run` accepts `latest`, a run file name, a run id (or an unambiguous 8+
-character prefix), or a path to a saved run JSON, resolved against
-`.evaluatorq/sim-runs/`. The stored personas, scenarios, and first messages are
-re-used exactly — no persona/scenario generation, no first-message generation,
-no dataset fetch — so the only thing that changes between runs is the target and
-the evaluators. Runs saved before this shipped carry no datapoints and are
-rejected with an explanatory error.
+`--from-run` accepts `latest`, the run name or file name `eq sim runs` prints, a
+run id (or an unambiguous 8+ character prefix), or a path to a saved run JSON,
+resolved against `.evaluatorq/sim-runs/`. The stored personas, scenarios, and
+first messages are re-used exactly — no persona/scenario generation, no
+first-message generation, no dataset fetch — and the run's turn cap is restored
+unless you pass `--max-turns`. What you vary between runs is the target and the
+evaluators. Runs saved before this shipped carry no datapoints and are rejected
+with an explanatory error.
 
 No built-in trace-to-persona extractor yet: turning raw traces (or previous
 runs) into seed phrases for `generate_personas()` / `generate_scenarios()` is a

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -107,14 +107,35 @@ personas/scenarios (extends the dataset).
 | Inline `personas` + `scenarios` | ✅ | — (they *are* the new cases) |
 | JSONL datapoints (`--datapoints` / `load_datapoints_from_jsonl()`) | ✅ | ⚠️ manual (hand-pick seeds) |
 | Orq dataset (`dataset_id=`) | ✅ | ⚠️ manual |
-| Previous runs (persisted to JSONL via `eq sim generate --datapoints`) | ✅ | ⚠️ manual |
+| Previous run (`previous_run="<id>"` / `--from-run`) | ✅ | ⚠️ manual |
 | Orq experiment | ❌ no importer | ⚠️ manual (read run rows → seed phrases) |
 | Production traces | ❌ no importer | ⚠️ manual (read traces → seed phrases) |
 
 Legend: ✅ built-in · ⚠️ possible but manual · ❌ not supported yet.
 
-`dataset_id`, `datapoints`, and `personas` + `scenarios` are mutually
-exclusive — pass exactly one source per run.
+`previous_run`, `dataset_id`, `datapoints`, and `personas` + `scenarios` are
+mutually exclusive — pass exactly one source per run.
+
+### Replaying a previous run
+
+Saved runs record the cases they simulated, so a run can be repeated against a
+new agent version without regenerating anything:
+
+```bash
+eq sim simulate --from-run latest --target agent:my-agent-v2
+```
+
+```python
+results = await simulate(target='agent:my-agent-v2', previous_run='latest')
+```
+
+`--from-run` accepts `latest`, a run file name, a run id (or an unambiguous 8+
+character prefix), or a path to a saved run JSON, resolved against
+`.evaluatorq/sim-runs/`. The stored personas, scenarios, and first messages are
+re-used exactly — no persona/scenario generation, no first-message generation,
+no dataset fetch — so the only thing that changes between runs is the target and
+the evaluators. Runs saved before this shipped carry no datapoints and are
+rejected with an explanatory error.
 
 No built-in trace-to-persona extractor yet: turning raw traces (or previous
 runs) into seed phrases for `generate_personas()` / `generate_scenarios()` is a

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -136,7 +136,8 @@ first messages are re-used exactly — no persona/scenario generation, no
 first-message generation, no dataset fetch — and the run's turn cap is restored
 unless you pass `--max-turns`. What you vary between runs is the target and the
 evaluators. Runs saved before this shipped carry no datapoints and are rejected
-with an explanatory error.
+with an explanatory error, as are runs stamped with a replay format newer than
+the installed version understands.
 
 No built-in trace-to-persona extractor yet: turning raw traces (or previous
 runs) into seed phrases for `generate_personas()` / `generate_scenarios()` is a

--- a/src/evaluatorq/simulation/__init__.py
+++ b/src/evaluatorq/simulation/__init__.py
@@ -45,6 +45,7 @@ from evaluatorq.simulation.types import DEFAULT_MODEL
 logger = logging.getLogger(__name__)  # noqa: RUF067
 
 if TYPE_CHECKING:
+    from evaluatorq.common.replay import ReplayError
     from evaluatorq.contracts import AgentTarget, LLMCallConfig, TokenUsage
     from evaluatorq.integrations.callable_integration import CallableTarget
     from evaluatorq.integrations.langgraph_integration import LangGraphTarget
@@ -182,6 +183,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {  # noqa: RUF067
     'RichHooks': ('evaluatorq.simulation.hooks', 'RichHooks'),
     'SimulationRunMeta': ('evaluatorq.simulation.hooks', 'SimulationRunMeta'),
     'SimulationError': ('evaluatorq.simulation.exceptions', 'SimulationError'),
+    'ReplayError': ('evaluatorq.common.replay', 'ReplayError'),
     'SimulationCancelledError': (
         'evaluatorq.simulation.exceptions',
         'SimulationCancelledError',
@@ -313,6 +315,7 @@ __all__ = [
     'PersonaGenerator',
     # Quality
     'PerturbationType',
+    'ReplayError',
     'RichHooks',
     'Scenario',
     'ScenarioGenerator',

--- a/src/evaluatorq/simulation/_config.py
+++ b/src/evaluatorq/simulation/_config.py
@@ -56,6 +56,7 @@ class SimulationConfig(BaseModel):
     scenarios: list[Scenario] | None = None
     datapoints: list[SimulationDatapoint] | None = None
     dataset_id: str | None = None
+    previous_run: str | None = None
 
     # --- Run behaviour -----------------------------------------------------
     max_turns: int = 10

--- a/src/evaluatorq/simulation/_config.py
+++ b/src/evaluatorq/simulation/_config.py
@@ -59,7 +59,9 @@ class SimulationConfig(BaseModel):
     previous_run: str | None = None
 
     # --- Run behaviour -----------------------------------------------------
-    max_turns: int = 10
+    max_turns: int | None = None
+    """None means "unset": resolved in ``_simulate_core`` to a replayed run's
+    cap when replaying, else to ``DEFAULT_MAX_TURNS``."""
     model: str = DEFAULT_MODEL
     evaluator_names: list[str] | None = None
     parallelism: int = 5

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -145,6 +145,7 @@ async def simulate(
     scenarios: list[Scenario] | None = None,
     datapoints: list[SimulationDatapoint] | None = None,
     dataset_id: str | None = None,
+    previous_run: str | None = None,
     max_turns: int = 10,
     sim_model: str = DEFAULT_MODEL,
     evaluator_names: list[str] | None = None,
@@ -194,6 +195,14 @@ async def simulate(
             ``datapoints``, ``personas``, ``scenarios``. Each dataset row's
             ``inputs`` must already match one of the simulation input shapes
             (``datapoint`` / ``persona`` + ``scenario`` / etc.).
+        previous_run: Replay a saved run instead of building new cases. Accepts
+            a run's file name, its run id (full or an unambiguous 8+ character
+            prefix), a path to a saved run JSON, or ``"latest"``, resolved
+            against ``.evaluatorq/sim-runs/``. The stored personas, scenarios,
+            and first messages are re-used verbatim — no generation, no dataset
+            fetch — so only the target and evaluators change between runs.
+            Mutually exclusive with ``datapoints``, ``dataset_id``, and
+            ``personas``/``scenarios``.
         upload_results: When ``True`` (the default) and ``ORQ_API_KEY`` is set,
             results are uploaded to the Orq platform as an experiment. Pass
             ``False`` to suppress the upload (e.g. for local-only runs).
@@ -232,6 +241,7 @@ async def simulate(
         scenarios=scenarios,
         datapoints=datapoints,
         dataset_id=dataset_id,
+        previous_run=previous_run,
         max_turns=max_turns,
         sim_model=sim_model,
         evaluator_names=evaluator_names,
@@ -259,6 +269,7 @@ async def _simulate_run(
     scenarios: list[Scenario] | None = None,
     datapoints: list[SimulationDatapoint] | None = None,
     dataset_id: str | None = None,
+    previous_run: str | None = None,
     max_turns: int = 10,
     sim_model: str = DEFAULT_MODEL,
     evaluator_names: list[str] | None = None,
@@ -324,6 +335,7 @@ async def _simulate_run(
                     scenarios=scenarios,
                     datapoints=datapoints,
                     dataset_id=dataset_id,
+                    previous_run=previous_run,
                     max_turns=max_turns,
                     model=sim_model,
                     evaluator_names=evaluator_names,
@@ -507,6 +519,7 @@ async def _generate_datapoints_inner(
             personas=gen_personas,
             scenarios=gen_scenarios,
             dataset_id=None,
+            previous_run=None,
             model=model,
             generation_client=gen_client,
         )
@@ -1047,6 +1060,7 @@ async def _simulate_core(
         personas=config.personas,
         scenarios=config.scenarios,
         dataset_id=config.dataset_id,
+        previous_run=config.previous_run,
         model=model,
         generation_client=config.generation_client,
     )
@@ -1186,6 +1200,8 @@ async def _simulate_core(
             results=results,
             run_id=run_id,
             experiment_url=experiment_url_out[0] if experiment_url_out else None,
+            # Persist the cases themselves so this run can be replayed later.
+            datapoints=sim_datapoints,
         )
 
         # Generate the LLM narrative before persistence so a saved report carries
@@ -1338,24 +1354,35 @@ async def _resolve_or_generate_datapoints(
     personas: list[Persona] | None,
     scenarios: list[Scenario] | None,
     dataset_id: str | None,
+    previous_run: str | None,
     model: str,
     generation_client: AsyncOpenAI | None,
 ) -> list[SimulationDatapoint]:
     """Return ready-to-run Datapoints.
 
-    Resolution precedence: ``dataset_id`` -> ``datapoints`` -> persona x scenario
-    cartesian product (with first-message generation). The three sources are
-    mutually exclusive. ``caller`` names the public entry point so any
-    API-key error message points the user at the right function.
+    Resolution precedence: ``previous_run`` -> ``dataset_id`` -> ``datapoints``
+    -> persona x scenario cartesian product (with first-message generation). The
+    four sources are mutually exclusive. ``caller`` names the public entry point
+    so any API-key error message points the user at the right function.
     """
     sources = [
+        ('previous_run', previous_run is not None),
         ('dataset_id', dataset_id is not None),
         ('datapoints', datapoints is not None),
         ('personas/scenarios', personas is not None or scenarios is not None),
     ]
     chosen = [name for name, present in sources if present]
     if len(chosen) > 1:
-        raise ValueError(f'Pass exactly one of dataset_id, datapoints, or personas+scenarios; got: {", ".join(chosen)}')
+        raise ValueError(
+            f'Pass exactly one of previous_run, dataset_id, datapoints, or personas+scenarios; got: {", ".join(chosen)}'
+        )
+
+    if previous_run is not None:
+        from evaluatorq.simulation.replay import load_simulation_replay
+
+        replayed = load_simulation_replay(previous_run)
+        logger.info(f'Replaying {len(replayed)} datapoints from previous run {previous_run!r}.')
+        return replayed
 
     if dataset_id is not None:
         api_key = _require_orq_api_key(caller)
@@ -1367,7 +1394,9 @@ async def _resolve_or_generate_datapoints(
         return datapoints
 
     if personas is None or scenarios is None:
-        raise ValueError("Either provide 'dataset_id', 'datapoints', or both 'personas' and 'scenarios'")
+        raise ValueError(
+            "Either provide 'previous_run', 'dataset_id', 'datapoints', or both 'personas' and 'scenarios'"
+        )
     if not personas or not scenarios:
         raise ValueError("'personas' and 'scenarios' arrays must both be non-empty")
 

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 from evaluatorq.common.llm_client import resolve_results_base_url
 from evaluatorq.common.thread_context import build_thread_id
 from evaluatorq.simulation._config import SimulationConfig
-from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, DEFAULT_MODEL
+from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, DEFAULT_MAX_TURNS, DEFAULT_MODEL
 from evaluatorq.simulation.utils.run_store import auto_save_run, build_simulation_run, fetch_agent_info, write_report
 
 if TYPE_CHECKING:
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from evaluatorq.simulation.evaluators.scorers import SimulationScorer
     from evaluatorq.simulation.generators import FirstMessageGenerator
     from evaluatorq.simulation.hooks import SimulationHooks
+    from evaluatorq.simulation.replay import SimulationReplay
     from evaluatorq.simulation.types import (
         Message,
         Persona,
@@ -146,7 +147,7 @@ async def simulate(
     datapoints: list[SimulationDatapoint] | None = None,
     dataset_id: str | None = None,
     previous_run: str | None = None,
-    max_turns: int = 10,
+    max_turns: int | None = None,
     sim_model: str = DEFAULT_MODEL,
     evaluator_names: list[str] | None = None,
     parallelism: int = 5,
@@ -195,6 +196,9 @@ async def simulate(
             ``datapoints``, ``personas``, ``scenarios``. Each dataset row's
             ``inputs`` must already match one of the simulation input shapes
             (``datapoint`` / ``persona`` + ``scenario`` / etc.).
+        max_turns: Cap on conversation turns. Defaults to 10, or — when
+            replaying via ``previous_run`` — to the cap the replayed run used.
+            An explicit value always wins.
         previous_run: Replay a saved run instead of building new cases. Accepts
             a run's file name, its run id (full or an unambiguous 8+ character
             prefix), a path to a saved run JSON, or ``"latest"``, resolved
@@ -270,7 +274,7 @@ async def _simulate_run(
     datapoints: list[SimulationDatapoint] | None = None,
     dataset_id: str | None = None,
     previous_run: str | None = None,
-    max_turns: int = 10,
+    max_turns: int | None = None,
     sim_model: str = DEFAULT_MODEL,
     evaluator_names: list[str] | None = None,
     parallelism: int = 5,
@@ -378,7 +382,7 @@ async def generate_and_simulate(
     target: str | Callable[[list[Message]], str | Awaitable[str]] | AgentTarget | None = None,
     num_personas: int = 5,
     num_scenarios: int = 5,
-    max_turns: int = 10,
+    max_turns: int | None = None,
     sim_model: str = DEFAULT_MODEL,
     evaluator_names: list[str] | None = None,
     parallelism: int = 5,
@@ -537,7 +541,7 @@ async def _generate_and_simulate_run(
     target: str | Callable[[list[Message]], str | Awaitable[str]] | AgentTarget | None = None,
     num_personas: int = 5,
     num_scenarios: int = 5,
-    max_turns: int = 10,
+    max_turns: int | None = None,
     sim_model: str = DEFAULT_MODEL,
     evaluator_names: list[str] | None = None,
     parallelism: int = 5,
@@ -1038,9 +1042,9 @@ async def _simulate_core(
     from evaluatorq.common.tracing import set_span_attrs
     from evaluatorq.simulation.exceptions import SimulationCancelledError
     from evaluatorq.simulation.hooks import DefaultHooks, SimStage, SimulationRunMeta
+    from evaluatorq.simulation.replay import load_simulation_replay
 
     evaluation_name = config.evaluation_name
-    max_turns = config.max_turns
     model = config.model
     parallelism = config.parallelism
     save = config.save
@@ -1054,6 +1058,7 @@ async def _simulate_core(
     # f"{run_id}:{index}"; persisted on SimulationRun / SimulationResult so the
     # dashboard can deep-link to the run's traces in Orq observability.
 
+    replayed = load_simulation_replay(config.previous_run) if config.previous_run is not None else None
     sim_datapoints = await _resolve_or_generate_datapoints(
         caller=caller,
         datapoints=config.datapoints,
@@ -1063,7 +1068,18 @@ async def _simulate_core(
         previous_run=config.previous_run,
         model=model,
         generation_client=config.generation_client,
+        replayed=replayed,
     )
+    # An explicit max_turns wins; otherwise a replay restores the cap its cases
+    # ran under, and only then do we fall back to the default. Rebind config so
+    # every downstream reader (run meta, the runner, the saved run) agrees.
+    max_turns = (
+        config.max_turns
+        if config.max_turns is not None
+        else ((replayed.max_turns if replayed is not None else None) or DEFAULT_MAX_TURNS)
+    )
+    if config.max_turns != max_turns:
+        config = config.model_copy(update={'max_turns': max_turns})
 
     set_span_attrs(
         pipeline_span,
@@ -1357,6 +1373,7 @@ async def _resolve_or_generate_datapoints(
     previous_run: str | None,
     model: str,
     generation_client: AsyncOpenAI | None,
+    replayed: SimulationReplay | None = None,
 ) -> list[SimulationDatapoint]:
     """Return ready-to-run Datapoints.
 
@@ -1378,11 +1395,13 @@ async def _resolve_or_generate_datapoints(
         )
 
     if previous_run is not None:
+        # The caller loads the replay (it also needs the run's turn cap) and
+        # passes it in, so the file is read once per run.
         from evaluatorq.simulation.replay import load_simulation_replay
 
-        replayed = load_simulation_replay(previous_run)
-        logger.info(f'Replaying {len(replayed)} datapoints from previous run {previous_run!r}.')
-        return replayed
+        resolved = replayed if replayed is not None else load_simulation_replay(previous_run)
+        logger.info(f'Replaying {len(resolved.datapoints)} datapoints from previous run {previous_run!r}.')
+        return resolved.datapoints
 
     if dataset_id is not None:
         api_key = _require_orq_api_key(caller)
@@ -1642,8 +1661,10 @@ async def _simulate_via_evaluatorq(
     from evaluatorq.types import DataPoint
 
     evaluation_name = config.evaluation_name
-    max_turns = config.max_turns
     model = config.model
+    # _simulate_core resolves max_turns before calling here; the fallback only
+    # covers a direct call that skipped it.
+    max_turns = config.max_turns if config.max_turns is not None else DEFAULT_MAX_TURNS
     parallelism = config.parallelism
     user_simulator = config.user_simulator
     judge = config.judge

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -308,7 +308,10 @@ async def _simulate_run(
             'orq.simulation.pipeline',
             {
                 'orq.simulation.evaluation_name': evaluation_name,
-                'orq.simulation.max_turns': max_turns,
+                # max_turns is None until _simulate_core resolves it (an explicit
+                # value, else a replayed run's cap, else the default), and
+                # set_span_attrs drops None — so the resolved value is stamped
+                # there rather than guessed here.
                 'orq.simulation.parallelism': parallelism,
             },
         ) as pipeline_span:
@@ -580,7 +583,10 @@ async def _generate_and_simulate_run(
                 'orq.simulation.mode': 'generate_and_simulate',
                 'orq.simulation.num_personas': num_personas,
                 'orq.simulation.num_scenarios': num_scenarios,
-                'orq.simulation.max_turns': max_turns,
+                # max_turns is None until _simulate_core resolves it (an explicit
+                # value, else a replayed run's cap, else the default), and
+                # set_span_attrs drops None — so the resolved value is stamped
+                # there rather than guessed here.
                 'orq.simulation.parallelism': parallelism,
             },
         ) as pipeline_span:
@@ -1083,7 +1089,7 @@ async def _simulate_core(
 
     set_span_attrs(
         pipeline_span,
-        {'orq.simulation.datapoints_count': len(sim_datapoints)},
+        {'orq.simulation.datapoints_count': len(sim_datapoints), 'orq.simulation.max_turns': max_turns},
     )
 
     resolved_hooks = config.hooks or DefaultHooks()

--- a/src/evaluatorq/simulation/cli.py
+++ b/src/evaluatorq/simulation/cli.py
@@ -404,6 +404,8 @@ _SIMULATE_EPILOG = _examples(
     'eq sim simulate -i dp.jsonl --openai-model gpt-4o-mini',
     '# from an orq dataset instead of a local file',
     'eq sim simulate --dataset-id ds_abc --target agent:my-agent',
+    '# replay the last saved run against a new agent version',
+    'eq sim simulate --from-run latest --target agent:my-agent-v2',
 )
 
 _RUN_EPILOG = _examples(
@@ -444,7 +446,7 @@ def simulate(
         typer.Option(
             '--input',
             '-i',
-            help='Path to datapoints JSONL file (or use --dataset-id).',
+            help='Path to datapoints JSONL file (or use --dataset-id / --from-run).',
         ),
     ] = None,
     dataset_id: Annotated[
@@ -452,6 +454,17 @@ def simulate(
         typer.Option(
             '--dataset-id',
             help='Fetch datapoints from this Orq dataset instead of a local file. Requires ORQ_API_KEY.',
+        ),
+    ] = None,
+    from_run: Annotated[
+        str | None,
+        typer.Option(
+            '--from-run',
+            help=(
+                'Replay a previous run from .evaluatorq/sim-runs/: pass its file name, '
+                'run id, path, or "latest". Re-runs the exact same personas, scenarios, '
+                'and first messages, so only the target and evaluators may differ.'
+            ),
         ),
     ] = None,
     target: Annotated[
@@ -574,7 +587,13 @@ def simulate(
         ),
     ] = True,
 ) -> None:
-    """Run simulations from a pre-built datapoints file.
+    """Run simulations from a pre-built datapoints file, an Orq dataset, or a previous run.
+
+    Inputs (provide exactly one):
+
+    - --input PATH       datapoints JSONL file.
+    - --dataset-id ID    Orq dataset.
+    - --from-run REF     replay a saved run's exact cases ("latest", file name, or run id).
 
     Targets (provide exactly one):
 
@@ -607,8 +626,14 @@ def simulate(
     _configure_logging(verbose, console=log_console)
     _echo_using(sim_model)
 
-    if (datapoints is None) == (dataset_id is None):
-        raise typer.BadParameter('Provide exactly one of --input or --dataset-id.')
+    sources = [
+        name
+        for name, given in (('--input', datapoints), ('--dataset-id', dataset_id), ('--from-run', from_run))
+        if given is not None
+    ]
+    if len(sources) != 1:
+        got = f' (got: {", ".join(sources)})' if sources else ''
+        raise typer.BadParameter(f'Provide exactly one of --input, --dataset-id, or --from-run{got}.')
     if datapoints is not None and not datapoints.exists():
         raise typer.BadParameter(f'Datapoints file not found: {datapoints}')
     if dataset_id is not None:
@@ -625,6 +650,7 @@ def simulate(
             _simulate_impl(
                 datapoints_path=datapoints,
                 dataset_id=dataset_id,
+                previous_run=from_run,
                 target=resolved_target,
                 sim_model=sim_model,
                 max_turns=max_turns,
@@ -679,6 +705,7 @@ async def _simulate_impl(
     *,
     datapoints_path: Path | None,
     dataset_id: str | None = None,
+    previous_run: str | None = None,
     target: Any,
     sim_model: str,
     max_turns: int,
@@ -691,9 +718,9 @@ async def _simulate_impl(
     from evaluatorq.simulation.utils.dataset_export import load_datapoints_from_jsonl
 
     loaded = None
-    if dataset_id is None:
+    if dataset_id is None and previous_run is None:
         if datapoints_path is None:  # the command guarantees exactly one source
-            raise ValueError('Either datapoints_path or dataset_id is required')
+            raise ValueError('One of datapoints_path, dataset_id, or previous_run is required')
         loaded = load_datapoints_from_jsonl(str(datapoints_path))
         if not loaded:
             raise ValueError(f'No datapoints loaded from {datapoints_path}')
@@ -701,6 +728,7 @@ async def _simulate_impl(
     return await _simulate_run(
         datapoints=loaded,
         dataset_id=dataset_id,
+        previous_run=previous_run,
         target=target,
         sim_model=sim_model,
         max_turns=max_turns,

--- a/src/evaluatorq/simulation/cli.py
+++ b/src/evaluatorq/simulation/cli.py
@@ -527,9 +527,13 @@ def simulate(
         ),
     ] = DEFAULT_MODEL,
     max_turns: Annotated[
-        int,
-        typer.Option('--max-turns', min=1, help='Maximum conversation turns.'),
-    ] = 10,
+        int | None,
+        typer.Option(
+            '--max-turns',
+            min=1,
+            help="Maximum conversation turns. Defaults to 10, or to the replayed run's cap with --from-run.",
+        ),
+    ] = None,
     parallelism: Annotated[
         int,
         typer.Option('--parallelism', min=1, help='Concurrent simulations.'),
@@ -708,7 +712,7 @@ async def _simulate_impl(
     previous_run: str | None = None,
     target: Any,
     sim_model: str,
-    max_turns: int,
+    max_turns: int | None,
     parallelism: int,
     evaluator_names: list[str] | None,
     evaluation_name: str,

--- a/src/evaluatorq/simulation/replay.py
+++ b/src/evaluatorq/simulation/replay.py
@@ -12,6 +12,7 @@ results keep persona and scenario *names*, not the objects the simulator needs.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from evaluatorq.common.replay import ReplayError, load_run_payload
@@ -23,8 +24,18 @@ if TYPE_CHECKING:
 SURFACE = 'simulation'
 
 
-def load_simulation_replay(reference: str, runs_dir: Path | None = None) -> list[SimulationDatapoint]:
-    """Resolve *reference* to a saved run and return the datapoints it ran.
+@dataclass(frozen=True)
+class SimulationReplay:
+    """A prior run's cases, plus the settings they were run under."""
+
+    datapoints: list[SimulationDatapoint]
+    max_turns: int | None = None
+    """Turn cap the original run used, restored unless the caller overrides it.
+    A conversation that ran to 12 turns is not the same case re-run at 10."""
+
+
+def load_simulation_replay(reference: str, runs_dir: Path | None = None) -> SimulationReplay:
+    """Resolve *reference* to a saved run and return the cases it ran.
 
     Raises:
         ReplayError: The run cannot be found, read, or stores no datapoints.
@@ -38,13 +49,21 @@ def load_simulation_replay(reference: str, runs_dir: Path | None = None) -> list
 
     raw = payload.get('datapoints')
     if not isinstance(raw, list) or not raw:
+        if payload.get('pipeline') is not None:
+            raise ReplayError(
+                f'{path.name} is a red team run, not a simulation run. '
+                f'Replay it with: eq redteam run --from-run {path.name} --target <target>'
+            )
         raise ReplayError(
-            f'Previous simulation run {path.name} stores no datapoints, so it cannot be replayed. '
-            'Only runs saved by evaluatorq 1.4.0+ record the cases they ran; re-run the original '
-            'configuration once to produce a replayable run.'
+            f'{path.name} records no simulation datapoints, so it cannot be replayed. Replay needs the '
+            'cases themselves, which only runs saved after replay support existed carry. Re-run the '
+            'original configuration once to produce a replayable run.'
         )
 
     try:
-        return [SimulationDatapoint.model_validate(row) for row in raw]
+        datapoints = [SimulationDatapoint.model_validate(row) for row in raw]
     except ValidationError as exc:
         raise ReplayError(f'Previous simulation run {path.name} has unreadable datapoints: {exc}') from exc
+
+    stored_turns = payload.get('max_turns')
+    return SimulationReplay(datapoints=datapoints, max_turns=stored_turns if isinstance(stored_turns, int) else None)

--- a/src/evaluatorq/simulation/replay.py
+++ b/src/evaluatorq/simulation/replay.py
@@ -1,0 +1,50 @@
+"""Rebuild a prior simulation run's datapoints so it can be replayed verbatim.
+
+Saved runs carry the ``SimulationDatapoint`` list they simulated. Replaying
+reads it back and hands it to the runner as the resolved datapoint set, so no
+persona/scenario generation and no first-message generation happen: the same
+conversations start again, against whatever target and evaluators the new
+invocation specifies.
+
+Runs saved before the ``datapoints`` field existed cannot be replayed — their
+results keep persona and scenario *names*, not the objects the simulator needs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from evaluatorq.common.replay import ReplayError, load_run_payload
+from evaluatorq.simulation.types import SimulationDatapoint
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SURFACE = 'simulation'
+
+
+def load_simulation_replay(reference: str, runs_dir: Path | None = None) -> list[SimulationDatapoint]:
+    """Resolve *reference* to a saved run and return the datapoints it ran.
+
+    Raises:
+        ReplayError: The run cannot be found, read, or stores no datapoints.
+    """
+    from pydantic import ValidationError
+
+    from evaluatorq.simulation.utils.run_store import get_sim_runs_dir
+
+    resolved_dir = runs_dir if runs_dir is not None else get_sim_runs_dir()
+    payload, path = load_run_payload(reference, resolved_dir, surface=SURFACE)
+
+    raw = payload.get('datapoints')
+    if not isinstance(raw, list) or not raw:
+        raise ReplayError(
+            f'Previous simulation run {path.name} stores no datapoints, so it cannot be replayed. '
+            'Only runs saved by evaluatorq 1.4.0+ record the cases they ran; re-run the original '
+            'configuration once to produce a replayable run.'
+        )
+
+    try:
+        return [SimulationDatapoint.model_validate(row) for row in raw]
+    except ValidationError as exc:
+        raise ReplayError(f'Previous simulation run {path.name} has unreadable datapoints: {exc}') from exc

--- a/src/evaluatorq/simulation/replay.py
+++ b/src/evaluatorq/simulation/replay.py
@@ -47,13 +47,18 @@ def load_simulation_replay(reference: str, runs_dir: Path | None = None) -> Simu
     resolved_dir = runs_dir if runs_dir is not None else get_sim_runs_dir()
     payload, path = load_run_payload(reference, resolved_dir, surface=SURFACE)
 
+    # Check the discriminator first, unconditionally: a red team run saved by
+    # this same version carries a non-empty top-level ``datapoints`` too, so
+    # gating this on an empty list would let it through to fail as a pydantic
+    # dump instead of the redirect. ``pipeline`` is red-team-only.
+    if payload.get('pipeline') is not None:
+        raise ReplayError(
+            f'{path.name} is a red team run, not a simulation run. '
+            f'Replay it with: eq redteam run --from-run {path.name} --target <target>'
+        )
+
     raw = payload.get('datapoints')
     if not isinstance(raw, list) or not raw:
-        if payload.get('pipeline') is not None:
-            raise ReplayError(
-                f'{path.name} is a red team run, not a simulation run. '
-                f'Replay it with: eq redteam run --from-run {path.name} --target <target>'
-            )
         raise ReplayError(
             f'{path.name} records no simulation datapoints, so it cannot be replayed. Replay needs the '
             'cases themselves, which only runs saved after replay support existed carry. Re-run the '

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -403,6 +403,11 @@ class SimulationRun(BaseModel):
     total_results: int
     scorer_averages: dict[str, float]
     results: list[SimulationResult]
+    datapoints: list[SimulationDatapoint] | None = None
+    """The exact cases this run simulated, stored so the run can be replayed
+    verbatim (``previous_run=`` / ``--from-run``). Results alone don't carry
+    enough — they keep persona/scenario *names*, not the objects. None for runs
+    saved before this field existed, which therefore cannot be replayed."""
     executive_summary: str | None = None
     run_id: str | None = None
     """Client-minted run-grouping id (uuid hex, not an Orq-side run id) shared by every

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -15,6 +15,11 @@ from evaluatorq.contracts import Message, ResponseTrace, StrEnum, TokenUsage
 
 DEFAULT_MODEL = 'openai/gpt-5.4-mini'
 
+DEFAULT_MAX_TURNS = 10
+"""Turn cap when the caller names none. The public ``max_turns`` defaults to
+``None`` rather than to this value so a replay can tell "unset" from
+"explicitly 10" and restore the replayed run's cap only in the former case."""
+
 
 class AgentInfoSnapshot(TypedDict, total=False):
     """Best-effort snapshot of an ORQ agent's configuration, as fetched by

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -413,6 +413,10 @@ class SimulationRun(BaseModel):
     verbatim (``previous_run=`` / ``--from-run``). Results alone don't carry
     enough — they keep persona/scenario *names*, not the objects. None for runs
     saved before this field existed, which therefore cannot be replayed."""
+    replay_version: int | None = None
+    """Format version of the replay payload above, stamped when ``datapoints`` is
+    written so a future format change reports itself instead of failing
+    structurally. None for runs saved before versioning, which read as v1."""
     executive_summary: str | None = None
     run_id: str | None = None
     """Client-minted run-grouping id (uuid hex, not an Orq-side run id) shared by every

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -131,6 +131,7 @@ def build_simulation_run(
     agent_info: AgentInfoSnapshot | None = None,
     run_id: str | None = None,
     experiment_url: str | None = None,
+    datapoints: list[Any] | None = None,
 ) -> SimulationRun:
     # Record the Orq host only for Orq-served targets; plain callables / OpenAI
     # models don't touch Orq, so the field stays None (omitted) for them.
@@ -170,6 +171,7 @@ def build_simulation_run(
         total_results=len(results),
         scorer_averages=scorer_averages,
         results=results,
+        datapoints=list(datapoints) if datapoints else None,
     )
 
 

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from evaluatorq.common.llm_client import orq_base_url as _orq_base_url
+from evaluatorq.common.replay import REPLAY_VERSION
 from evaluatorq.common.run_store_dir import get_store_dir
 from evaluatorq.simulation.types import AgentInfoSnapshot, SimulationRun
 
@@ -172,6 +173,7 @@ def build_simulation_run(
         scorer_averages=scorer_averages,
         results=results,
         datapoints=list(datapoints) if datapoints else None,
+        replay_version=REPLAY_VERSION if datapoints else None,
     )
 
 

--- a/tests/common/test_tracing_lifecycle.py
+++ b/tests/common/test_tracing_lifecycle.py
@@ -192,6 +192,9 @@ async def test_initialization_caps_export_batch_size_to_queue_size(
     monkeypatch.setattr(tracing_setup, '_tracer', None)
     monkeypatch.setattr(tracing_setup, '_is_initialized', False)
     monkeypatch.setattr(tracing_setup, '_initialization_attempted', False)
+    # Opt out of the suite-wide export guard: this test drives real setup with
+    # the exporter and provider faked out above.
+    monkeypatch.delenv('ORQ_DISABLE_TRACING', raising=False)
     monkeypatch.setenv('OTEL_EXPORTER_OTLP_ENDPOINT', 'https://example.test')
     monkeypatch.setenv('ORQ_OTEL_MAX_QUEUE_SIZE', '100')
     monkeypatch.setenv('ORQ_OTEL_MAX_BATCH_SIZE', '200')
@@ -295,3 +298,20 @@ async def test_shutdown_without_sdk_disables_reinitialization_for_process_lifeti
 def test_shutdown_tracing_is_not_publicly_importable() -> None:
     with pytest.raises(ImportError):
         exec('from evaluatorq.tracing import _shutdown_tracing')
+
+
+@pytest.mark.asyncio
+async def test_the_suite_never_installs_a_live_span_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The autouse guard in the root conftest must hold even with a real key in
+    the environment. Without it, the first test to reach setup installs a
+    process-wide OTLP exporter and every later span is queued for upload to
+    my.orq.ai, flushed at interpreter shutdown.
+    """
+    monkeypatch.setenv('ORQ_API_KEY', 'looks-real-enough')
+    monkeypatch.setattr(tracing_setup, '_initialization_attempted', False)
+    monkeypatch.setattr(tracing_setup, '_is_initialized', False)
+
+    assert await tracing_setup.init_tracing_if_needed() is False
+    assert tracing_setup._sdk is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,23 @@ def _isolate_run_stores(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _disable_real_span_export(monkeypatch):
+    """Keep the suite from installing a live OTLP exporter.
+
+    ``init_tracing_if_needed()`` installs a real BatchSpanProcessor whenever
+    ORQ_API_KEY is set, and it latches for the process — so on a developer
+    machine with a real key the first test that reaches it wins, and every span
+    the rest of the suite produces is queued for export to my.orq.ai and flushed
+    at interpreter shutdown (a 401, or worse, a successful upload of test spans).
+    Which test gets there first depends on file order, which is why this shows
+    up in some batches and not others. Tests that exercise setup itself opt back
+    in by deleting this var.
+    """
+    monkeypatch.setenv("ORQ_DISABLE_TRACING", "1")
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _clear_span_max_text_chars_cache():
     """Clear lru_cache between tests so EVALUATORQ_SPAN_MAX_TEXT_CHARS env changes propagate."""
     from evaluatorq.common.tracing import _default_span_max_text_chars

--- a/tests/redteam/e2e/test_replay_pipeline.py
+++ b/tests/redteam/e2e/test_replay_pipeline.py
@@ -323,3 +323,45 @@ async def test_hybrid_replay_against_a_bare_agent_target_keeps_the_static_leg(
 
     assert (replayed.summary.datapoint_breakdown or {}).get('static') == source_static
     assert _attack_ids(replayed) == _attack_ids(original)
+
+
+@pytest.mark.asyncio
+async def test_mixed_hybrid_run_counts_the_static_leg_once(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """Regression: a non-replay hybrid mixing a string target with an AgentTarget.
+
+    The AgentTarget branch used to append the whole static dataset on top of
+    shared datapoints that already carried the tagged static rows, doubling that
+    leg. The inflated list never reaches execution (the run uses the first
+    prepared target's datapoints), so it is pinned here at the per-target
+    breakdown, which is computed from each target's own list.
+    """
+    from .conftest import MockAgentTarget
+
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+    seen: list[list[str]] = []
+    real_breakdown = runner_mod._datapoint_breakdown
+
+    def _spy(datapoints):
+        seen.append([dp.inputs.get('id', '') for dp in datapoints])
+        return real_breakdown(datapoints)
+
+    with _patches(mock_backend_bundle), patch.object(runner_mod, '_datapoint_breakdown', _spy):
+        await red_team(
+            ['agent:e2e-test-agent', MockAgentTarget('direct-agent')],
+            mode='hybrid',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            dataset=str(static_dataset_path),
+            name='mixed-hybrid',
+        )
+
+    assert seen, 'per-target breakdown should have been computed'
+    for ids in seen:
+        assert len(ids) == len(set(ids)), f'datapoints duplicated for a target: {ids}'
+    assert len({len(ids) for ids in seen}) == 1, f'targets disagree on datapoint count: {[len(i) for i in seen]}'

--- a/tests/redteam/e2e/test_replay_pipeline.py
+++ b/tests/redteam/e2e/test_replay_pipeline.py
@@ -1,0 +1,150 @@
+"""E2E: a saved run can be replayed verbatim against a different target."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager, contextmanager
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from openai import AsyncOpenAI
+
+from evaluatorq.redteam import red_team
+from evaluatorq.redteam.replay import load_redteam_replay
+from evaluatorq.redteam.runner import get_runs_dir
+from evaluatorq.tracing import TracingContext
+
+from .conftest import (
+    DeterministicAsyncOpenAI,
+    MockBackend,
+    validate_report_structure,
+)
+
+
+@asynccontextmanager
+async def _noop_tracing_session(*args, **kwargs):
+    yield TracingContext(run_id='test', run_name='test', enabled=False, parent_context=None, trace_type='redteam')
+
+
+@contextmanager
+def _patches(mock_backend_bundle: MockBackend):
+    with (
+        patch('evaluatorq.redteam.runner.resolve_backend', return_value=mock_backend_bundle),
+        patch('evaluatorq.redteam.backends.registry.resolve_backend', return_value=mock_backend_bundle),
+        patch('evaluatorq.redteam.runner.tracing_session', _noop_tracing_session),
+    ):
+        yield
+
+
+def _attack_ids(report) -> list[str]:
+    return sorted(r.attack.id for r in report.results)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_run_replays_the_same_attacks(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+) -> None:
+    """The replay re-runs the stored cases and generates nothing new."""
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        original = await red_team(
+            'agent:e2e-test-agent',
+            mode='dynamic',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            name='replay-source',
+        )
+
+    stored = load_redteam_replay('latest', get_runs_dir())
+    assert stored.datapoints, 'the saved run should carry its datapoints'
+
+    # A replay against a *different* target: same cases, new subject.
+    with _patches(mock_backend_bundle):
+        replayed = await red_team(
+            'agent:other-agent',
+            previous_run='latest',
+            parallelism=2,
+            llm_client=client,
+            name='replay-run',
+        )
+
+    errors = validate_report_structure(replayed, expected_pipeline='dynamic', min_results=1)
+    assert not errors, f'Report validation errors: {errors}'
+    assert _attack_ids(replayed) == _attack_ids(original)
+    assert replayed.tested_agents == ['other-agent']
+
+
+@pytest.mark.asyncio
+async def test_replay_skips_strategy_generation(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+) -> None:
+    """No planner call happens on replay even with generation left enabled."""
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        await red_team(
+            'agent:e2e-test-agent',
+            mode='dynamic',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            name='replay-source',
+        )
+
+    with (
+        _patches(mock_backend_bundle),
+        patch('evaluatorq.redteam.runner.generate_dynamic_datapoints_for_vulnerabilities') as gen_vulns,
+        patch('evaluatorq.redteam.runner.generate_dynamic_datapoints') as gen_cats,
+        patch('evaluatorq.redteam.runner.classify_agent_capabilities') as classify,
+    ):
+        replayed = await red_team(
+            'agent:e2e-test-agent',
+            previous_run='latest',
+            parallelism=2,
+            llm_client=client,
+            name='replay-run',
+        )
+
+    assert gen_vulns.call_count == 0
+    assert gen_cats.call_count == 0
+    assert classify.call_count == 0
+    assert replayed.total_results > 0
+
+
+@pytest.mark.asyncio
+async def test_replayed_run_is_itself_replayable(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+) -> None:
+    """Replays are saved with their datapoints too, so the chain doesn't break."""
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        await red_team(
+            'agent:e2e-test-agent',
+            mode='dynamic',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            name='replay-source',
+        )
+    first = load_redteam_replay('latest', get_runs_dir())
+
+    with _patches(mock_backend_bundle):
+        await red_team(
+            'agent:e2e-test-agent',
+            previous_run='replay-source',
+            parallelism=2,
+            llm_client=client,
+            name='replay-run',
+        )
+
+    second = load_redteam_replay('replay-run', get_runs_dir())
+    assert [dp.inputs for dp in second.datapoints] == [dp.inputs for dp in first.datapoints]

--- a/tests/redteam/e2e/test_replay_pipeline.py
+++ b/tests/redteam/e2e/test_replay_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path  # noqa: TC003 — pytest fixture annotation
 from typing import cast
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ import pytest
 from openai import AsyncOpenAI
 
 from evaluatorq.redteam import red_team
+from evaluatorq.redteam import runner as runner_mod
 from evaluatorq.redteam.replay import load_redteam_replay
 from evaluatorq.redteam.runner import get_runs_dir
 from evaluatorq.tracing import TracingContext
@@ -148,3 +150,176 @@ async def test_replayed_run_is_itself_replayable(
 
     second = load_redteam_replay('replay-run', get_runs_dir())
     assert [dp.inputs for dp in second.datapoints] == [dp.inputs for dp in first.datapoints]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_and_static_replays_keep_their_pipeline_and_split(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """A hybrid replay restores both legs; a static replay stays static."""
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        hybrid = await red_team(
+            'agent:e2e-test-agent',
+            mode='hybrid',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            dataset=str(static_dataset_path),
+            name='hybrid-source',
+        )
+    with _patches(mock_backend_bundle):
+        hybrid_replay = await red_team(
+            'agent:e2e-test-agent', previous_run='hybrid-source', parallelism=2, llm_client=client, name='hybrid-replay'
+        )
+
+    assert hybrid_replay.pipeline == hybrid.pipeline
+    assert _attack_ids(hybrid_replay) == _attack_ids(hybrid)
+    assert hybrid_replay.summary.datapoint_breakdown == hybrid.summary.datapoint_breakdown
+
+    with _patches(mock_backend_bundle):
+        static = await red_team(
+            'agent:e2e-test-agent',
+            mode='static',
+            categories=['ASI01'],
+            parallelism=2,
+            llm_client=client,
+            dataset=str(static_dataset_path),
+            name='static-source',
+        )
+    with _patches(mock_backend_bundle):
+        static_replay = await red_team(
+            'agent:e2e-test-agent', previous_run='static-source', parallelism=2, llm_client=client, name='static-replay'
+        )
+
+    assert static_replay.pipeline.value == 'static'
+    assert _attack_ids(static_replay) == _attack_ids(static)
+
+
+@pytest.mark.asyncio
+async def test_replay_restores_the_original_turn_budget(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+) -> None:
+    """max_turns isn't in the datapoints, so it must be carried by the run record."""
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        await red_team(
+            'agent:e2e-test-agent',
+            mode='dynamic',
+            categories=['ASI01'],
+            generate_strategies=False,
+            max_turns=9,
+            attacker_instructions='handles refunds',
+            parallelism=2,
+            llm_client=client,
+            name='turns-source',
+        )
+
+    replay = load_redteam_replay('turns-source', get_runs_dir())
+    assert replay.max_turns == 9
+    assert replay.attacker_instructions == 'handles refunds'
+
+    seen: list[int] = []
+    real_job = runner_mod.create_dynamic_redteam_job
+
+    def _record(*args, **kwargs):
+        seen.append(kwargs['max_turns'])
+        return real_job(*args, **kwargs)
+
+    with _patches(mock_backend_bundle), patch.object(runner_mod, 'create_dynamic_redteam_job', _record):
+        await red_team(
+            'agent:e2e-test-agent', previous_run='turns-source', parallelism=2, llm_client=client, name='turns-replay'
+        )
+    assert seen == [9], f'replay should run at the original turn budget, got {seen}'
+
+    # An explicit value still wins over the restored one.
+    seen.clear()
+    with _patches(mock_backend_bundle), patch.object(runner_mod, 'create_dynamic_redteam_job', _record):
+        await red_team(
+            'agent:e2e-test-agent',
+            previous_run='turns-source',
+            max_turns=3,
+            parallelism=2,
+            llm_client=client,
+            name='turns-override',
+        )
+    assert seen == [3]
+
+
+@pytest.mark.asyncio
+async def test_multi_target_replay_runs_every_target_on_the_same_cases(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+) -> None:
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        original = await red_team(
+            'agent:e2e-test-agent',
+            mode='dynamic',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            name='multi-source',
+        )
+
+    with _patches(mock_backend_bundle):
+        replayed = await red_team(
+            ['agent:v1', 'agent:v2'], previous_run='multi-source', parallelism=2, llm_client=client, name='multi-replay'
+        )
+
+    assert sorted(replayed.tested_agents) == ['v1', 'v2']
+    assert replayed.total_results == original.total_results * 2
+    assert set(_attack_ids(replayed)) == set(_attack_ids(original))
+
+
+@pytest.mark.asyncio
+async def test_hybrid_replay_against_a_bare_agent_target_keeps_the_static_leg(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """The AgentTarget leg must split replayed datapoints by their hybrid tag.
+
+    Before the split fix this branch only recognised a static leg when a dataset
+    had been loaded in-process, so on a replay (where none is) every static row
+    was relabelled dynamic and sent to the wrong inner job. With no string target
+    present the AgentTarget is the first prepared target, which is what makes the
+    difference reach the report.
+    """
+    from .conftest import MockAgentTarget
+
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+
+    with _patches(mock_backend_bundle):
+        original = await red_team(
+            'agent:e2e-test-agent',
+            mode='hybrid',
+            categories=['ASI01'],
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=client,
+            dataset=str(static_dataset_path),
+            name='at-hybrid-source',
+        )
+    source_static = (original.summary.datapoint_breakdown or {}).get('static', 0)
+    assert source_static > 0, 'fixture should produce a static leg'
+
+    with _patches(mock_backend_bundle):
+        replayed = await red_team(
+            MockAgentTarget('direct-agent'),
+            previous_run='at-hybrid-source',
+            parallelism=2,
+            llm_client=client,
+            name='at-hybrid-replay',
+        )
+
+    assert (replayed.summary.datapoint_breakdown or {}).get('static') == source_static
+    assert _attack_ids(replayed) == _attack_ids(original)

--- a/tests/redteam/test_cli_from_run.py
+++ b/tests/redteam/test_cli_from_run.py
@@ -1,0 +1,71 @@
+"""CLI wiring for `eq redteam run --from-run` (RES-1126)."""
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from evaluatorq.redteam.cli import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def test_from_run_is_forwarded_as_previous_run() -> None:
+    report = MagicMock()
+    report.model_dump.return_value = {}
+
+    with patch('evaluatorq.redteam.red_team', new=AsyncMock(return_value=report)) as mock_rt:
+        result = runner.invoke(
+            app,
+            ['run', '--target', 'agent:test-agent', '--from-run', 'latest', '--yes'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_rt.call_args.kwargs['previous_run'] == 'latest'
+
+
+def test_from_run_with_a_data_selection_flag_exits_cleanly(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ['run', '--target', 'agent:test-agent', '--from-run', 'latest', '--category', 'ASI01', '--yes'],
+    )
+
+    assert result.exit_code == 1
+    assert 'cannot be combined with data-selection arguments' in result.output + (result.stderr or '')
+
+
+def test_unresolvable_from_run_exits_cleanly(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+
+    result = runner.invoke(app, ['run', '--target', 'agent:test-agent', '--from-run', 'nope', '--yes'])
+
+    assert result.exit_code == 1
+    assert 'Could not resolve previous red team run' in result.output + (result.stderr or '')
+
+
+def test_from_run_resolves_a_saved_run_by_name(tmp_path: Path, monkeypatch) -> None:
+    """A stored run is found by its run name, not just by file name."""
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+
+    from evaluatorq.redteam.replay import load_redteam_replay
+    from evaluatorq.redteam.runner import get_runs_dir
+
+    runs_dir = get_runs_dir()
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / 'nightly_20260101_000000.json').write_text(
+        json.dumps({'run_name': 'nightly', 'pipeline': 'dynamic', 'datapoints': [{'id': 'a', 'category': 'ASI01'}]}),
+        encoding='utf-8',
+    )
+
+    replay = load_redteam_replay('nightly', runs_dir)
+    assert replay.run_name == 'nightly'
+    assert len(replay.datapoints) == 1

--- a/tests/redteam/test_cli_from_run.py
+++ b/tests/redteam/test_cli_from_run.py
@@ -62,7 +62,7 @@ def test_from_run_resolves_a_saved_run_by_name(tmp_path: Path, monkeypatch) -> N
     runs_dir = get_runs_dir()
     runs_dir.mkdir(parents=True, exist_ok=True)
     (runs_dir / 'nightly_20260101_000000.json').write_text(
-        json.dumps({'run_name': 'nightly', 'pipeline': 'dynamic', 'datapoints': [{'id': 'a', 'category': 'ASI01'}]}),
+        json.dumps({'run_name': 'nightly', 'pipeline': 'dynamic', 'datapoints': [{'id': 'a', 'category': 'ASI01', 'strategy': {'name': 's'}}]}),
         encoding='utf-8',
     )
 

--- a/tests/redteam/test_replay.py
+++ b/tests/redteam/test_replay.py
@@ -85,7 +85,7 @@ def test_run_without_stored_datapoints_cannot_be_replayed(tmp_path: Path) -> Non
     runs = tmp_path / 'runs'
     _save_run(runs, 'legacy_20260101_000000', {'pipeline': 'dynamic', 'results': []})
 
-    with pytest.raises(ReplayError, match='stores no datapoints'):
+    with pytest.raises(ReplayError, match='records no red team datapoints'):
         load_redteam_replay('latest', runs)
 
 
@@ -153,3 +153,65 @@ async def test_previous_run_reports_an_unresolvable_reference(tmp_path: Path, mo
 
     with pytest.raises(ReplayError, match='Could not resolve previous red team run'):
         await red_team(target='agent:demo', previous_run='nope')
+
+
+def test_run_config_is_persisted_and_restored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """max_turns / attacker_instructions aren't in the datapoints, so they're stored."""
+    from evaluatorq.redteam import runner as runner_mod
+
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+
+    path = runner_mod._auto_save_run(
+        _minimal_report(),
+        name='rt',
+        datapoints=[DYNAMIC_INPUTS],
+        run_config={'max_turns': 9, 'attacker_instructions': 'financial agent'},
+    )
+    assert path is not None
+
+    replay = load_redteam_replay('latest', runner_mod.get_runs_dir())
+    assert replay.max_turns == 9
+    assert replay.attacker_instructions == 'financial agent'
+
+
+def test_run_config_absent_leaves_the_defaults_alone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(runs, 'rt_20260101_000000', {'pipeline': 'dynamic', 'datapoints': [DYNAMIC_INPUTS]})
+
+    replay = load_redteam_replay('latest', runs)
+    assert replay.max_turns is None
+    assert replay.attacker_instructions is None
+
+
+def test_a_simulation_run_is_rejected_with_a_pointer_to_the_right_command(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(
+        runs,
+        'sim_20260101_000000',
+        {
+            'run_name': 'sim',
+            'mode': 'simulate',
+            'datapoints': [{'id': 'dp', 'persona': {'name': 'p'}, 'scenario': {'name': 's', 'goal': 'g'}}],
+        },
+    )
+
+    with pytest.raises(ReplayError, match='eq sim simulate --from-run'):
+        load_redteam_replay('latest', runs)
+
+
+def test_datapoint_without_strategy_or_messages_is_rejected(tmp_path: Path) -> None:
+    """A row that can't drive an attack fails up front, not per-row mid-run."""
+    runs = tmp_path / 'runs'
+    _save_run(runs, 'rt_20260101_000000', {'pipeline': 'dynamic', 'datapoints': [{'id': 'x', 'category': 'ASI01'}]})
+
+    with pytest.raises(ReplayError, match="neither a 'strategy'"):
+        load_redteam_replay('latest', runs)
+
+
+def test_detail_summary_report_is_rejected_without_blaming_the_version(tmp_path: Path) -> None:
+    """`--save detail` writes 03_summary_report.json, which never carries datapoints."""
+    runs = tmp_path / 'artifacts'
+    _save_run(runs, '03_summary_report', {'pipeline': 'dynamic', 'results': []})
+
+    with pytest.raises(ReplayError, match='--save detail summary report'):
+        load_redteam_replay(str(runs / '03_summary_report.json'), tmp_path / 'runs')

--- a/tests/redteam/test_replay.py
+++ b/tests/redteam/test_replay.py
@@ -256,3 +256,28 @@ def test_untagged_datapoints_leave_the_stored_label_alone(tmp_path: Path) -> Non
     _save_run(runs, 'rt_20260101_000000', {'pipeline': 'static', 'datapoints': [STATIC_INPUTS]})
 
     assert load_redteam_replay('latest', runs).pipeline == Pipeline.STATIC
+
+
+def test_a_saved_run_stamps_the_replay_format_version(tmp_path, monkeypatch) -> None:
+    """The marker rides with the stored cases: a run with nothing replayable in
+    it should not claim a replay format."""
+    import evaluatorq.redteam.runner as runner_mod
+    from evaluatorq.common.replay import REPLAY_VERSION
+
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+    report = _minimal_report()
+
+    with_cases = runner_mod._auto_save_run(report, 'stamped', [{'id': 'a', 'strategy': {}}], {})
+    without_cases = runner_mod._auto_save_run(report, 'bare', [], None)
+
+    assert with_cases is not None and without_cases is not None
+    assert json.loads(with_cases.read_text())['replay_version'] == REPLAY_VERSION
+    assert 'replay_version' not in json.loads(without_cases.read_text())
+
+
+def test_replay_error_is_importable_from_the_redteam_surface() -> None:
+    import evaluatorq.redteam as rt
+    from evaluatorq.common.replay import ReplayError as internal
+
+    assert rt.ReplayError is internal
+    assert 'ReplayError' in rt.__all__

--- a/tests/redteam/test_replay.py
+++ b/tests/redteam/test_replay.py
@@ -215,3 +215,44 @@ def test_detail_summary_report_is_rejected_without_blaming_the_version(tmp_path:
 
     with pytest.raises(ReplayError, match='--save detail summary report'):
         load_redteam_replay(str(runs / '03_summary_report.json'), tmp_path / 'runs')
+
+
+def test_static_tags_win_over_an_under_reported_pipeline_label(tmp_path: Path) -> None:
+    """merge_reports collapses a hybrid label when the static leg yields no rows.
+
+    The datapoints still carry their tags, so replaying must not route
+    messages-only rows into the dynamic attack job.
+    """
+    runs = tmp_path / 'runs'
+    _save_run(
+        runs,
+        'rt_20260101_000000',
+        {
+            'pipeline': 'dynamic',  # under-reported by merge_reports
+            'datapoints': [
+                {**DYNAMIC_INPUTS, 'hybrid_source': 'dynamic'},
+                {**STATIC_INPUTS, 'hybrid_source': 'static'},
+            ],
+        },
+    )
+
+    assert load_redteam_replay('latest', runs).pipeline == Pipeline.HYBRID
+
+
+def test_a_more_specific_stored_label_is_not_downgraded(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(
+        runs,
+        'rt_20260101_000000',
+        {'pipeline': 'static', 'datapoints': [{**STATIC_INPUTS, 'hybrid_source': 'static'}]},
+    )
+
+    assert load_redteam_replay('latest', runs).pipeline == Pipeline.STATIC
+
+
+def test_untagged_datapoints_leave_the_stored_label_alone(tmp_path: Path) -> None:
+    """A static-mode run tags nothing, so its label must survive."""
+    runs = tmp_path / 'runs'
+    _save_run(runs, 'rt_20260101_000000', {'pipeline': 'static', 'datapoints': [STATIC_INPUTS]})
+
+    assert load_redteam_replay('latest', runs).pipeline == Pipeline.STATIC

--- a/tests/redteam/test_replay.py
+++ b/tests/redteam/test_replay.py
@@ -1,0 +1,155 @@
+"""Replaying a prior red-team run (`previous_run=` / `--from-run`)."""
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from evaluatorq.common.replay import ReplayError
+from evaluatorq.redteam.contracts import Pipeline
+from evaluatorq.redteam.replay import load_redteam_replay
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DYNAMIC_INPUTS = {
+    'id': 'dynamic_goal_hijacking_role_confusion',
+    'vulnerability': 'goal_hijacking',
+    'category': 'ASI01',
+    'strategy': {'name': 'role_confusion', 'is_generated': False},
+    'objective': 'make the agent adopt a new goal',
+}
+STATIC_INPUTS = {
+    'id': 'OWASP-ASI03-0001',
+    'vulnerability': 'privilege_compromise',
+    'category': 'ASI03',
+    'messages': [{'role': 'user', 'content': 'escalate me'}],
+}
+
+
+def _save_run(runs_dir: Path, name: str, payload: dict[str, Any]) -> Path:
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    path = runs_dir / f'{name}.json'
+    path.write_text(json.dumps(payload), encoding='utf-8')
+    return path
+
+
+def test_replay_rebuilds_datapoints_and_pipeline(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(
+        runs,
+        'rt_20260101_000000',
+        {'run_name': 'rt', 'pipeline': 'dynamic', 'datapoints': [DYNAMIC_INPUTS]},
+    )
+
+    replay = load_redteam_replay('latest', runs)
+
+    assert replay.pipeline == Pipeline.DYNAMIC
+    assert replay.run_name == 'rt'
+    assert [dp.inputs for dp in replay.datapoints] == [DYNAMIC_INPUTS]
+    assert replay.categories == ['ASI01']
+
+
+def test_replay_preserves_hybrid_split(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(
+        runs,
+        'rt_20260101_000000',
+        {
+            'pipeline': 'hybrid',
+            'datapoints': [
+                {**DYNAMIC_INPUTS, 'hybrid_source': 'dynamic'},
+                {**STATIC_INPUTS, 'hybrid_source': 'static'},
+            ],
+        },
+    )
+
+    replay = load_redteam_replay('latest', runs)
+
+    assert replay.pipeline == Pipeline.HYBRID
+    assert [dp.inputs['hybrid_source'] for dp in replay.datapoints] == ['dynamic', 'static']
+    assert replay.categories == ['ASI01', 'ASI03']
+
+
+def test_pipeline_is_inferred_when_the_stored_value_is_unusable(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(runs, 'rt_20260101_000000', {'datapoints': [{**STATIC_INPUTS, 'hybrid_source': 'static'}]})
+
+    assert load_redteam_replay('latest', runs).pipeline == Pipeline.STATIC
+
+
+def test_run_without_stored_datapoints_cannot_be_replayed(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(runs, 'legacy_20260101_000000', {'pipeline': 'dynamic', 'results': []})
+
+    with pytest.raises(ReplayError, match='stores no datapoints'):
+        load_redteam_replay('latest', runs)
+
+
+def test_malformed_datapoint_entry_is_rejected(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _save_run(runs, 'rt_20260101_000000', {'pipeline': 'dynamic', 'datapoints': ['not-an-object']})
+
+    with pytest.raises(ReplayError, match='datapoint 0 is not an object'):
+        load_redteam_replay('latest', runs)
+
+
+def test_missing_run_is_reported_clearly(tmp_path: Path) -> None:
+    with pytest.raises(ReplayError, match='Could not resolve previous red team run'):
+        load_redteam_replay('does-not-exist', tmp_path / 'runs')
+
+
+def test_auto_save_persists_the_executed_datapoints(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from evaluatorq.redteam import runner as runner_mod
+
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+
+    report = _minimal_report()
+    path = runner_mod._auto_save_run(report, name='rt', datapoints=[DYNAMIC_INPUTS])
+
+    assert path is not None
+    stored = json.loads(path.read_text(encoding='utf-8'))
+    assert stored['datapoints'] == [DYNAMIC_INPUTS]
+
+    replay = load_redteam_replay('latest', runner_mod.get_runs_dir())
+    assert [dp.inputs for dp in replay.datapoints] == [DYNAMIC_INPUTS]
+
+
+def _minimal_report() -> Any:
+    from datetime import datetime, timezone
+
+    from evaluatorq.redteam.contracts import RedTeamReport, ReportSummary
+
+    return RedTeamReport(
+        created_at=datetime.now(tz=timezone.utc),
+        pipeline=Pipeline.DYNAMIC,
+        categories_tested=['ASI01'],
+        total_results=0,
+        results=[],
+        summary=ReportSummary(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_previous_run_rejects_data_selection_arguments(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from evaluatorq.redteam import red_team
+
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+
+    with pytest.raises(ValueError, match='cannot be combined with data-selection arguments: dataset, categories'):
+        await red_team(target='agent:demo', previous_run='latest', dataset='local.json', categories=['ASI01'])
+
+
+@pytest.mark.asyncio
+async def test_previous_run_reports_an_unresolvable_reference(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from evaluatorq.redteam import red_team
+
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+
+    with pytest.raises(ReplayError, match='Could not resolve previous red team run'):
+        await red_team(target='agent:demo', previous_run='nope')

--- a/tests/simulation/test_cli_from_run.py
+++ b/tests/simulation/test_cli_from_run.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -17,7 +18,16 @@ runner = CliRunner()
 
 
 def _output(result) -> str:
-    return result.output + (result.stderr or '')
+    """Combined stdout+stderr, unwrapped.
+
+    Typer renders usage errors through rich, which hard-wraps them into a box
+    at the terminal width — so a substring assertion passes on a wide dev
+    terminal and fails on a narrow CI one. Strip ANSI and the box borders, then
+    collapse whitespace, so assertions are about the message not the viewport.
+    """
+    raw = result.output + (result.stderr or '')
+    plain = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', raw)
+    return re.sub(r'\s+', ' ', re.sub(r'[│╭╮╰╯─╷╵]', ' ', plain))
 
 
 def test_from_run_is_forwarded_as_previous_run(monkeypatch) -> None:

--- a/tests/simulation/test_cli_from_run.py
+++ b/tests/simulation/test_cli_from_run.py
@@ -1,0 +1,75 @@
+"""CLI wiring for `eq sim simulate --from-run` (RES-1126)."""
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from evaluatorq.simulation.cli import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def _output(result) -> str:
+    return result.output + (result.stderr or '')
+
+
+def test_from_run_is_forwarded_as_previous_run(monkeypatch) -> None:
+    from evaluatorq.simulation.utils.run_store import build_simulation_run
+
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
+    run = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='orq_agent',
+        evaluator_names=[],
+        results=[],
+    )
+    with patch('evaluatorq.simulation.cli._simulate_impl', new=AsyncMock(return_value=run)) as impl:
+        result = runner.invoke(
+            app,
+            ['simulate', '--from-run', 'latest', '--target', 'agent:demo', '--no-save', '--yes'],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, _output(result)
+    assert impl.call_args.kwargs['previous_run'] == 'latest'
+
+
+def test_input_and_from_run_are_mutually_exclusive(tmp_path: Path) -> None:
+    dp = tmp_path / 'dp.jsonl'
+    dp.write_text('', encoding='utf-8')
+
+    result = runner.invoke(
+        app,
+        ['simulate', '--input', str(dp), '--from-run', 'latest', '--target', 'agent:demo', '--yes'],
+    )
+
+    assert result.exit_code != 0
+    assert 'exactly one of --input, --dataset-id, or --from-run' in _output(result)
+
+
+def test_no_input_source_is_rejected() -> None:
+    result = runner.invoke(app, ['simulate', '--target', 'agent:demo', '--yes'])
+
+    assert result.exit_code != 0
+    assert 'exactly one of --input, --dataset-id, or --from-run' in _output(result)
+
+
+def test_unresolvable_from_run_exits_cleanly(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv('EVALUATORQ_DIR', str(tmp_path / '.evaluatorq'))
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
+
+    result = runner.invoke(
+        app,
+        ['simulate', '--from-run', 'nope', '--target', 'agent:demo', '--no-save', '--yes'],
+    )
+
+    assert result.exit_code == 1
+    assert 'Could not resolve previous simulation run' in _output(result)

--- a/tests/simulation/test_replay.py
+++ b/tests/simulation/test_replay.py
@@ -16,6 +16,7 @@ from evaluatorq.simulation.types import (
     Persona,
     Scenario,
     SimulationDatapoint,
+    StartingEmotion,
 )
 from evaluatorq.simulation.utils.run_store import auto_save_run, build_simulation_run, get_sim_runs_dir
 
@@ -37,7 +38,7 @@ def _datapoint(name: str = 'dp-1') -> SimulationDatapoint:
         name='Refund chase',
         goal='Get the refund released today',
         context='Third contact about the same order.',
-        starting_emotion='frustrated',
+        starting_emotion=StartingEmotion.frustrated,
         criteria=[Criterion(description='Agent states a refund date', type='must_happen')],
     )
     return SimulationDatapoint(
@@ -64,8 +65,8 @@ def test_saved_run_carries_its_datapoints(tmp_path: Path) -> None:
     stored = json.loads(path.read_text(encoding='utf-8'))
     assert stored['datapoints'][0]['id'] == 'dp-1'
 
-    [replayed] = load_simulation_replay('latest', get_sim_runs_dir())
-    assert replayed == dp
+    replayed = load_simulation_replay('latest', get_sim_runs_dir())
+    assert replayed.datapoints == [dp]
 
 
 def test_replay_resolves_by_run_name(tmp_path: Path) -> None:
@@ -80,7 +81,7 @@ def test_replay_resolves_by_run_name(tmp_path: Path) -> None:
     auto_save_run(run=run, run_name='nightly')
 
     replayed = load_simulation_replay('nightly', get_sim_runs_dir())
-    assert [dp.id for dp in replayed] == ['dp-a', 'dp-b']
+    assert [dp.id for dp in replayed.datapoints] == ['dp-a', 'dp-b']
 
 
 def test_run_saved_without_datapoints_cannot_be_replayed(tmp_path: Path) -> None:
@@ -93,7 +94,7 @@ def test_run_saved_without_datapoints_cannot_be_replayed(tmp_path: Path) -> None
     )
     auto_save_run(run=run, run_name='legacy')
 
-    with pytest.raises(ReplayError, match='stores no datapoints'):
+    with pytest.raises(ReplayError, match='records no simulation datapoints'):
         load_simulation_replay('latest', get_sim_runs_dir())
 
 

--- a/tests/simulation/test_replay.py
+++ b/tests/simulation/test_replay.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -146,3 +147,102 @@ async def test_previous_run_is_mutually_exclusive(tmp_path: Path) -> None:
             model='openai/gpt-5.4-mini',
             generation_client=None,
         )
+
+
+def test_a_red_team_run_is_rejected_with_a_pointer_to_the_right_command(tmp_path: Path) -> None:
+    """Both surfaces store a top-level `datapoints`, so the discriminator is `pipeline`."""
+    runs = tmp_path / 'runs'
+    runs.mkdir(parents=True)
+    (runs / 'rt_20260101_000000.json').write_text(
+        json.dumps({
+            'run_name': 'rt',
+            'pipeline': 'dynamic',
+            # A red team run saved by this same version: non-empty datapoints, so
+            # the guard cannot be gated on the list being empty.
+            'datapoints': [{'id': 'a', 'category': 'ASI01', 'strategy': {'name': 's'}}],
+        }),
+        encoding='utf-8',
+    )
+
+    with pytest.raises(ReplayError, match='eq redteam run --from-run'):
+        load_simulation_replay('latest', runs)
+
+
+def test_max_turns_is_restored_from_the_replayed_run(tmp_path: Path) -> None:
+    run = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='callback',
+        evaluator_names=[],
+        results=[],
+        max_turns=7,
+        datapoints=[_datapoint()],
+    )
+    auto_save_run(run=run, run_name='sim')
+
+    assert load_simulation_replay('latest', get_sim_runs_dir()).max_turns == 7
+
+
+@pytest.fixture
+def pipeline_spans():
+    """Collect simulation spans in memory."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+    class _Collect(SpanExporter):
+        def __init__(self) -> None:
+            self.spans: list[object] = []
+
+        def export(self, spans):  # noqa: ANN001, ANN202
+            self.spans.extend(spans)
+            return SpanExportResult.SUCCESS
+
+    exporter = _Collect()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    with patch('evaluatorq.simulation.tracing.get_tracer', return_value=provider.get_tracer('test')):
+        yield exporter
+    provider.shutdown()
+
+
+def _pipeline_attrs(exporter) -> dict[str, object]:
+    for span in exporter.spans:
+        if span.name == 'orq.simulation.pipeline':
+            return dict(span.attributes or {})
+    raise AssertionError('no orq.simulation.pipeline span was recorded')
+
+
+@pytest.mark.asyncio
+async def test_pipeline_span_carries_the_default_turn_cap(pipeline_spans) -> None:
+    """max_turns is None until resolved, and set_span_attrs drops None — so the
+    attribute has to be stamped after resolution or it vanishes from traces."""
+    from evaluatorq.simulation.api import simulate
+
+    with (
+        patch('evaluatorq.simulation.api._resolve_or_generate_datapoints', new=AsyncMock(return_value=[])),
+        patch('evaluatorq.simulation.api._simulate_via_evaluatorq', new=AsyncMock(return_value=[])),
+    ):
+        await simulate(evaluation_name='x', target=lambda _m: 'hi', datapoints=[])
+
+    assert _pipeline_attrs(pipeline_spans)['orq.simulation.max_turns'] == 10
+
+
+@pytest.mark.asyncio
+async def test_pipeline_span_carries_a_replayed_turn_cap(tmp_path: Path, pipeline_spans) -> None:
+    from evaluatorq.simulation.api import simulate
+
+    run = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='callback',
+        evaluator_names=[],
+        results=[],
+        max_turns=7,
+        datapoints=[_datapoint()],
+    )
+    auto_save_run(run=run, run_name='sim')
+
+    with patch('evaluatorq.simulation.api._simulate_via_evaluatorq', new=AsyncMock(return_value=[])):
+        await simulate(evaluation_name='x', target=lambda _m: 'hi', previous_run='latest')
+
+    assert _pipeline_attrs(pipeline_spans)['orq.simulation.max_turns'] == 7

--- a/tests/simulation/test_replay.py
+++ b/tests/simulation/test_replay.py
@@ -1,0 +1,147 @@
+"""Replaying a prior simulation run (`previous_run=` / `--from-run`)."""
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from evaluatorq.common.replay import ReplayError
+from evaluatorq.simulation.replay import load_simulation_replay
+from evaluatorq.simulation.types import (
+    CommunicationStyle,
+    Criterion,
+    Persona,
+    Scenario,
+    SimulationDatapoint,
+)
+from evaluatorq.simulation.utils.run_store import auto_save_run, build_simulation_run, get_sim_runs_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _datapoint(name: str = 'dp-1') -> SimulationDatapoint:
+    persona = Persona(
+        name='Impatient Ien',
+        patience=2,
+        assertiveness=8,
+        politeness=4,
+        technical_level=6,
+        communication_style=CommunicationStyle.terse,
+        background='Long-time customer with a stalled refund.',
+    )
+    scenario = Scenario(
+        name='Refund chase',
+        goal='Get the refund released today',
+        context='Third contact about the same order.',
+        starting_emotion='frustrated',
+        criteria=[Criterion(description='Agent states a refund date', type='must_happen')],
+    )
+    return SimulationDatapoint(
+        id=name,
+        persona=persona,
+        scenario=scenario,
+        user_system_prompt='',
+        first_message='Where is my refund?',
+    )
+
+
+def test_saved_run_carries_its_datapoints(tmp_path: Path) -> None:
+    dp = _datapoint()
+    run = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='callback',
+        evaluator_names=[],
+        results=[],
+        datapoints=[dp],
+    )
+    path = auto_save_run(run=run, run_name='sim')
+
+    stored = json.loads(path.read_text(encoding='utf-8'))
+    assert stored['datapoints'][0]['id'] == 'dp-1'
+
+    [replayed] = load_simulation_replay('latest', get_sim_runs_dir())
+    assert replayed == dp
+
+
+def test_replay_resolves_by_run_name(tmp_path: Path) -> None:
+    run = build_simulation_run(
+        run_name='nightly',
+        mode='simulate',
+        target_kind='callback',
+        evaluator_names=[],
+        results=[],
+        datapoints=[_datapoint('dp-a'), _datapoint('dp-b')],
+    )
+    auto_save_run(run=run, run_name='nightly')
+
+    replayed = load_simulation_replay('nightly', get_sim_runs_dir())
+    assert [dp.id for dp in replayed] == ['dp-a', 'dp-b']
+
+
+def test_run_saved_without_datapoints_cannot_be_replayed(tmp_path: Path) -> None:
+    run = build_simulation_run(
+        run_name='legacy',
+        mode='simulate',
+        target_kind='callback',
+        evaluator_names=[],
+        results=[],
+    )
+    auto_save_run(run=run, run_name='legacy')
+
+    with pytest.raises(ReplayError, match='stores no datapoints'):
+        load_simulation_replay('latest', get_sim_runs_dir())
+
+
+def test_missing_run_is_reported_clearly(tmp_path: Path) -> None:
+    with pytest.raises(ReplayError, match='Could not resolve previous simulation run'):
+        load_simulation_replay('does-not-exist', get_sim_runs_dir())
+
+
+@pytest.mark.asyncio
+async def test_previous_run_short_circuits_other_sources(tmp_path: Path) -> None:
+    from evaluatorq.simulation.api import _resolve_or_generate_datapoints
+
+    dp = _datapoint()
+    run = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='callback',
+        evaluator_names=[],
+        results=[],
+        datapoints=[dp],
+    )
+    auto_save_run(run=run, run_name='sim')
+
+    resolved = await _resolve_or_generate_datapoints(
+        caller='simulate',
+        datapoints=None,
+        personas=None,
+        scenarios=None,
+        dataset_id=None,
+        previous_run='latest',
+        model='openai/gpt-5.4-mini',
+        generation_client=None,
+    )
+    assert resolved == [dp]
+
+
+@pytest.mark.asyncio
+async def test_previous_run_is_mutually_exclusive(tmp_path: Path) -> None:
+    from evaluatorq.simulation.api import _resolve_or_generate_datapoints
+
+    with pytest.raises(ValueError, match='Pass exactly one of previous_run'):
+        await _resolve_or_generate_datapoints(
+            caller='simulate',
+            datapoints=[_datapoint()],
+            personas=None,
+            scenarios=None,
+            dataset_id=None,
+            previous_run='latest',
+            model='openai/gpt-5.4-mini',
+            generation_client=None,
+        )

--- a/tests/simulation/test_replay.py
+++ b/tests/simulation/test_replay.py
@@ -246,3 +246,38 @@ async def test_pipeline_span_carries_a_replayed_turn_cap(tmp_path: Path, pipelin
         await simulate(evaluation_name='x', target=lambda _m: 'hi', previous_run='latest')
 
     assert _pipeline_attrs(pipeline_spans)['orq.simulation.max_turns'] == 7
+
+
+def test_a_saved_run_stamps_the_replay_format_version() -> None:
+    """The marker is only meaningful next to stored cases, so it rides with them."""
+    from evaluatorq.common.replay import REPLAY_VERSION
+    from evaluatorq.simulation.utils.run_store import build_simulation_run
+
+    with_cases = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='orq_agent',
+        evaluator_names=[],
+        results=[],
+        datapoints=[_datapoint()],
+    )
+    without_cases = build_simulation_run(
+        run_name='sim',
+        mode='simulate',
+        target_kind='orq_agent',
+        evaluator_names=[],
+        results=[],
+    )
+
+    assert with_cases.replay_version == REPLAY_VERSION
+    assert without_cases.replay_version is None
+
+
+def test_replay_error_is_importable_from_the_simulation_surface() -> None:
+    """SDK callers passing previous_run= need to catch it without reaching into
+    evaluatorq.common."""
+    import evaluatorq.simulation as sim
+    from evaluatorq.common.replay import ReplayError as internal
+
+    assert sim.ReplayError is internal
+    assert 'ReplayError' in sim.__all__

--- a/tests/unit/test_replay_resolver.py
+++ b/tests/unit/test_replay_resolver.py
@@ -119,3 +119,14 @@ def test_load_run_payload_rejects_malformed_json(tmp_path: Path) -> None:
 
     with pytest.raises(ReplayError, match='not valid JSON'):
         load_run_payload('broken', runs, surface='red team')
+
+
+def test_stale_manifest_does_not_mask_a_name_match(tmp_path: Path) -> None:
+    """A manifest pointing at a deleted report must not suppress the fallback."""
+    runs = tmp_path / 'runs'
+    gone = _write_run(runs, 'abcdefaa1111_gone')
+    start_manifest(run_id='abcdefaa1111', surface='redteam', run_name='gone', runs_dir=runs).complete(report_path=gone)
+    gone.unlink()
+    survivor = _write_run(runs, 'abcdefaa1111')
+
+    assert resolve_run_path('abcdefaa1111', runs, surface='red team') == survivor

--- a/tests/unit/test_replay_resolver.py
+++ b/tests/unit/test_replay_resolver.py
@@ -130,3 +130,14 @@ def test_stale_manifest_does_not_mask_a_name_match(tmp_path: Path) -> None:
     survivor = _write_run(runs, 'abcdefaa1111')
 
     assert resolve_run_path('abcdefaa1111', runs, surface='red team') == survivor
+
+
+def test_ambiguous_run_name_takes_the_newest_and_says_so(tmp_path: Path, caplog) -> None:
+    """Names repeat by design, so ambiguity resolves rather than raising — loudly."""
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'nightly_20260101_000000', mtime=1_000_000)
+    newest = _write_run(runs, 'nightly_20260202_000000', mtime=2_000_000)
+
+    with caplog.at_level('INFO'):
+        assert resolve_run_path('nightly', runs, surface='red team') == newest
+    assert any('matches 2 runs' in r.message for r in caplog.records)

--- a/tests/unit/test_replay_resolver.py
+++ b/tests/unit/test_replay_resolver.py
@@ -1,0 +1,121 @@
+"""Resolution of a "previous run" reference to a stored run file."""
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from evaluatorq.common.replay import ReplayError, load_run_payload, resolve_run_path
+from evaluatorq.common.run_manifest import start_manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_run(runs_dir: Path, name: str, *, payload: dict[str, object] | None = None, mtime: int | None = None) -> Path:
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    path = runs_dir / f'{name}.json'
+    path.write_text(json.dumps(payload if payload is not None else {'run_name': name}), encoding='utf-8')
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_latest_picks_the_newest_report(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'old_20260101_000000', mtime=1_000_000)
+    newest = _write_run(runs, 'new_20260102_000000', mtime=2_000_000)
+
+    assert resolve_run_path('latest', runs, surface='red team') == newest
+
+
+def test_latest_without_runs_is_a_clear_error(tmp_path: Path) -> None:
+    with pytest.raises(ReplayError, match='nothing to replay'):
+        resolve_run_path('latest', tmp_path / 'runs', surface='red team')
+
+
+def test_file_name_with_and_without_extension(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    path = _write_run(runs, 'rt_20260101_000000')
+
+    assert resolve_run_path('rt_20260101_000000.json', runs, surface='red team') == path
+    assert resolve_run_path('rt_20260101_000000', runs, surface='red team') == path
+
+
+def test_explicit_path_outside_the_runs_dir(tmp_path: Path) -> None:
+    elsewhere = _write_run(tmp_path / 'elsewhere', 'saved')
+
+    assert resolve_run_path(str(elsewhere), tmp_path / 'runs', surface='red team') == elsewhere
+
+
+def test_run_name_prefix_resolves_to_newest_matching_run(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'nightly_20260101_000000', mtime=1_000_000)
+    newest = _write_run(runs, 'nightly_20260202_000000', mtime=2_000_000)
+
+    assert resolve_run_path('nightly', runs, surface='red team') == newest
+
+
+def test_manifest_run_id_and_unambiguous_prefix(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    report = _write_run(runs, 'rt_20260101_000000')
+    writer = start_manifest(run_id='a1b2c3d4e5f6', surface='redteam', run_name='rt', runs_dir=runs)
+    writer.complete(report_path=report)
+
+    assert resolve_run_path('a1b2c3d4e5f6', runs, surface='red team') == report
+    assert resolve_run_path('a1b2c3d4', runs, surface='red team') == report
+
+
+def test_short_prefix_is_not_treated_as_a_run_id(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    report = _write_run(runs, 'rt_20260101_000000')
+    start_manifest(run_id='a1b2c3d4e5f6', surface='redteam', run_name='rt', runs_dir=runs).complete(report_path=report)
+
+    with pytest.raises(ReplayError, match='Could not resolve'):
+        resolve_run_path('a1b2', runs, surface='red team')
+
+
+def test_ambiguous_run_id_prefix_is_rejected(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    first = _write_run(runs, 'one_20260101_000000')
+    second = _write_run(runs, 'two_20260101_000000')
+    start_manifest(run_id='abcdefaa1111', surface='redteam', run_name='one', runs_dir=runs).complete(report_path=first)
+    start_manifest(run_id='abcdefbb2222', surface='redteam', run_name='two', runs_dir=runs).complete(report_path=second)
+
+    with pytest.raises(ReplayError, match='ambiguous'):
+        resolve_run_path('abcdef', runs, surface='red team')
+
+
+def test_unknown_reference_lists_recent_runs(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'rt_20260101_000000')
+
+    with pytest.raises(ReplayError, match='rt_20260101_000000.json'):
+        resolve_run_path('nope', runs, surface='red team')
+
+
+def test_empty_reference_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ReplayError, match='Empty previous'):
+        resolve_run_path('   ', tmp_path, surface='red team')
+
+
+def test_load_run_payload_returns_dict_and_path(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    path = _write_run(runs, 'rt_20260101_000000', payload={'run_name': 'rt', 'datapoints': []})
+
+    payload, resolved = load_run_payload('latest', runs, surface='red team')
+    assert resolved == path
+    assert payload['run_name'] == 'rt'
+
+
+def test_load_run_payload_rejects_malformed_json(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    runs.mkdir(parents=True)
+    (runs / 'broken.json').write_text('{not json', encoding='utf-8')
+
+    with pytest.raises(ReplayError, match='not valid JSON'):
+        load_run_payload('broken', runs, surface='red team')

--- a/tests/unit/test_replay_resolver.py
+++ b/tests/unit/test_replay_resolver.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from evaluatorq.common.replay import ReplayError, load_run_payload, resolve_run_path
+from evaluatorq.common.replay import REPLAY_VERSION, ReplayError, load_run_payload, resolve_run_path
 from evaluatorq.common.run_manifest import start_manifest
 
 if TYPE_CHECKING:
@@ -141,3 +141,32 @@ def test_ambiguous_run_name_takes_the_newest_and_says_so(tmp_path: Path, caplog)
     with caplog.at_level('INFO'):
         assert resolve_run_path('nightly', runs, surface='red team') == newest
     assert any('matches 2 runs' in r.message for r in caplog.records)
+
+
+def test_a_newer_replay_format_is_rejected_with_an_upgrade_hint(tmp_path: Path) -> None:
+    """The version marker exists so the *next* format change reports itself
+    instead of failing structurally somewhere downstream."""
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'future', payload={'run_name': 'future', 'replay_version': REPLAY_VERSION + 1})
+
+    with pytest.raises(ReplayError, match='newer version of evaluatorq'):
+        load_run_payload('future', runs, surface='red team')
+
+
+def test_the_current_replay_format_is_accepted(tmp_path: Path) -> None:
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'current', payload={'run_name': 'current', 'replay_version': REPLAY_VERSION})
+
+    payload, _ = load_run_payload('current', runs, surface='red team')
+
+    assert payload['run_name'] == 'current'
+
+
+def test_an_unversioned_run_is_read_as_the_original_format(tmp_path: Path) -> None:
+    """Runs saved before versioning carry no marker and are still replayable."""
+    runs = tmp_path / 'runs'
+    _write_run(runs, 'legacy', payload={'run_name': 'legacy'})
+
+    payload, _ = load_run_payload('legacy', runs, surface='red team')
+
+    assert 'replay_version' not in payload


### PR DESCRIPTION
Closes [RES-1126](https://linear.app/orqai/issue/RES-1126/support-previous-run-as-an-input-source-for-sim-red-teaming-replay).

## What

A first-class "replay this run" input on both surfaces. Passing it short-circuits every other data path — no dataset load, no persona or strategy generation, no attack generation. The stored cases run again against whatever target and evaluators the new invocation names, so version-to-version regression on an identical case bank is one command.

```bash
eq redteam run --target agent:my-agent-v2 --from-run latest
eq sim simulate --from-run latest --target agent:my-agent-v2
```

```python
await red_team(target='agent:my-agent-v2', previous_run='latest')
await simulate(target='agent:my-agent-v2', previous_run='latest')
```

Run references accept what the runs listings already print: `latest`, a run file name, a run name, a run id (or an unambiguous 8+ character prefix), or a path to a saved run JSON.

## How

Replay needs the cases, and neither surface stored them on the default path: red team only wrote datapoints under `save='detail'`, and sim results keep persona/scenario *names*, not the objects. So the saved records now carry what they ran.

- `common/replay.py` — shared reference resolver (`latest` → path → runs-dir name → manifest run id → run-name prefix), with an error that names the runs dir and lists recent runs.
- `redteam/replay.py` — rebuilds `DataPoint`s from a saved run and restores its pipeline mode; `_auto_save_run` now persists the executed datapoint inputs next to the report (not on the report model, so nothing changes for uploads).
- `simulation/replay.py` — `SimulationRun.datapoints` is populated on save and read back on replay.
- Both runners take the replayed set as pre-built datapoints for *every* target, skipping capability classification, planning, estimation, and the dataset load.

`previous_run` is mutually exclusive with the data-selection arguments it would otherwise silently override, and raises naming the conflicts. Runs saved before this carry no datapoints and are rejected with an explanatory error rather than a partial replay.

Also fixes a latent double-count in hybrid runs that mix string targets with `AgentTarget` objects, where the static leg was appended twice.

## Testing

`uv run pytest -m 'not integration'` — 3272 passed (38 new). `ruff check`, `ruff format --check`, and `basedpyright` clean on `src`; `mkdocs build --strict` and the mermaid validator pass.

New coverage: reference resolution (incl. ambiguous prefixes and unreadable files), replay rebuilding for both surfaces, legacy runs without datapoints, mutual-exclusion errors, CLI wiring for both flags, and an e2e pair asserting a replay re-runs the same attack ids against a new target while making zero generation or classification calls.

Data-source matrices in both surface READMEs move "previous runs" from ⚠️ manual to ✅ built-in, with a replay section each.
