### PR TITLE
refactor(redteam): registry-backed delivery methods, pass objects through as-is (RES-966)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ src/evaluatorq/
 └── redteam/                 # Red teaming subpackage
     ├── contracts.py         # Red-team-specific data models, enums, Pydantic schemas (shared cross-subpackage models live in top-level contracts.py)
     ├── vulnerability_registry.py  # Single source of truth for vulnerabilities
+    ├── delivery_method_registry.py # Canonical + custom delivery methods (register/resolve/is_known)
     ├── runner.py            # Unified red_team() entry point
     ├── cli.py               # Typer CLI for red teaming
     ├── hooks.py             # Pipeline lifecycle hooks (DefaultHooks, RichHooks)

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -230,6 +230,31 @@ Strategies can declare capability requirements to skip attacks that don't apply 
 
 Available capability tags: `code_execution`, `shell_access`, `file_system`, `web_request`, `database`, `email`, `messaging`, `memory_read`, `memory_write`, `knowledge_retrieval`, `user_data`.
 
+### Custom delivery methods
+
+`delivery_method` is an **open set**. The canonical methods live in the `DeliveryMethod`
+enum (each mapped to a technique family in `DELIVERY_METHOD_CATEGORY`), and
+`delivery_method_registry.py` mirrors the vulnerability registry so you can add your own
+without touching the enum:
+
+```python
+from evaluatorq.redteam.delivery_method_registry import (
+    register_delivery_method,
+    is_known_delivery_method,
+)
+
+# Register a custom method so it validates and filters as known.
+register_delivery_method('emoji-smuggling', category='obfuscation')
+
+is_known_delivery_method('emoji-smuggling')  # True
+```
+
+Unlike vulnerabilities (reject-unknown, since an unknown vuln has no strategies or
+evaluator), delivery methods are **coerce-known + passthrough-unknown**: an unregistered
+value is a harmless filter label that either matches a dataset row spelled the same or
+does not. Registering is only needed when you want `is_known_delivery_method` /
+`--delivery-method` to treat your value as canonical rather than passthrough.
+
 ## Adding a new framework
 
 Frameworks are a reporting/compliance layer on top of vulnerabilities. Adding a framework means:

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -253,8 +253,10 @@ Unlike vulnerabilities (reject-unknown, since an unknown vuln has no strategies 
 evaluator), delivery methods are **coerce-known + passthrough-unknown**: an unregistered
 value is a harmless filter label that either matches a dataset row spelled the same or
 does not. Filtering therefore works without registering anything — registering only
-suppresses the "unknown delivery method" warning that `--delivery-method` and the
-`RedTeamInput` boundary emit. A registered value stays a plain string; only enum members
+suppresses the "unknown delivery method" warnings: the `--delivery-method` CLI flag warns up
+front via `typer.echo`, and a programmatic `red_team()` run surfaces an unmatched method through
+the pipeline's post-filter check as a `loguru` warning (the `RedTeamInput` validator itself resolves
+silently). A registered value stays a plain string; only enum members
 resolve to a `DeliveryMethod` object.
 
 The registry is **in-memory and process-local** — it is not persisted and there is no

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -243,7 +243,7 @@ from evaluatorq.redteam.delivery_method_registry import (
     is_known_delivery_method,
 )
 
-# Register a custom method so it validates and filters as known.
+# Register a custom method so it validates as known.
 register_delivery_method('emoji-smuggling', category='obfuscation')
 
 is_known_delivery_method('emoji-smuggling')  # True
@@ -252,8 +252,16 @@ is_known_delivery_method('emoji-smuggling')  # True
 Unlike vulnerabilities (reject-unknown, since an unknown vuln has no strategies or
 evaluator), delivery methods are **coerce-known + passthrough-unknown**: an unregistered
 value is a harmless filter label that either matches a dataset row spelled the same or
-does not. Registering is only needed when you want `is_known_delivery_method` /
-`--delivery-method` to treat your value as canonical rather than passthrough.
+does not. Filtering therefore works without registering anything — registering only
+suppresses the "unknown delivery method" warning that `--delivery-method` and the
+`RedTeamInput` boundary emit. A registered value stays a plain string; only enum members
+resolve to a `DeliveryMethod` object.
+
+The registry is **in-memory and process-local** — it is not persisted and there is no
+plugin/entry-point loading. Registering in a standalone script does not make the value
+known to a separate `eq redteam run` process; to get the CLI benefit, register in the
+same process that invokes the CLI (or accept the warning, since filtering works either
+way).
 
 ## Adding a new framework
 

--- a/src/evaluatorq/dashboard/filters.py
+++ b/src/evaluatorq/dashboard/filters.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str
 from evaluatorq.simulation.metrics import TURN_METRICS
 
 if TYPE_CHECKING:
@@ -84,7 +85,7 @@ def _rt_options_from_results(results: list[Any]) -> dict[str, list[str]]:
     all_categories = sorted({r.attack.category for r in results})
     all_severities = [s for s in SEVERITY_ORDER if any(r.attack.severity.value == s for r in results)]
     all_techniques = sorted({r.attack.attack_technique.value for r in results})
-    all_delivery = sorted({getattr(dm, 'value', dm) for r in results for dm in (r.attack.delivery_methods or [])})
+    all_delivery = sorted({delivery_method_str(dm) for r in results for dm in (r.attack.delivery_methods or [])})
     all_vulnerabilities = sorted({r.attack.vulnerability for r in results if r.attack.vulnerability})
     all_agents = sorted({r.agent.key or r.agent.display_name or 'unknown' for r in results})
 
@@ -157,7 +158,7 @@ def _rt_apply(report: Any, selections: dict[str, list[str]]) -> list[Any]:
             results = [
                 r
                 for r in results
-                if any(getattr(dm, 'value', dm) in sel_delivery for dm in (r.attack.delivery_methods or []))
+                if any(delivery_method_str(dm) in sel_delivery for dm in (r.attack.delivery_methods or []))
             ]
 
     # vulnerability (multiselect) — only when options exist

--- a/src/evaluatorq/dashboard/redteam_charts.py
+++ b/src/evaluatorq/dashboard/redteam_charts.py
@@ -33,6 +33,7 @@ from evaluatorq.common.reports import (
 )
 from evaluatorq.common.reports.vega import vl_bar_h, vl_heatmap, vl_stacked_bar
 from evaluatorq.redteam.contracts import OWASP_CATEGORY_NAMES, RedTeamReport, RedTeamResult
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str
 from evaluatorq.redteam.reports.converters import _is_evaluated, _is_vulnerable
 
 # ---------------------------------------------------------------------------
@@ -94,7 +95,7 @@ def _dim_value(r: RedTeamResult, dim: str) -> str:
     if dim == 'delivery_method':
         if r.attack.delivery_methods:
             dm = r.attack.delivery_methods[0]
-            return getattr(dm, 'value', str(dm))
+            return delivery_method_str(dm)
         return 'unknown'
     if dim == 'turn_type':
         return r.attack.turn_type.value if r.attack.turn_type else 'unknown'

--- a/src/evaluatorq/dashboard/redteam_transcripts.py
+++ b/src/evaluatorq/dashboard/redteam_transcripts.py
@@ -25,6 +25,7 @@ from evaluatorq.dashboard.redteam_charts import (
 from evaluatorq.dashboard.report_kit import tag
 from evaluatorq.dashboard.trace_links import single_trace_url, thread_trace_url, trace_link_button
 from evaluatorq.dashboard.view import render_message_list
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str
 from evaluatorq.redteam.reports.converters import _is_evaluated, _is_vulnerable
 
 if TYPE_CHECKING:
@@ -53,7 +54,7 @@ def render_attack_fragment(r: RedTeamResult) -> str:
     """
     atk = r.attack
 
-    tags: list[str] = [tag(getattr(dm, 'value', str(dm))) for dm in atk.delivery_methods or []]
+    tags: list[str] = [tag(delivery_method_str(dm)) for dm in atk.delivery_methods or []]
     if atk.turn_type:
         tags.append(tag(f'{atk.turn_type.value}-turn'))
     if atk.category:

--- a/src/evaluatorq/redteam/cli.py
+++ b/src/evaluatorq/redteam/cli.py
@@ -418,6 +418,7 @@ def run(
     resolved_delivery_methods: list[DeliveryMethod | str] | None = None
     if delivery_tokens:
         from evaluatorq.redteam.delivery_method_registry import (
+            delivery_method_str,
             is_known_delivery_method,
             list_available_delivery_methods,
             resolve_delivery_methods,
@@ -425,7 +426,9 @@ def run(
 
         unknown = [d for d in delivery_tokens if not is_known_delivery_method(d)]
         if unknown:
-            known_repr = sorted(str(m) for m in list_available_delivery_methods())
+            # delivery_method_str, not str(): a member's str() is its repr on the
+            # 3.10 StrEnum polyfill, which would print unusable 'DeliveryMethod.X'.
+            known_repr = sorted(delivery_method_str(m) for m in list_available_delivery_methods())
             typer.echo(
                 f'Warning: delivery method(s) {unknown} are not known delivery methods {known_repr}; '
                 'filtering by them literally (they will only match a dataset row spelled exactly the same).',

--- a/src/evaluatorq/redteam/cli.py
+++ b/src/evaluatorq/redteam/cli.py
@@ -410,21 +410,28 @@ def run(
                 f"Valid names: {sorted(known)} (or a 'generated_*' name from a prior run)."
             )
 
-    # Convert known delivery methods to the enum (parsed as plain strings to
-    # support comma-separated input, which typer's enum binding cannot do).
-    # Unknown values are an open set — kept as raw strings (so a dataset's custom
+    # Resolve delivery methods against the registry (enum plus registered), parsed
+    # as plain strings to support comma-separated input which typer's enum
+    # binding cannot do. Known values coerce to the DeliveryMethod object;
+    # unknown ones are an open set — kept as raw strings (so a dataset's custom
     # delivery method is still filterable) with a warning, not a hard error.
     resolved_delivery_methods: list[DeliveryMethod | str] | None = None
     if delivery_tokens:
-        valid = {m.value for m in DeliveryMethod}
-        unknown = [d for d in delivery_tokens if d not in valid]
+        from evaluatorq.redteam.delivery_method_registry import (
+            is_known_delivery_method,
+            list_available_delivery_methods,
+            resolve_delivery_methods,
+        )
+
+        unknown = [d for d in delivery_tokens if not is_known_delivery_method(d)]
         if unknown:
+            known_repr = sorted(str(m) for m in list_available_delivery_methods())
             typer.echo(
-                f'Warning: delivery method(s) {unknown} are not in DeliveryMethod {sorted(valid)}; '
+                f'Warning: delivery method(s) {unknown} are not known delivery methods {known_repr}; '
                 'filtering by them literally (they will only match a dataset row spelled exactly the same).',
                 err=True,
             )
-        resolved_delivery_methods = [DeliveryMethod(d) if d in valid else d for d in delivery_tokens]
+        resolved_delivery_methods = resolve_delivery_methods(list(delivery_tokens))
 
     target_config = TargetConfig(system_prompt=system_prompt) if system_prompt else None
     targets: list[str] | str = target if len(target) > 1 else target[0]

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -122,8 +122,15 @@ class DeliveryMethod(StrEnum):
 
 
 def is_known_delivery_method(value: str) -> bool:
-    """Check whether *value* is a known :class:`DeliveryMethod` member."""
-    return value in DeliveryMethod.__members__.values()
+    """Check whether *value* is a known delivery method (enum plus registered).
+
+    Delegates to the delivery-method registry so registered custom methods count
+    as known. Lazy import: the registry imports :class:`DeliveryMethod` from this
+    module, so importing it at module top level would be a cycle.
+    """
+    from evaluatorq.redteam.delivery_method_registry import is_known_delivery_method as _is_known
+
+    return _is_known(value)
 
 
 class Severity(StrEnum):
@@ -473,17 +480,20 @@ class RedTeamInput(BaseModel):
     @field_validator('delivery_method', mode='before')
     @classmethod
     def _coerce_delivery_method(cls, value: Any) -> Any:
-        """Coerce a known delivery method to the DeliveryMethod enum (exact match).
+        """Normalize the delivery method once, at the contract boundary.
 
-        Unknown or empty values pass through as a raw string — the field is an
-        open set, so a dataset may carry a delivery method the enum doesn't list.
-        No fuzzy normalization: a value either equals a DeliveryMethod or it does not.
+        Routes through the delivery-method registry: a known value (enum member
+        or a registered custom) resolves to its canonical ``DeliveryMethod``
+        object; unknown or empty values pass through as a raw string — the field
+        is an open set, so a dataset may carry a delivery method the enum doesn't
+        list. No fuzzy normalization: a value equals a known method or it does not.
+
+        Lazy import to avoid a cycle (the registry imports from this module).
         """
         if isinstance(value, str) and value:
-            try:
-                return DeliveryMethod(value)
-            except ValueError:
-                return value
+            from evaluatorq.redteam.delivery_method_registry import resolve_delivery_method
+
+            return resolve_delivery_method(value)
         return value
 
     @model_validator(mode='after')

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -482,11 +482,12 @@ class RedTeamInput(BaseModel):
     def _coerce_delivery_method(cls, value: Any) -> Any:
         """Normalize the delivery method once, at the contract boundary.
 
-        Routes through the delivery-method registry: a known value (enum member
-        or a registered custom) resolves to its canonical ``DeliveryMethod``
-        object; unknown or empty values pass through as a raw string — the field
-        is an open set, so a dataset may carry a delivery method the enum doesn't
-        list. No fuzzy normalization: a value equals a known method or it does not.
+        Routes through the delivery-method registry: an enum member resolves to
+        its canonical ``DeliveryMethod`` object. Everything else — including a
+        registered custom, which is *known* but has no member to resolve to —
+        passes through as a raw string; the field is an open set, so a dataset
+        may carry a delivery method the enum doesn't list. No fuzzy
+        normalization: a value equals a known method or it does not.
 
         Lazy import to avoid a cycle (the registry imports from this module).
         """

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 import types
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from evaluatorq.redteam.contracts import DeliveryMethod
 
 if TYPE_CHECKING:
@@ -77,8 +79,10 @@ def delivery_method_str(value: DeliveryMethod | str) -> str:
 # The one piece of real structure delivery methods carry; kept so ``register``
 # has somewhere to place a custom method and the registry mirrors the
 # vulnerability registry's structured defs rather than being a bare set.
-# Category is the only metadata a consumer needs today; add richer per-method
-# defs here if one ever does.
+# The category value itself has no runtime consumer today (the import-time
+# completeness check below inspects keys only) — it is structural/placeholder
+# metadata kept so the shape matches the vulnerability registry and a future
+# consumer has somewhere to read from. Add richer per-method defs here if one does.
 DELIVERY_METHOD_CATEGORY: Mapping[DeliveryMethod, str] = {
     DeliveryMethod.DAN: 'persona',
     DeliveryMethod.ROLE_PLAY: 'persona',
@@ -122,12 +126,12 @@ def register_delivery_method(value: str, *, category: str = 'custom') -> str:
     CLI's unknown-method warning; filtering already worked without it.
 
     A value equal to an existing :class:`DeliveryMethod` member is a no-op (the
-    enum is already canonical); a member *name* that is not also a value is
-    rejected, since registering ``'ROLE_PLAY'`` would shadow ``'role-play'``
-    with a spelling no dataset row carries. Registration is process-local and
-    not persisted, so it must happen in the same process that later runs the
-    CLI. Returns the registered value, or raises ``ValueError`` on an empty
-    value or a member name.
+    enum is already canonical) — it warns and discards the passed ``category``
+    rather than storing it. A member *name* that is not also a value is rejected,
+    since registering ``'ROLE_PLAY'`` would shadow ``'role-play'`` with a spelling
+    no dataset row carries. Registration is process-local and not persisted, so it
+    must happen in the same process that later runs the CLI. Returns the registered
+    value, or raises ``ValueError`` on an empty value or a member name.
     """
     if not value:
         msg = 'Cannot register an empty delivery method.'
@@ -140,7 +144,13 @@ def register_delivery_method(value: str, *, category: str = 'custom') -> str:
     except ValueError:
         pass
     else:
-        return value  # already canonical — no-op
+        # Already canonical: no-op. Warn (not silent) and drop the category —
+        # there is no custom entry to attach it to.
+        logger.warning(
+            f'{value!r} is already a canonical delivery method; register_delivery_method is a no-op '
+            f'(category {category!r} discarded).'
+        )
+        return value
     member_by_name = DeliveryMethod.__members__.get(value)
     if member_by_name is not None:
         msg = (

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -25,6 +25,12 @@ mode, each chosen for its own contract.
 
 No fuzzy normalization: a value equals a known method exactly, or it is unknown
 (RES-295 non-goal, unchanged).
+
+Registry lifecycle: registrations are **process-global and idempotent** — a
+custom method registered by one call is known to every later call in the same
+process, by design (that is what a registry is for). It is never persisted to
+disk, so a fresh process starts with only the enum. Tests that register a custom
+method should reset ``_CUSTOM_DELIVERY_METHODS`` between cases to stay isolated.
 """
 
 from __future__ import annotations
@@ -33,12 +39,25 @@ from evaluatorq.redteam.contracts import DeliveryMethod
 
 __all__ = [
     'DELIVERY_METHOD_CATEGORY',
+    'delivery_method_str',
     'is_known_delivery_method',
     'list_available_delivery_methods',
     'register_delivery_method',
     'resolve_delivery_method',
     'resolve_delivery_methods',
 ]
+
+
+def delivery_method_str(value: DeliveryMethod | str) -> str:
+    """Canonical string for a delivery method — the value, version-independently.
+
+    ``str(DeliveryMethod.DAN)`` returns ``'DAN'`` on native 3.11+ ``StrEnum`` but
+    the ``'DeliveryMethod.DAN'`` repr on the 3.10 ``StrEnum`` polyfill (which has
+    no ``__str__`` override). So never call ``str()`` on a member for display or
+    string-keying — use this. Filtering is unaffected (a member compares/hashes
+    equal to its value on every version); only string rendering diverges.
+    """
+    return value.value if isinstance(value, DeliveryMethod) else value
 
 
 # Technique family for each canonical method (the groupings the enum documents).
@@ -121,7 +140,7 @@ def resolve_delivery_methods(values: list[DeliveryMethod | str]) -> list[Deliver
     result: list[DeliveryMethod | str] = []
     for value in values:
         resolved = resolve_delivery_method(value)
-        key = str(resolved)
+        key = delivery_method_str(resolved)
         if key not in seen:
             seen.add(key)
             result.append(resolved)

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -7,11 +7,13 @@ and API validate against **registry plus enum** rather than a frozen enum.
 
 Strictness policy (RES-966 decision)
 ------------------------------------
-Delivery methods are **coerce-known + passthrough-unknown**: a value that is a
-known method (enum member or a registered custom) resolves to its canonical
-:class:`DeliveryMethod` object; anything else passes through as a raw string.
-This preserves the open set RES-295 deliberately chose (a dataset may carry a
-delivery method the enum does not list), now extensible via
+Delivery methods are **coerce-known + passthrough-unknown**: an enum member
+resolves to its canonical :class:`DeliveryMethod` object; anything else passes
+through as a raw string. A *registered custom* is known (it validates without a
+warning) but stays a string — there is no enum member for it to resolve to, so
+registration's observable effect is :func:`is_known_delivery_method` returning
+``True``. This preserves the open set RES-295 deliberately chose (a dataset may
+carry a delivery method the enum does not list), now extensible via
 :func:`register_delivery_method`.
 
 This differs on purpose from :func:`vulnerability_registry.resolve_vulnerabilities`,
@@ -26,16 +28,24 @@ mode, each chosen for its own contract.
 No fuzzy normalization: a value equals a known method exactly, or it is unknown
 (RES-295 non-goal, unchanged).
 
-Registry lifecycle: registrations are **process-global and idempotent** — a
-custom method registered by one call is known to every later call in the same
-process, by design (that is what a registry is for). It is never persisted to
-disk, so a fresh process starts with only the enum. Tests that register a custom
+Registry lifecycle: registrations are **process-global** — a custom method
+registered by one call is known to every later call in the same process, by
+design (that is what a registry is for). Re-registering the same value is
+last-write-wins on its category. Registrations are never persisted to disk, so a
+fresh process starts with only the enum: a value registered in one script is
+*not* known to a separate ``eq redteam`` invocation. Tests that register a custom
 method should reset ``_CUSTOM_DELIVERY_METHODS`` between cases to stay isolated.
 """
 
 from __future__ import annotations
 
+import types
+from typing import TYPE_CHECKING
+
 from evaluatorq.redteam.contracts import DeliveryMethod
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     'DELIVERY_METHOD_CATEGORY',
@@ -66,7 +76,7 @@ def delivery_method_str(value: DeliveryMethod | str) -> str:
 # vulnerability registry's structured defs rather than being a bare set.
 # Category is the only metadata a consumer needs today; add richer per-method
 # defs here if one ever does.
-DELIVERY_METHOD_CATEGORY: dict[DeliveryMethod, str] = {
+DELIVERY_METHOD_CATEGORY: Mapping[DeliveryMethod, str] = {
     DeliveryMethod.DAN: 'persona',
     DeliveryMethod.ROLE_PLAY: 'persona',
     DeliveryMethod.SKELETON_KEY: 'persona',
@@ -85,6 +95,15 @@ DELIVERY_METHOD_CATEGORY: dict[DeliveryMethod, str] = {
     DeliveryMethod.WORD_SUBSTITUTION: 'tool-agent',
 }
 
+# Fail at import, not in CI: a new enum member without a technique family would
+# otherwise ship silently. Frozen afterwards so no caller can mutate the
+# canonical set at runtime (mirrors vulnerability_registry.py).
+_missing = sorted(delivery_method_str(m) for m in set(DeliveryMethod) - set(DELIVERY_METHOD_CATEGORY))
+if _missing:
+    raise RuntimeError(f'Missing DELIVERY_METHOD_CATEGORY entries for: {_missing}')
+
+DELIVERY_METHOD_CATEGORY = types.MappingProxyType(dict(DELIVERY_METHOD_CATEGORY))  # pyright: ignore[reportConstantRedefinition]
+
 # Registered custom methods: value -> category. Seeded empty; the enum members
 # are always known without being listed here. ``register_delivery_method``
 # appends to this so ``is_known``/``resolve`` see the addition immediately.
@@ -92,10 +111,17 @@ _CUSTOM_DELIVERY_METHODS: dict[str, str] = {}
 
 
 def register_delivery_method(value: str, *, category: str = 'custom') -> str:
-    """Register a custom delivery method so it validates and resolves as known.
+    """Register a custom delivery method so it validates as known.
+
+    A registered value stays a plain string — there is no enum member for
+    :func:`resolve_delivery_method` to coerce it to. What registration buys is
+    :func:`is_known_delivery_method` returning ``True``, which suppresses the
+    CLI's unknown-method warning; filtering already worked without it.
 
     A value equal to an existing :class:`DeliveryMethod` member is a no-op (the
-    enum is already canonical). Returns the registered value.
+    enum is already canonical). Registration is process-local and not persisted,
+    so it must happen in the same process that later runs the CLI. Returns the
+    registered value.
     """
     if not value:
         msg = 'Cannot register an empty delivery method.'
@@ -119,8 +145,9 @@ def is_known_delivery_method(value: str) -> bool:
 
 
 def resolve_delivery_method(value: DeliveryMethod | str) -> DeliveryMethod | str:
-    """Resolve one value: a known method becomes its :class:`DeliveryMethod`
-    object, an unknown one passes through unchanged (open set).
+    """Resolve one value: an enum member (by value) becomes its
+    :class:`DeliveryMethod` object, anything else passes through unchanged (open
+    set) — including a registered custom, which is *known* but has no member.
 
     Already a :class:`DeliveryMethod`? Returned as-is — this is the identity that
     lets registry-backed objects flow through the pipeline without conversion.

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -64,8 +64,8 @@ def delivery_method_str(value: DeliveryMethod | str) -> str:
 # The one piece of real structure delivery methods carry; kept so ``register``
 # has somewhere to place a custom method and the registry mirrors the
 # vulnerability registry's structured defs rather than being a bare set.
-# ponytail: category is the only metadata a consumer needs today; add richer
-# per-method defs here if one ever does.
+# Category is the only metadata a consumer needs today; add richer per-method
+# defs here if one ever does.
 DELIVERY_METHOD_CATEGORY: dict[DeliveryMethod, str] = {
     DeliveryMethod.DAN: 'persona',
     DeliveryMethod.ROLE_PLAY: 'persona',

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -33,8 +33,10 @@ registered by one call is known to every later call in the same process, by
 design (that is what a registry is for). Re-registering the same value is
 last-write-wins on its category. Registrations are never persisted to disk, so a
 fresh process starts with only the enum: a value registered in one script is
-*not* known to a separate ``eq redteam`` invocation. Tests that register a custom
-method should reset ``_CUSTOM_DELIVERY_METHODS`` between cases to stay isolated.
+*not* known to a separate ``eq redteam`` invocation. Because the set is global,
+tests that register a custom method must call
+:func:`clear_custom_delivery_methods` between cases to stay isolated — the
+``tests/redteam`` conftest does this automatically.
 """
 
 from __future__ import annotations
@@ -49,6 +51,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     'DELIVERY_METHOD_CATEGORY',
+    'clear_custom_delivery_methods',
     'delivery_method_str',
     'is_known_delivery_method',
     'list_available_delivery_methods',
@@ -119,12 +122,20 @@ def register_delivery_method(value: str, *, category: str = 'custom') -> str:
     CLI's unknown-method warning; filtering already worked without it.
 
     A value equal to an existing :class:`DeliveryMethod` member is a no-op (the
-    enum is already canonical). Registration is process-local and not persisted,
-    so it must happen in the same process that later runs the CLI. Returns the
-    registered value.
+    enum is already canonical); a member *name* is rejected, since registering
+    ``'ROLE_PLAY'`` would shadow ``'role-play'`` with a spelling no dataset row
+    carries. Registration is process-local and not persisted, so it must happen
+    in the same process that later runs the CLI. Returns the registered value.
     """
     if not value:
         msg = 'Cannot register an empty delivery method.'
+        raise ValueError(msg)
+    member_by_name = DeliveryMethod.__members__.get(value)
+    if member_by_name is not None:
+        msg = (
+            f'{value!r} is the name of an existing DeliveryMethod, not a delivery-method value. '
+            f'Use {delivery_method_str(member_by_name)!r} (already known — no registration needed).'
+        )
         raise ValueError(msg)
     try:
         DeliveryMethod(value)
@@ -172,6 +183,16 @@ def resolve_delivery_methods(values: list[DeliveryMethod | str]) -> list[Deliver
             seen.add(key)
             result.append(resolved)
     return result
+
+
+def clear_custom_delivery_methods() -> None:
+    """Drop every registered custom method, leaving only the enum.
+
+    Public because the registry is process-global: test suites (and anything
+    else that registers) need a supported way to restore the baseline instead of
+    reaching into module internals.
+    """
+    _CUSTOM_DELIVERY_METHODS.clear()
 
 
 def list_available_delivery_methods() -> list[DeliveryMethod | str]:

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -1,0 +1,133 @@
+"""Delivery-method registry — the single source of truth for delivery methods.
+
+Mirrors :mod:`evaluatorq.redteam.vulnerability_registry`: a canonical set (the
+:class:`DeliveryMethod` enum, grouped by technique family) plus a mutable
+registry for custom entries, with ``register``/``resolve`` helpers so the CLI
+and API validate against **registry plus enum** rather than a frozen enum.
+
+Strictness policy (RES-966 decision)
+------------------------------------
+Delivery methods are **coerce-known + passthrough-unknown**: a value that is a
+known method (enum member or a registered custom) resolves to its canonical
+:class:`DeliveryMethod` object; anything else passes through as a raw string.
+This preserves the open set RES-295 deliberately chose (a dataset may carry a
+delivery method the enum does not list), now extensible via
+:func:`register_delivery_method`.
+
+This differs on purpose from :func:`vulnerability_registry.resolve_vulnerabilities`,
+which **rejects** unknown values. The *pattern* is the same (enum plus registered,
+resolve/register); the *strictness* differs because the semantics do. An unknown
+delivery method is a harmless filter/label — it either matches a dataset row
+spelled the same or it does not. An unknown vulnerability has no strategies and
+no evaluator, so passing it through would silently produce an unscoreable run;
+rejecting it is the safe boundary there. Same registry shape, different failure
+mode, each chosen for its own contract.
+
+No fuzzy normalization: a value equals a known method exactly, or it is unknown
+(RES-295 non-goal, unchanged).
+"""
+
+from __future__ import annotations
+
+from evaluatorq.redteam.contracts import DeliveryMethod
+
+__all__ = [
+    'DELIVERY_METHOD_CATEGORY',
+    'is_known_delivery_method',
+    'list_available_delivery_methods',
+    'register_delivery_method',
+    'resolve_delivery_method',
+    'resolve_delivery_methods',
+]
+
+
+# Technique family for each canonical method (the groupings the enum documents).
+# The one piece of real structure delivery methods carry; kept so ``register``
+# has somewhere to place a custom method and the registry mirrors the
+# vulnerability registry's structured defs rather than being a bare set.
+# ponytail: category is the only metadata a consumer needs today; add richer
+# per-method defs here if one ever does.
+DELIVERY_METHOD_CATEGORY: dict[DeliveryMethod, str] = {
+    DeliveryMethod.DAN: 'persona',
+    DeliveryMethod.ROLE_PLAY: 'persona',
+    DeliveryMethod.SKELETON_KEY: 'persona',
+    DeliveryMethod.BASE64: 'obfuscation',
+    DeliveryMethod.LEETSPEAK: 'obfuscation',
+    DeliveryMethod.MULTILINGUAL: 'obfuscation',
+    DeliveryMethod.CHARACTER_SPACING: 'obfuscation',
+    DeliveryMethod.CRESCENDO: 'multi-turn',
+    DeliveryMethod.MANY_SHOT: 'multi-turn',
+    DeliveryMethod.AUTHORITY_IMPERSONATION: 'social-engineering',
+    DeliveryMethod.REFUSAL_SUPPRESSION: 'social-engineering',
+    DeliveryMethod.DIRECT_REQUEST: 'direct',
+    DeliveryMethod.CODE_ELICITATION: 'direct',
+    DeliveryMethod.CODE_ASSISTANCE: 'direct',
+    DeliveryMethod.TOOL_RESPONSE: 'tool-agent',
+    DeliveryMethod.WORD_SUBSTITUTION: 'tool-agent',
+}
+
+# Registered custom methods: value -> category. Seeded empty; the enum members
+# are always known without being listed here. ``register_delivery_method``
+# appends to this so ``is_known``/``resolve`` see the addition immediately.
+_CUSTOM_DELIVERY_METHODS: dict[str, str] = {}
+
+
+def register_delivery_method(value: str, *, category: str = 'custom') -> str:
+    """Register a custom delivery method so it validates and resolves as known.
+
+    A value equal to an existing :class:`DeliveryMethod` member is a no-op (the
+    enum is already canonical). Returns the registered value.
+    """
+    if not value:
+        msg = 'Cannot register an empty delivery method.'
+        raise ValueError(msg)
+    try:
+        DeliveryMethod(value)
+    except ValueError:
+        _CUSTOM_DELIVERY_METHODS[value] = category
+    return value
+
+
+def is_known_delivery_method(value: str) -> bool:
+    """True when *value* is a canonical enum member or a registered custom method."""
+    if value in _CUSTOM_DELIVERY_METHODS:
+        return True
+    try:
+        DeliveryMethod(value)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_delivery_method(value: DeliveryMethod | str) -> DeliveryMethod | str:
+    """Resolve one value: a known method becomes its :class:`DeliveryMethod`
+    object, an unknown one passes through unchanged (open set).
+
+    Already a :class:`DeliveryMethod`? Returned as-is — this is the identity that
+    lets registry-backed objects flow through the pipeline without conversion.
+    """
+    if isinstance(value, DeliveryMethod):
+        return value
+    try:
+        return DeliveryMethod(value)
+    except ValueError:
+        return value
+
+
+def resolve_delivery_methods(values: list[DeliveryMethod | str]) -> list[DeliveryMethod | str]:
+    """Resolve a list, coercing known values to enum objects and keeping unknown
+    ones as strings. Order preserved, duplicates removed."""
+    seen: set[str] = set()
+    result: list[DeliveryMethod | str] = []
+    for value in values:
+        resolved = resolve_delivery_method(value)
+        key = str(resolved)
+        if key not in seen:
+            seen.add(key)
+            result.append(resolved)
+    return result
+
+
+def list_available_delivery_methods() -> list[DeliveryMethod | str]:
+    """Every known method: the canonical enum members plus registered customs."""
+    return [*DeliveryMethod, *_CUSTOM_DELIVERY_METHODS]

--- a/src/evaluatorq/redteam/delivery_method_registry.py
+++ b/src/evaluatorq/redteam/delivery_method_registry.py
@@ -122,14 +122,25 @@ def register_delivery_method(value: str, *, category: str = 'custom') -> str:
     CLI's unknown-method warning; filtering already worked without it.
 
     A value equal to an existing :class:`DeliveryMethod` member is a no-op (the
-    enum is already canonical); a member *name* is rejected, since registering
-    ``'ROLE_PLAY'`` would shadow ``'role-play'`` with a spelling no dataset row
-    carries. Registration is process-local and not persisted, so it must happen
-    in the same process that later runs the CLI. Returns the registered value.
+    enum is already canonical); a member *name* that is not also a value is
+    rejected, since registering ``'ROLE_PLAY'`` would shadow ``'role-play'``
+    with a spelling no dataset row carries. Registration is process-local and
+    not persisted, so it must happen in the same process that later runs the
+    CLI. Returns the registered value, or raises ``ValueError`` on an empty
+    value or a member name.
     """
     if not value:
         msg = 'Cannot register an empty delivery method.'
         raise ValueError(msg)
+    # Value lookup FIRST: DeliveryMethod.DAN is spelled 'DAN' on both sides, so
+    # a name check that ran first would reject the canonical value as if it were
+    # a name and suggest the identical string back.
+    try:
+        DeliveryMethod(value)
+    except ValueError:
+        pass
+    else:
+        return value  # already canonical — no-op
     member_by_name = DeliveryMethod.__members__.get(value)
     if member_by_name is not None:
         msg = (
@@ -137,10 +148,7 @@ def register_delivery_method(value: str, *, category: str = 'custom') -> str:
             f'Use {delivery_method_str(member_by_name)!r} (already known — no registration needed).'
         )
         raise ValueError(msg)
-    try:
-        DeliveryMethod(value)
-    except ValueError:
-        _CUSTOM_DELIVERY_METHODS[value] = category
+    _CUSTOM_DELIVERY_METHODS[value] = category
     return value
 
 

--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -28,6 +28,7 @@ from evaluatorq.redteam.contracts import (
     StaticDataset,
     normalize_category,
 )
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str
 from evaluatorq.redteam.exceptions import DatasetError
 from evaluatorq.redteam.frameworks.owasp.evaluators import get_evaluator_for_category
 from evaluatorq.redteam.tracing import with_redteam_span
@@ -528,7 +529,7 @@ def _load_from_file(
     if delivery_methods:
         selected = set(delivery_methods)
         samples = [s for s in samples if s.input.delivery_method in selected]
-        logger.info(f'Filtered to delivery methods: {sorted(str(m) for m in selected)} ({len(samples)} samples)')
+        logger.info(f'Filtered to delivery methods: {sorted(delivery_method_str(m) for m in selected)} ({len(samples)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:
@@ -565,7 +566,7 @@ def _apply_filters(
     if delivery_methods:
         selected = set(delivery_methods)
         datapoints = [dp for dp in datapoints if dp.inputs.get('delivery_method') in selected]
-        logger.info(f'Filtered to delivery methods: {sorted(str(m) for m in selected)} ({len(datapoints)} samples)')
+        logger.info(f'Filtered to delivery methods: {sorted(delivery_method_str(m) for m in selected)} ({len(datapoints)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:

--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -529,7 +529,9 @@ def _load_from_file(
     if delivery_methods:
         selected = set(delivery_methods)
         samples = [s for s in samples if s.input.delivery_method in selected]
-        logger.info(f'Filtered to delivery methods: {sorted(delivery_method_str(m) for m in selected)} ({len(samples)} samples)')
+        logger.info(
+            f'Filtered to delivery methods: {sorted(delivery_method_str(m) for m in selected)} ({len(samples)} samples)'
+        )
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:
@@ -566,7 +568,9 @@ def _apply_filters(
     if delivery_methods:
         selected = set(delivery_methods)
         datapoints = [dp for dp in datapoints if dp.inputs.get('delivery_method') in selected]
-        logger.info(f'Filtered to delivery methods: {sorted(delivery_method_str(m) for m in selected)} ({len(datapoints)} samples)')
+        logger.info(
+            f'Filtered to delivery methods: {sorted(delivery_method_str(m) for m in selected)} ({len(datapoints)} samples)'
+        )
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:

--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -20,6 +20,7 @@ from evaluatorq.redteam.backends.registry import create_async_llm_client
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     PIPELINE_CONFIG,
+    DeliveryMethod,
     EvaluatorConfig,
     EvaluatorqEvaluatorConfig,
     LLMCallConfig,
@@ -32,7 +33,7 @@ from evaluatorq.redteam.frameworks.owasp.evaluators import get_evaluator_for_cat
 from evaluatorq.redteam.tracing import with_redteam_span
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Collection
 
     from openai import AsyncOpenAI
 
@@ -118,7 +119,7 @@ def load_owasp_agentic_dataset(
     dataset: str | Path | None = None,
     num_samples: int | None = None,
     categories: list[str] | None = None,
-    delivery_methods: list[str] | None = None,
+    delivery_methods: Collection[DeliveryMethod | str] | None = None,
 ) -> list[DataPoint]:
     """Load red team dataset from various sources.
 
@@ -406,7 +407,7 @@ def _fetch_from_huggingface(
     filename: str = DEFAULT_HF_FILENAME,
     num_samples: int | None = None,
     categories: list[str] | None = None,
-    delivery_methods: list[str] | None = None,
+    delivery_methods: Collection[DeliveryMethod | str] | None = None,
 ) -> list[DataPoint]:
     """Fetch red team samples from a HuggingFace dataset repository."""
     try:
@@ -502,7 +503,7 @@ def _load_from_file(
     path: str | Path,
     num_samples: int | None = None,
     categories: list[str] | None = None,
-    delivery_methods: list[str] | None = None,
+    delivery_methods: Collection[DeliveryMethod | str] | None = None,
 ) -> list[DataPoint]:
     """Load OWASP dataset from a local JSON file in ``{"samples": [...]}`` format."""
     path = Path(path)
@@ -527,7 +528,7 @@ def _load_from_file(
     if delivery_methods:
         selected = set(delivery_methods)
         samples = [s for s in samples if s.input.delivery_method in selected]
-        logger.info(f'Filtered to delivery methods: {sorted(selected)} ({len(samples)} samples)')
+        logger.info(f'Filtered to delivery methods: {sorted(str(m) for m in selected)} ({len(samples)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:
@@ -550,7 +551,7 @@ def _apply_filters(
     datapoints: list[DataPoint],
     num_samples: int | None = None,
     categories: list[str] | None = None,
-    delivery_methods: list[str] | None = None,
+    delivery_methods: Collection[DeliveryMethod | str] | None = None,
 ) -> list[DataPoint]:
     """Apply category, delivery-method, and sample-count filters to datapoints.
 
@@ -564,7 +565,7 @@ def _apply_filters(
     if delivery_methods:
         selected = set(delivery_methods)
         datapoints = [dp for dp in datapoints if dp.inputs.get('delivery_method') in selected]
-        logger.info(f'Filtered to delivery methods: {sorted(selected)} ({len(datapoints)} samples)')
+        logger.info(f'Filtered to delivery methods: {sorted(str(m) for m in selected)} ({len(datapoints)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:

--- a/src/evaluatorq/redteam/reports/converters.py
+++ b/src/evaluatorq/redteam/reports/converters.py
@@ -44,6 +44,7 @@ from evaluatorq.redteam.contracts import (
     infer_framework,
     normalize_category,
 )
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str
 from evaluatorq.redteam.frameworks.owasp.evaluators import get_evaluator_metadata_for_category
 from evaluatorq.redteam.runtime.jobs import _normalize_usage as _normalize_token_usage
 from evaluatorq.redteam.vulnerability_registry import (
@@ -904,7 +905,10 @@ def compute_report_summary(results: list[RedTeamResult]) -> ReportSummary:
     dm_eval_totals: dict[str, int] = {}
     dm_vulns: dict[str, int] = {}
     for r in results:
-        for dm in r.attack.delivery_methods:
+        for raw_dm in r.attack.delivery_methods:
+            # String-key so a DeliveryMethod member never leaks its 3.10 repr
+            # (DeliveryMethod.X) into report keys — see delivery_method_str.
+            dm = delivery_method_str(raw_dm)
             dm_totals[dm] = dm_totals.get(dm, 0) + 1
             if _is_evaluated(r):
                 dm_eval_totals[dm] = dm_eval_totals.get(dm, 0) + 1

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -65,6 +65,7 @@ from evaluatorq.redteam.contracts import (
     normalize_category,
     parse_target,
 )
+from evaluatorq.redteam.delivery_method_registry import resolve_delivery_methods
 from evaluatorq.redteam.exceptions import CancelledError, CredentialError, RedTeamError
 from evaluatorq.redteam.hooks import (
     CompositePipelineHooks,
@@ -568,8 +569,13 @@ async def red_team(
     # rejected at the CLI boundary; here we pass through verbatim and detect
     # empty/unmatched intersections post-filter from the actually-matched set.
     resolved_strategy_names: set[str] | None = set(strategies) if strategies is not None else None
+    # Resolve through the registry so known values (enum plus registered) become
+    # canonical DeliveryMethod objects and unknown ones stay raw strings. The
+    # objects then flow through the planner, loader filter, and reporting as-is —
+    # no enum→string→enum conversion (DeliveryMethod is a StrEnum, so a set of
+    # them matches the dataset's string delivery_method directly).
     resolved_delivery_methods: set[DeliveryMethod | str] | None = (
-        set(delivery_methods) if delivery_methods is not None else None
+        set(resolve_delivery_methods(list(delivery_methods))) if delivery_methods is not None else None
     )
 
     resolved_vulns: list[Vulnerability] | None
@@ -1148,20 +1154,6 @@ def _create_job_for_target(
 # ---------------------------------------------------------------------------
 
 
-def _delivery_method_values(delivery_methods: set[DeliveryMethod | str] | None) -> list[str] | None:
-    """Convert a delivery-method selection to plain strings for the dataset loader.
-
-    The selection is an open set: known methods are :class:`DeliveryMethod` enum
-    members, unknown ones are raw strings. Both become their string value for the
-    loader (which filters by exact string match). Static rows are filtered inside
-    ``load_owasp_agentic_dataset`` before its ``num_samples`` cap. ``None`` stays
-    ``None`` so the loader leaves the filter disabled.
-    """
-    if delivery_methods is None:
-        return None
-    return [m.value if isinstance(m, DeliveryMethod) else m for m in delivery_methods]
-
-
 def _check_filter_results(
     datapoints: list[DataPoint],
     strategy_names: set[str] | None,
@@ -1210,7 +1202,9 @@ def _check_filter_results(
         if unmatched:
             logger.warning(f'Unmatched strategy name(s): {unmatched} — no datapoints matched.')
     if delivery_methods is not None:
-        unmatched_methods = sorted(set(_delivery_method_values(delivery_methods) or []) - matched_methods)
+        # DeliveryMethod is a StrEnum, so str(m) is its value — clean for both
+        # the set difference against the string matched set and the display.
+        unmatched_methods = sorted({str(m) for m in delivery_methods} - matched_methods)
         if unmatched_methods:
             msg = f'Unmatched delivery method(s): {unmatched_methods} — no datapoints use them.'
             # When some methods DID match, name what's actually present so a
@@ -1223,7 +1217,7 @@ def _check_filter_results(
 
     if not datapoints:
         names_repr = sorted(strategy_names) if strategy_names else None
-        methods_repr = sorted(_delivery_method_values(delivery_methods) or []) if delivery_methods else None
+        methods_repr = sorted(str(m) for m in delivery_methods) if delivery_methods else None
         msg = (
             'Filter selection produced zero datapoints — nothing to run. '
             f'(strategies={names_repr}, delivery_methods={methods_repr})'
@@ -1420,7 +1414,7 @@ async def _prepare_target(
                     dataset=dataset,
                     num_samples=max_static_datapoints,
                     categories=categories,
-                    delivery_methods=_delivery_method_values(resolved_delivery_methods),
+                    delivery_methods=resolved_delivery_methods,
                 )
 
             # Tag with hybrid_source only (no target_tag — datapoints are shared)
@@ -1846,7 +1840,7 @@ async def _run_dynamic_or_hybrid(
             dataset=dataset,
             num_samples=max_static_datapoints,
             categories=categories,
-            delivery_methods=_delivery_method_values(resolved_delivery_methods),
+            delivery_methods=resolved_delivery_methods,
         )
         est_static = len(static_data)
 
@@ -2609,7 +2603,7 @@ async def _run_static(
         dataset=dataset,
         num_samples=max_static_datapoints,
         categories=categories,
-        delivery_methods=_delivery_method_values(resolved_delivery_methods),
+        delivery_methods=resolved_delivery_methods,
     )
 
     # Filter out datapoints whose category has no registered evaluator

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -65,7 +65,7 @@ from evaluatorq.redteam.contracts import (
     normalize_category,
     parse_target,
 )
-from evaluatorq.redteam.delivery_method_registry import resolve_delivery_methods
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str, resolve_delivery_methods
 from evaluatorq.redteam.exceptions import CancelledError, CredentialError, RedTeamError
 from evaluatorq.redteam.hooks import (
     CompositePipelineHooks,
@@ -1202,9 +1202,10 @@ def _check_filter_results(
         if unmatched:
             logger.warning(f'Unmatched strategy name(s): {unmatched} — no datapoints matched.')
     if delivery_methods is not None:
-        # DeliveryMethod is a StrEnum, so str(m) is its value — clean for both
-        # the set difference against the string matched set and the display.
-        unmatched_methods = sorted({str(m) for m in delivery_methods} - matched_methods)
+        # Compare on canonical value strings: matched_methods holds raw dataset
+        # strings, and a DeliveryMethod member does NOT stringify to its value on
+        # the 3.10 StrEnum polyfill — delivery_method_str is version-independent.
+        unmatched_methods = sorted({delivery_method_str(m) for m in delivery_methods} - matched_methods)
         if unmatched_methods:
             msg = f'Unmatched delivery method(s): {unmatched_methods} — no datapoints use them.'
             # When some methods DID match, name what's actually present so a
@@ -1217,7 +1218,7 @@ def _check_filter_results(
 
     if not datapoints:
         names_repr = sorted(strategy_names) if strategy_names else None
-        methods_repr = sorted(str(m) for m in delivery_methods) if delivery_methods else None
+        methods_repr = sorted(delivery_method_str(m) for m in delivery_methods) if delivery_methods else None
         msg = (
             'Filter selection produced zero datapoints — nothing to run. '
             f'(strategies={names_repr}, delivery_methods={methods_repr})'

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -662,6 +662,10 @@ async def red_team(
     resolved_delivery_methods: set[DeliveryMethod | str] | None = (
         set(resolve_delivery_methods(list(delivery_methods))) if delivery_methods is not None else None
     )
+    # An unknown/misspelled delivery method stays a raw string here and silently
+    # narrows the run. The CLI already warns up front via typer.echo; programmatic
+    # callers get a loguru warning from _check_filter_results (post-filter, against
+    # the actual dataset), plus a hard RedTeamError if the selection is fully empty.
 
     resolved_vulns: list[Vulnerability] | None
     if replay is not None:

--- a/src/evaluatorq/redteam/ui/dashboard.py
+++ b/src/evaluatorq/redteam/ui/dashboard.py
@@ -26,6 +26,7 @@ from evaluatorq.redteam.contracts import (
     RedTeamResult,
     ReportSummary,
 )
+from evaluatorq.redteam.delivery_method_registry import delivery_method_str
 from evaluatorq.redteam.reports.converters import compute_report_summary
 from evaluatorq.redteam.reports.export_md import export_markdown
 from evaluatorq.redteam.reports.guidance import REMEDIATION_GUIDANCE
@@ -1970,7 +1971,7 @@ def _render_result_detail(result: RedTeamResult) -> None:
     mc5.markdown(f'**Turn Type:** {atk.turn_type.value}')
 
     if atk.delivery_methods:
-        st.markdown(f'**Delivery Methods:** {", ".join(getattr(dm, "value", dm) for dm in atk.delivery_methods)}')
+        st.markdown(f'**Delivery Methods:** {", ".join(delivery_method_str(dm) for dm in atk.delivery_methods)}')
 
     # Execution details
     if result.execution:

--- a/src/evaluatorq/redteam/ui/dashboard.py
+++ b/src/evaluatorq/redteam/ui/dashboard.py
@@ -366,7 +366,7 @@ def _render_sidebar_filters(results: list[RedTeamResult]) -> list[RedTeamResult]
     all_categories = sorted({r.attack.category for r in results})
     all_severities = [s for s in SEVERITY_ORDER if any(r.attack.severity.value == s for r in results)]
     all_techniques = sorted({r.attack.attack_technique.value for r in results})
-    all_delivery = sorted({getattr(dm, 'value', dm) for r in results for dm in (r.attack.delivery_methods or [])})
+    all_delivery = sorted({delivery_method_str(dm) for r in results for dm in (r.attack.delivery_methods or [])})
     all_vulnerabilities = sorted({r.attack.vulnerability for r in results if r.attack.vulnerability})
     all_agents = sorted({r.agent.key or r.agent.display_name or 'unknown' for r in results})
 
@@ -475,7 +475,7 @@ def _render_sidebar_filters(results: list[RedTeamResult]) -> list[RedTeamResult]
         filtered = [
             r
             for r in filtered
-            if any(getattr(dm, 'value', dm) in sel_delivery for dm in (r.attack.delivery_methods or []))
+            if any(delivery_method_str(dm) in sel_delivery for dm in (r.attack.delivery_methods or []))
         ]
 
     if all_vulnerabilities and set(sel_vulnerabilities) != set(all_vulnerabilities):

--- a/tests/dashboard/test_delivery_method_display.py
+++ b/tests/dashboard/test_delivery_method_display.py
@@ -1,0 +1,31 @@
+"""Regression tests for enum delivery-method display rendering."""
+
+from __future__ import annotations
+
+from evaluatorq.redteam.contracts import DeliveryMethod
+
+
+def test_chart_dimension_displays_enum_value(rt_result_safe) -> None:
+    from evaluatorq.dashboard.redteam_charts import _dim_value
+
+    result = rt_result_safe.model_copy(
+        update={'attack': rt_result_safe.attack.model_copy(update={'delivery_methods': [DeliveryMethod.CRESCENDO]})}
+    )
+    rendered = _dim_value(result, 'delivery_method')
+    assert 'crescendo' in rendered
+    # Version-honest leak check: str(member) yields 'DeliveryMethod.CRESCENDO' on the
+    # 3.10 polyfill; a .name mistake yields 'CRESCENDO' on any version. The member
+    # NAME must never appear — only the value 'crescendo' should.
+    assert 'CRESCENDO' not in rendered
+
+
+def test_attack_fragment_displays_enum_value(rt_result_safe) -> None:
+    from evaluatorq.dashboard.redteam_transcripts import render_attack_fragment
+
+    result = rt_result_safe.model_copy(
+        update={'attack': rt_result_safe.attack.model_copy(update={'delivery_methods': [DeliveryMethod.CRESCENDO]})}
+    )
+    rendered = render_attack_fragment(result)
+    assert 'crescendo' in rendered
+    # See test_chart_dimension_displays_enum_value: NAME leak is caught on any version.
+    assert 'CRESCENDO' not in rendered

--- a/tests/dashboard/test_filter.py
+++ b/tests/dashboard/test_filter.py
@@ -341,6 +341,25 @@ class TestFilterDefUnit:
         assert 'vulnerability' in opts
         assert 'agent' in opts
 
+    def test_redteam_delivery_method_options_use_values_not_enum_reprs(self) -> None:
+        """Options must carry 'direct-request', never 'DeliveryMethod.DIRECT_REQUEST'.
+
+        The fixture's attacks hold DeliveryMethod members, and str(member) renders the
+        repr on the 3.10 StrEnum polyfill — so this pins delivery_method_str as the
+        rendering path for the filter rail and chart labels.
+        """
+        from evaluatorq.dashboard.filters import FILTERS
+
+        report = _rt_report()
+        assert FILTERS['redteam'].options(report)['delivery_method'] == ['direct-request']
+
+    def test_redteam_apply_delivery_method_filter(self) -> None:
+        from evaluatorq.dashboard.filters import FILTERS
+
+        report = _rt_report()
+        assert len(FILTERS['redteam'].apply(report, {'delivery_method': ['direct-request']})) == 4
+        assert FILTERS['redteam'].apply(report, {'delivery_method': ['base64']}) == []
+
     def test_redteam_apply_category_filter(self) -> None:
         from evaluatorq.dashboard.filters import FILTERS
 

--- a/tests/redteam/conftest.py
+++ b/tests/redteam/conftest.py
@@ -16,3 +16,18 @@ def _ensure_llm_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     if not os.getenv("OPENAI_API_KEY") and not os.getenv("ORQ_API_KEY"):
         monkeypatch.setenv("OPENAI_API_KEY", "test-dummy-key")
+
+
+@pytest.fixture(autouse=True)
+def _clean_custom_delivery_registry():
+    """Keep the process-global custom delivery-method registry out of other tests.
+
+    Registration is process-wide, so a test that registers a method would otherwise
+    change what later tests consider "known" — e.g. the CLI test asserting an
+    unknown-method warning would flip depending on test order.
+    """
+    from evaluatorq.redteam.delivery_method_registry import clear_custom_delivery_methods
+
+    clear_custom_delivery_methods()
+    yield
+    clear_custom_delivery_methods()

--- a/tests/redteam/e2e/test_static_pipeline.py
+++ b/tests/redteam/e2e/test_static_pipeline.py
@@ -150,6 +150,35 @@ async def test_static_delivery_method_empty_match_hard_fails(
 
 
 @pytest.mark.asyncio
+async def test_static_unknown_delivery_method_passes_through_and_hard_fails(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """An unknown (unregistered) delivery method filters literally rather than being dropped.
+
+    Distinct from the enum case above: an unknown value never becomes a DeliveryMethod,
+    so it travels the raw-string branch through resolve -> loader filter -> error message.
+    If passthrough ever regressed to dropping unknowns, the filter would silently disable
+    itself and run the whole dataset instead of raising.
+    """
+    from evaluatorq.redteam.exceptions import RedTeamError
+
+    with _static_patches(mock_backend_bundle), pytest.raises(RedTeamError) as exc:
+        await red_team(
+            "agent:e2e-static-model",
+            mode="static",
+            delivery_methods=["bespoke-technique"],  # not an enum member, not registered
+            parallelism=2,
+            dataset=str(static_dataset_path),
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+        )
+    message = str(exc.value)
+    assert "bespoke-technique" in message  # the requested value survived as-is
+    assert "direct-request" in message  # what the dataset actually carries
+
+
+@pytest.mark.asyncio
 async def test_static_datapoint_capping(
     mock_llm_client: DeterministicAsyncOpenAI,
     mock_backend_bundle: MockBackend,

--- a/tests/redteam/test_cli.py
+++ b/tests/redteam/test_cli.py
@@ -368,6 +368,17 @@ class TestDeliveryMethodFlag:
         assert mock_rt.call_args.kwargs["delivery_methods"] == ["not-a-real-method"]
         assert "not known delivery methods" in result.output
 
+    def test_registered_custom_delivery_method_no_warning(self):
+        from evaluatorq.redteam.delivery_method_registry import register_delivery_method
+
+        register_delivery_method('emoji-smuggling', category='obfuscation')
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-d", "emoji-smuggling", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == ["emoji-smuggling"]
+        assert "not known delivery methods" not in result.output
+
     def test_delivery_method_defaults_to_none_when_omitted(self):
         result, mock_rt = _run_with_mocked_red_team(
             ["run", "--target", "agent:test-agent", "--yes"]

--- a/tests/redteam/test_cli.py
+++ b/tests/redteam/test_cli.py
@@ -366,7 +366,7 @@ class TestDeliveryMethodFlag:
         )
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["delivery_methods"] == ["not-a-real-method"]
-        assert "not in DeliveryMethod" in result.output
+        assert "not known delivery methods" in result.output
 
     def test_delivery_method_defaults_to_none_when_omitted(self):
         result, mock_rt = _run_with_mocked_red_team(

--- a/tests/redteam/test_delivery_method_registry.py
+++ b/tests/redteam/test_delivery_method_registry.py
@@ -70,9 +70,17 @@ def test_register_makes_custom_known_and_resolvable_as_string() -> None:
     assert 'honeypot' in {reg.delivery_method_str(m) for m in reg.list_available_delivery_methods()}
 
 
-def test_register_existing_enum_value_is_noop() -> None:
-    reg.register_delivery_method('crescendo')
-    assert 'crescendo' not in reg._CUSTOM_DELIVERY_METHODS  # enum is already canonical
+def test_register_existing_enum_value_is_noop(caplog) -> None:
+    import logging
+
+    before = len(reg.list_available_delivery_methods())
+    with caplog.at_level(logging.WARNING):
+        reg.register_delivery_method('crescendo', category='ignored')
+    assert len(reg.list_available_delivery_methods()) == before
+    assert reg.resolve_delivery_method('crescendo') is DeliveryMethod.CRESCENDO
+    # The no-op is observable, not silent: it warns and names the discarded category.
+    assert 'no-op' in caplog.text
+    assert 'ignored' in caplog.text
 
 
 @pytest.mark.parametrize('member', list(DeliveryMethod), ids=lambda m: m.name)
@@ -96,7 +104,7 @@ def test_register_enum_member_name_is_rejected() -> None:
     """
     with pytest.raises(ValueError, match='role-play'):
         reg.register_delivery_method('ROLE_PLAY')
-    assert 'ROLE_PLAY' not in reg._CUSTOM_DELIVERY_METHODS
+    assert not reg.is_known_delivery_method('ROLE_PLAY')
 
 
 def test_register_empty_raises() -> None:
@@ -202,6 +210,20 @@ def test_check_filter_results_matched_enum_method_no_unmatched_warning(caplog) -
     with caplog.at_level(logging.WARNING):
         _check_filter_results([dp], None, {DeliveryMethod.CRESCENDO}, names_apply=False)
     assert 'Unmatched delivery method' not in caplog.text
+
+
+def test_check_filter_results_mixed_match_reports_only_unmatched(caplog) -> None:
+    import logging
+
+    from evaluatorq.redteam.runner import _check_filter_results
+    from evaluatorq.types import DataPoint
+
+    dp = DataPoint(inputs={'delivery_method': 'crescendo', 'category': 'ASI01'})
+    with caplog.at_level(logging.WARNING):
+        _check_filter_results([dp], None, {DeliveryMethod.CRESCENDO, 'base64'}, names_apply=False)
+    assert 'base64' in caplog.text
+    assert 'Present' in caplog.text
+    assert "Unmatched delivery method(s): ['base64']" in caplog.text
 
 
 def test_check_filter_results_empty_run_error_reports_values_not_reprs() -> None:

--- a/tests/redteam/test_delivery_method_registry.py
+++ b/tests/redteam/test_delivery_method_registry.py
@@ -75,6 +75,18 @@ def test_register_existing_enum_value_is_noop() -> None:
     assert 'crescendo' not in reg._CUSTOM_DELIVERY_METHODS  # enum is already canonical
 
 
+@pytest.mark.parametrize('member', list(DeliveryMethod), ids=lambda m: m.name)
+def test_register_any_enum_value_is_noop(member: DeliveryMethod) -> None:
+    """Every member's value must register as a no-op, not just the name != value ones.
+
+    DeliveryMethod.DAN is spelled 'DAN' as both name and value, so a name check
+    ordered before the value lookup rejects the canonical value and suggests the
+    identical string back. Only a sweep over all members catches that.
+    """
+    assert reg.register_delivery_method(reg.delivery_method_str(member)) == reg.delivery_method_str(member)
+    assert reg.delivery_method_str(member) not in reg._CUSTOM_DELIVERY_METHODS
+
+
 def test_register_enum_member_name_is_rejected() -> None:
     """Registering the member NAME instead of its value must not create a shadow.
 

--- a/tests/redteam/test_delivery_method_registry.py
+++ b/tests/redteam/test_delivery_method_registry.py
@@ -70,7 +70,7 @@ def test_register_makes_custom_known_and_resolvable_as_string() -> None:
     assert reg.is_known_delivery_method('honeypot')
     # Registered customs stay strings (open set): no enum member exists for them.
     assert reg.resolve_delivery_method('honeypot') == 'honeypot'
-    assert 'honeypot' in {str(m) for m in reg.list_available_delivery_methods()}
+    assert 'honeypot' in {reg.delivery_method_str(m) for m in reg.list_available_delivery_methods()}
 
 
 def test_register_existing_enum_value_is_noop() -> None:
@@ -85,7 +85,7 @@ def test_register_empty_raises() -> None:
 
 def test_list_available_includes_enum_and_customs() -> None:
     reg.register_delivery_method('honeypot')
-    values = {str(m) for m in reg.list_available_delivery_methods()}
+    values = {reg.delivery_method_str(m) for m in reg.list_available_delivery_methods()}
     assert 'crescendo' in values  # enum
     assert 'honeypot' in values  # custom
     assert len(reg.list_available_delivery_methods()) == len(DeliveryMethod) + 1
@@ -140,3 +140,51 @@ def test_contract_boundary_coerces_registered_custom_to_string() -> None:
     # it validates as "known" (no warning) while remaining open-set.
     assert dp.delivery_method == 'honeypot'
     assert reg.is_known_delivery_method(dp.delivery_method)
+
+
+# ---------------------------------------------------------------------------
+# delivery_method_str: version-independent value stringification
+# ---------------------------------------------------------------------------
+
+
+def test_delivery_method_str_returns_value_for_member() -> None:
+    # str(member) is the repr on the 3.10 StrEnum polyfill; delivery_method_str
+    # must always return the value so display/keying is version-independent.
+    assert reg.delivery_method_str(DeliveryMethod.DAN) == 'DAN'
+    assert reg.delivery_method_str(DeliveryMethod.CRESCENDO) == 'crescendo'
+
+
+def test_delivery_method_str_passes_strings_through() -> None:
+    assert reg.delivery_method_str('my-custom') == 'my-custom'
+
+
+# ---------------------------------------------------------------------------
+# _check_filter_results diagnostics use canonical values (regression: the seam
+# removal must not report a matched method as unmatched, nor leak enum reprs)
+# ---------------------------------------------------------------------------
+
+
+def test_check_filter_results_matched_enum_method_no_unmatched_warning(caplog) -> None:
+    import logging
+
+    from evaluatorq.redteam.runner import _check_filter_results
+    from evaluatorq.types import DataPoint
+
+    # A datapoint whose static delivery_method matches the requested member.
+    dp = DataPoint(inputs={'delivery_method': 'DAN', 'category': 'ASI01'})
+    with caplog.at_level(logging.WARNING):
+        _check_filter_results([dp], None, {DeliveryMethod.DAN}, names_apply=False)
+    assert 'Unmatched delivery method' not in caplog.text
+
+
+def test_check_filter_results_empty_run_error_reports_values_not_reprs() -> None:
+    from evaluatorq.redteam.exceptions import RedTeamError
+    from evaluatorq.redteam.runner import _check_filter_results
+
+    with pytest.raises(RedTeamError) as exc:
+        _check_filter_results([], None, {DeliveryMethod.DAN, 'custom'}, names_apply=False)
+    text = str(exc.value)
+    assert 'DAN' in text
+    assert 'custom' in text
+    # never the enum repr, which the 3.10 polyfill would produce via str()
+    assert 'DeliveryMethod.DAN' not in text

--- a/tests/redteam/test_delivery_method_registry.py
+++ b/tests/redteam/test_delivery_method_registry.py
@@ -13,12 +13,9 @@ from evaluatorq.redteam import delivery_method_registry as reg
 from evaluatorq.redteam.contracts import DeliveryMethod, RedTeamInput, Severity, TurnType, VulnerabilityDomain
 
 
-@pytest.fixture(autouse=True)
-def _clean_custom_registry():
-    """Each test starts and ends with an empty custom registry (module global)."""
-    reg._CUSTOM_DELIVERY_METHODS.clear()
-    yield
-    reg._CUSTOM_DELIVERY_METHODS.clear()
+# Isolation comes from the autouse _clean_custom_delivery_registry fixture in
+# tests/redteam/conftest.py — it covers every red-team test, not just this module,
+# since registration is process-global.
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +75,18 @@ def test_register_existing_enum_value_is_noop() -> None:
     assert 'crescendo' not in reg._CUSTOM_DELIVERY_METHODS  # enum is already canonical
 
 
+def test_register_enum_member_name_is_rejected() -> None:
+    """Registering the member NAME instead of its value must not create a shadow.
+
+    'ROLE_PLAY' is not a DeliveryMethod value ('role-play' is), so registering it
+    would land in the custom set: reported known, CLI warning suppressed, and
+    filtering against a spelling no dataset row carries.
+    """
+    with pytest.raises(ValueError, match='role-play'):
+        reg.register_delivery_method('ROLE_PLAY')
+    assert 'ROLE_PLAY' not in reg._CUSTOM_DELIVERY_METHODS
+
+
 def test_register_empty_raises() -> None:
     with pytest.raises(ValueError, match='empty'):
         reg.register_delivery_method('')
@@ -99,9 +108,13 @@ def test_list_available_includes_enum_and_customs() -> None:
 def test_delivery_method_set_membership_matches_string() -> None:
     # The loader filters `dp.delivery_method in selected`. This is why passing
     # DeliveryMethod objects works against the dataset's string values.
-    selected: set[DeliveryMethod | str] = {DeliveryMethod.DAN, 'custom'}
-    assert 'DAN' in selected
-    assert DeliveryMethod.DAN in selected
+    # CRESCENDO deliberately: its name ('CRESCENDO') differs from its value
+    # ('crescendo'), so this fails if membership ever keyed on the name. A member
+    # like DAN, where name == value, cannot tell the two apart.
+    selected: set[DeliveryMethod | str] = {DeliveryMethod.CRESCENDO, 'custom'}
+    assert 'crescendo' in selected
+    assert DeliveryMethod.CRESCENDO in selected
+    assert 'CRESCENDO' not in selected  # the member name is not the match key
     assert 'custom' in selected
 
 
@@ -171,9 +184,11 @@ def test_check_filter_results_matched_enum_method_no_unmatched_warning(caplog) -
     from evaluatorq.types import DataPoint
 
     # A datapoint whose static delivery_method matches the requested member.
-    dp = DataPoint(inputs={'delivery_method': 'DAN', 'category': 'ASI01'})
+    # CRESCENDO (name != value) so a name/value confusion in the comparison shows
+    # up here as a spurious "unmatched" warning.
+    dp = DataPoint(inputs={'delivery_method': 'crescendo', 'category': 'ASI01'})
     with caplog.at_level(logging.WARNING):
-        _check_filter_results([dp], None, {DeliveryMethod.DAN}, names_apply=False)
+        _check_filter_results([dp], None, {DeliveryMethod.CRESCENDO}, names_apply=False)
     assert 'Unmatched delivery method' not in caplog.text
 
 
@@ -182,12 +197,12 @@ def test_check_filter_results_empty_run_error_reports_values_not_reprs() -> None
     from evaluatorq.redteam.runner import _check_filter_results
 
     with pytest.raises(RedTeamError) as exc:
-        _check_filter_results([], None, {DeliveryMethod.DAN, 'custom'}, names_apply=False)
+        _check_filter_results([], None, {DeliveryMethod.CRESCENDO, 'custom'}, names_apply=False)
     text = str(exc.value)
-    assert 'DAN' in text
+    assert 'crescendo' in text
     assert 'custom' in text
     # never the enum repr, which the 3.10 polyfill would produce via str()
-    assert 'DeliveryMethod.DAN' not in text
+    assert 'DeliveryMethod.CRESCENDO' not in text
 
 
 def test_every_enum_member_has_a_category() -> None:

--- a/tests/redteam/test_delivery_method_registry.py
+++ b/tests/redteam/test_delivery_method_registry.py
@@ -188,3 +188,10 @@ def test_check_filter_results_empty_run_error_reports_values_not_reprs() -> None
     assert 'custom' in text
     # never the enum repr, which the 3.10 polyfill would produce via str()
     assert 'DeliveryMethod.DAN' not in text
+
+
+def test_every_enum_member_has_a_category() -> None:
+    """Completeness: DELIVERY_METHOD_CATEGORY must map every DeliveryMethod
+    member, so a newly added method can never ship without a technique family."""
+    missing = [m for m in DeliveryMethod if m not in reg.DELIVERY_METHOD_CATEGORY]
+    assert not missing, f'delivery methods missing from DELIVERY_METHOD_CATEGORY: {missing}'

--- a/tests/redteam/test_delivery_method_registry.py
+++ b/tests/redteam/test_delivery_method_registry.py
@@ -1,0 +1,142 @@
+"""Tests for the delivery-method registry (RES-966).
+
+Covers the coerce-known + passthrough-unknown policy, registration of custom
+methods, and the identity property that lets registry-backed objects flow
+through the pipeline unchanged (no enum -> string -> enum hop).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.redteam import delivery_method_registry as reg
+from evaluatorq.redteam.contracts import DeliveryMethod, RedTeamInput, Severity, TurnType, VulnerabilityDomain
+
+
+@pytest.fixture(autouse=True)
+def _clean_custom_registry():
+    """Each test starts and ends with an empty custom registry (module global)."""
+    reg._CUSTOM_DELIVERY_METHODS.clear()
+    yield
+    reg._CUSTOM_DELIVERY_METHODS.clear()
+
+
+# ---------------------------------------------------------------------------
+# resolve: coerce-known, passthrough-unknown, identity
+# ---------------------------------------------------------------------------
+
+
+def test_known_string_coerces_to_enum() -> None:
+    resolved = reg.resolve_delivery_method('crescendo')
+    assert resolved is DeliveryMethod.CRESCENDO
+    assert isinstance(resolved, DeliveryMethod)
+
+
+def test_unknown_string_passes_through() -> None:
+    resolved = reg.resolve_delivery_method('my-custom-jailbreak')
+    assert resolved == 'my-custom-jailbreak'
+    assert not isinstance(resolved, DeliveryMethod)
+
+
+def test_enum_member_is_returned_as_is() -> None:
+    # The identity that lets objects flow through the pipeline without conversion.
+    assert reg.resolve_delivery_method(DeliveryMethod.DAN) is DeliveryMethod.DAN
+
+
+def test_resolve_list_dedupes_preserving_order_and_coerces() -> None:
+    out = reg.resolve_delivery_methods(['DAN', 'custom', 'DAN', DeliveryMethod.DAN, 'crescendo'])
+    assert out == [DeliveryMethod.DAN, 'custom', DeliveryMethod.CRESCENDO]
+    # a str 'DAN' and DeliveryMethod.DAN dedupe to one (StrEnum equality)
+    assert out.count(DeliveryMethod.DAN) == 1
+
+
+# ---------------------------------------------------------------------------
+# is_known / register / list
+# ---------------------------------------------------------------------------
+
+
+def test_is_known_enum_member() -> None:
+    assert reg.is_known_delivery_method('crescendo')
+    assert reg.is_known_delivery_method('DAN')
+
+
+def test_is_known_false_for_unregistered() -> None:
+    assert not reg.is_known_delivery_method('totally-unknown')
+
+
+def test_register_makes_custom_known_and_resolvable_as_string() -> None:
+    assert not reg.is_known_delivery_method('honeypot')
+    reg.register_delivery_method('honeypot', category='experimental')
+    assert reg.is_known_delivery_method('honeypot')
+    # Registered customs stay strings (open set): no enum member exists for them.
+    assert reg.resolve_delivery_method('honeypot') == 'honeypot'
+    assert 'honeypot' in {str(m) for m in reg.list_available_delivery_methods()}
+
+
+def test_register_existing_enum_value_is_noop() -> None:
+    reg.register_delivery_method('crescendo')
+    assert 'crescendo' not in reg._CUSTOM_DELIVERY_METHODS  # enum is already canonical
+
+
+def test_register_empty_raises() -> None:
+    with pytest.raises(ValueError, match='empty'):
+        reg.register_delivery_method('')
+
+
+def test_list_available_includes_enum_and_customs() -> None:
+    reg.register_delivery_method('honeypot')
+    values = {str(m) for m in reg.list_available_delivery_methods()}
+    assert 'crescendo' in values  # enum
+    assert 'honeypot' in values  # custom
+    assert len(reg.list_available_delivery_methods()) == len(DeliveryMethod) + 1
+
+
+# ---------------------------------------------------------------------------
+# StrEnum identity that makes the seam removal safe
+# ---------------------------------------------------------------------------
+
+
+def test_delivery_method_set_membership_matches_string() -> None:
+    # The loader filters `dp.delivery_method in selected`. This is why passing
+    # DeliveryMethod objects works against the dataset's string values.
+    selected: set[DeliveryMethod | str] = {DeliveryMethod.DAN, 'custom'}
+    assert 'DAN' in selected
+    assert DeliveryMethod.DAN in selected
+    assert 'custom' in selected
+
+
+# ---------------------------------------------------------------------------
+# RedTeamInput boundary coercion routes through the registry
+# ---------------------------------------------------------------------------
+
+
+def _input(delivery_method: str) -> RedTeamInput:
+    return RedTeamInput(
+        id='x',
+        vulnerability='goal_hijacking',
+        delivery_method=delivery_method,
+        severity=Severity.LOW,
+        vulnerability_domain=VulnerabilityDomain.AGENT,
+        turn_type=TurnType.SINGLE,
+        source='test',
+    )
+
+
+def test_contract_boundary_coerces_known_delivery_method() -> None:
+    dp = _input('crescendo')
+    assert dp.delivery_method is DeliveryMethod.CRESCENDO
+
+
+def test_contract_boundary_passes_unknown_through() -> None:
+    dp = _input('bespoke-technique')
+    assert dp.delivery_method == 'bespoke-technique'
+    assert not isinstance(dp.delivery_method, DeliveryMethod)
+
+
+def test_contract_boundary_coerces_registered_custom_to_string() -> None:
+    reg.register_delivery_method('honeypot')
+    dp = _input('honeypot')
+    # A registered custom has no enum member, so it stays a string; the point is
+    # it validates as "known" (no warning) while remaining open-set.
+    assert dp.delivery_method == 'honeypot'
+    assert reg.is_known_delivery_method(dp.delivery_method)


### PR DESCRIPTION
Closes RES-966. Follow-up to RES-295.

## What

Delivery methods now mirror the vulnerability-registry pattern, and `DeliveryMethod | str` objects flow through the planner, loader filter, and reporting **unchanged** — no `enum -> string -> enum` conversion hops. This is safe because `DeliveryMethod` is a `StrEnum`: a set of members matches the dataset's string `delivery_method` directly (same hash and equality), so the round-trip the old seam performed was never needed.

## Changes

- **New `delivery_method_registry.py`** mirroring `vulnerability_registry.py`: the canonical set (the enum, grouped by technique family in `DELIVERY_METHOD_CATEGORY`) plus a mutable custom registry, with `register_delivery_method` / `is_known_delivery_method` / `resolve_delivery_method` / `resolve_delivery_methods` / `list_available_delivery_methods`.
- **Removed the conversion seam** (`runner.py`): deleted `_delivery_method_values`; `resolved_delivery_methods` is built through the registry and passed as the object set straight to the loader (3 sites) and `_check_filter_results` (display strings derived inline via `str()`, which is the value for a StrEnum).
- **Normalized once at the contract boundary** (item 4): `RedTeamInput._coerce_delivery_method` and `is_known_delivery_method` both route through the registry, so it is the single source of truth and a known value is coerced exactly once.
- **Loader** (`evaluatorq_bridge.py`): `delivery_methods` params widened to `Collection[DeliveryMethod | str]`; filter log lines render values, not enum reprs.
- **CLI** (`cli.py`): `--delivery-method` validates against registry + enum via `is_known_delivery_method`.

## Strictness policy (the decision item 3 asks for)

Delivery methods stay **coerce-known + passthrough-unknown** (the open set RES-295 deliberately chose, now registry-extensible). Vulnerabilities keep **reject-unknown**. The *registry pattern* is consistent (both: enum + registered, resolve/register); the *strictness* differs on purpose because the semantics do — an unknown delivery method is a harmless filter label (it matches a dataset row spelled the same or it does not), whereas an unknown vulnerability has no strategies and no evaluator, so passing it through would silently produce an unscoreable run. Same registry shape, different failure mode, each chosen for its own contract. This is documented in the registry module docstring; happy to make vulnerabilities open-set too if reviewers prefer literal symmetry.

**Out of scope** (per ticket): no fuzzy normalization — a value equals a known method exactly or it is unknown.

## Testing

- 14 new registry tests (`tests/redteam/test_delivery_method_registry.py`): coerce-known / passthrough-unknown / enum-identity, register + is_known + list, the StrEnum set-membership property that makes the seam removal safe, and the `RedTeamInput` boundary coercion.
- Full redteam suite: 1315 passed. `ruff` and `basedpyright` clean on the 5 changed src files.
- One existing CLI test's warning-text assertion updated (message reworded; behavior identical).

An adversarial verification swarm is running against the ticket spec (StrEnum-equality correctness, the mutable-global registry lifecycle, and whether the strictness decision holds); any confirmed findings will land as follow-up commits.

Ticket: RES-966