### PR TITLE
feat(redteam): make an empty filter list mean "match nothing" (RES-1182)

### DIFF
--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -523,10 +523,10 @@ def _load_from_file(
         raise DatasetError(msg) from e
     samples = dataset.samples
 
-    if categories:
+    if categories is not None:
         samples = _filter_by_categories(samples, categories, category_of=lambda s: s.input.category)
 
-    if delivery_methods:
+    if delivery_methods is not None:
         selected = set(delivery_methods)
         samples = [s for s in samples if s.input.delivery_method in selected]
         logger.info(
@@ -562,10 +562,10 @@ def _apply_filters(
     cap limits the already-filtered set rather than slicing first and filtering the
     remainder (which would yield fewer than ``num_samples`` rows).
     """
-    if categories:
+    if categories is not None:
         datapoints = _filter_by_categories(datapoints, categories, category_of=lambda dp: dp.inputs.get('category', ''))
 
-    if delivery_methods:
+    if delivery_methods is not None:
         selected = set(delivery_methods)
         datapoints = [dp for dp in datapoints if dp.inputs.get('delivery_method') in selected]
         logger.info(

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -431,15 +431,21 @@ async def red_team(
             boundary; names that match no datapoint emit a warning. Does not
             apply to static (dataset) datapoints, which carry no strategy name —
             a warning is emitted if combined with ``static`` mode. ``None``
-            disables the filter.
+            disables the filter; an empty list selects nothing (see below).
         delivery_methods: Restrict the run to attacks whose delivery method
             overlaps the supplied selection. Applies to dynamic strategies
             (``AttackStrategy.delivery_methods``) and to static datapoints
             (``inputs['delivery_method']``). Combines with ``strategies`` using
             AND semantics. Methods matching no datapoint emit a warning. ``None``
-            disables the filter. When a supplied filter leaves zero datapoints to
-            run, ``red_team`` raises :class:`RedTeamError` rather than silently
-            running nothing.
+            disables the filter; an empty list selects nothing.
+
+            Filter semantics are uniform across ``categories``,
+            ``vulnerabilities``, ``strategies`` and ``delivery_methods``:
+            ``None`` means "no filter", and an empty list means "match nothing"
+            — never "match everything". Since an empty selection leaves zero
+            datapoints, ``red_team`` raises :class:`RedTeamError` rather than
+            silently running nothing (or, worse, running the full sweep the
+            caller meant to filter down).
         max_turns: Maximum conversation turns for multi-turn attacks. Defaults
             to 5, or — when replaying via ``previous_run`` — to the turn budget
             the replayed run used. An explicit value always wins.
@@ -542,8 +548,8 @@ async def red_team(
             for label, supplied in (
                 ('mode', Pipeline(mode) != Pipeline.DYNAMIC),
                 ('dataset', dataset is not None),
-                ('categories', bool(categories)),
-                ('vulnerabilities', bool(vulnerabilities)),
+                ('categories', categories is not None),
+                ('vulnerabilities', vulnerabilities is not None),
                 ('strategies', strategies is not None),
                 ('delivery_methods', delivery_methods is not None),
                 ('max_per_category', max_per_category is not None),
@@ -674,10 +680,10 @@ async def red_team(
         # the stored datapoints have already made.
         resolved_categories = replay.categories
         resolved_vulns = None
-    elif vulnerabilities:
+    elif vulnerabilities is not None:
         resolved_vulns = resolve_vulnerabilities(vulnerabilities)
         resolved_categories = [get_primary_category(v) for v in resolved_vulns]
-    elif categories:
+    elif categories is not None:
         # Surface unrecognized codes instead of silently swallowing the ValueError and
         # proceeding with resolved_vulns=None — that skips the evaluability gate and runs
         # a meaningless attack with no scoring.
@@ -1261,6 +1267,20 @@ def _create_job_for_target(
 # ---------------------------------------------------------------------------
 
 
+def _category_selection(
+    categories: list[str] | None,
+    vulnerabilities: list[Vulnerability] | None,
+) -> list[str] | None:
+    """Render the explicit category/vulnerability selection, or None if unset.
+
+    Distinguishes "not set" from "set to nothing": an empty selection returns
+    ``[]``, which the empty-run guard treats as a filter that was applied.
+    """
+    if categories is None and vulnerabilities is None:
+        return None
+    return sorted([*(categories or []), *(v.value for v in vulnerabilities or [])])
+
+
 def _check_filter_results(
     datapoints: list[DataPoint],
     strategy_names: set[str] | None,
@@ -1268,6 +1288,7 @@ def _check_filter_results(
     *,
     names_apply: bool = True,
     present_methods: list[str] | None = None,
+    category_selection: list[str] | None = None,
 ) -> None:
     """Surface strategy/delivery-method filter mismatches; fail on an empty run.
 
@@ -1287,8 +1308,12 @@ def _check_filter_results(
     filter, they are surfaced in the error so the user sees a spelling mismatch
     (``you asked for 'crescendo', the dataset uses 'Crescendo attack'``) rather
     than a bare "zero datapoints".
+
+    ``category_selection`` carries the explicit category/vulnerability selection
+    (``None`` when unset, ``[]`` when set to nothing) so a category filter that
+    empties the run hits the same guard as a delivery filter instead of exiting 0.
     """
-    if strategy_names is None and delivery_methods is None:
+    if strategy_names is None and delivery_methods is None and category_selection is None:
         return
 
     matched_names: set[str] = set()
@@ -1324,11 +1349,16 @@ def _check_filter_results(
             logger.warning(msg)
 
     if not datapoints:
-        names_repr = sorted(strategy_names) if strategy_names else None
-        methods_repr = sorted(delivery_method_str(m) for m in delivery_methods) if delivery_methods else None
+        # `is not None`, not truthiness: an empty selection is exactly the case
+        # that needs naming, and rendering it as None would hide the filter that
+        # emptied the run behind "no filter was set".
+        names_repr = sorted(strategy_names) if strategy_names is not None else None
+        methods_repr = (
+            sorted(delivery_method_str(m) for m in delivery_methods) if delivery_methods is not None else None
+        )
         msg = (
             'Filter selection produced zero datapoints — nothing to run. '
-            f'(strategies={names_repr}, delivery_methods={methods_repr})'
+            f'(categories={category_selection}, strategies={names_repr}, delivery_methods={methods_repr})'
         )
         if present_methods:
             msg += f' Delivery methods present in the dataset: {present_methods}.'
@@ -1544,7 +1574,12 @@ async def _prepare_target(
                     },
                 )
             )
-            _check_filter_results(all_datapoints, resolved_strategy_names, resolved_delivery_methods)
+            _check_filter_results(
+                all_datapoints,
+                resolved_strategy_names,
+                resolved_delivery_methods,
+                category_selection=_category_selection(categories, resolved_vulns),
+            )
 
         # Build the static job via shared helper
         sys_prompt = target_config.system_prompt if target_config else None
@@ -1581,7 +1616,12 @@ async def _prepare_target(
             await await_maybe(
                 hooks.on_stage_end(PipelineStage.DATAPOINT_GENERATION, {'num_datapoints': len(all_datapoints)})
             )
-            _check_filter_results(all_datapoints, resolved_strategy_names, resolved_delivery_methods)
+            _check_filter_results(
+                all_datapoints,
+                resolved_strategy_names,
+                resolved_delivery_methods,
+                category_selection=_category_selection(categories, resolved_vulns),
+            )
 
         # Build the dynamic dispatcher job
         @job(f'redteam:dynamic:{safe_target}')
@@ -1691,7 +1731,9 @@ async def _run_dynamic_or_hybrid(
     resolved_hooks: PipelineHooks = hooks or DefaultHooks()
     pipeline_start = datetime.now(tz=timezone.utc).astimezone()
 
-    resolved_categories = categories or list_available_categories()
+    # `is None`, not truthiness: an empty list is a real selection that matches
+    # nothing, and `or` would silently widen it back to the full category sweep.
+    resolved_categories = list_available_categories() if categories is None else categories
 
     resolved_agent_targets = agent_targets or []
     all_target_labels, agent_target_labels = _deduplicate_target_labels(targets, resolved_agent_targets)
@@ -2289,7 +2331,12 @@ async def _run_dynamic_or_hybrid(
                     return result.get('output', result) if isinstance(result, dict) else result
 
             if at_is_generating:
-                _check_filter_results(at_all_dps, resolved_strategy_names, resolved_delivery_methods)
+                _check_filter_results(
+                    at_all_dps,
+                    resolved_strategy_names,
+                    resolved_delivery_methods,
+                    category_selection=_category_selection(categories, resolved_vulns),
+                )
 
             prepared_targets.append(
                 PreparedTarget(
@@ -2794,7 +2841,14 @@ async def _run_static(
 
             present_rows = load_owasp_agentic_dataset(dataset=dataset, categories=categories)
             present_methods = sorted({m for dp in present_rows if (m := dp.inputs.get('delivery_method'))})
-        _check_filter_results(data, None, resolved_delivery_methods, names_apply=False, present_methods=present_methods)
+        _check_filter_results(
+            data,
+            None,
+            resolved_delivery_methods,
+            names_apply=False,
+            present_methods=present_methods,
+            category_selection=_category_selection(categories, None),
+        )
         _save_stage(output_dir, '01_datapoints.json', json.dumps([dp.inputs for dp in data], indent=2, default=str))
 
     # Build one job per target using the shared helper

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -445,7 +445,9 @@ async def red_team(
             — never "match everything". Since an empty selection leaves zero
             datapoints, ``red_team`` raises :class:`RedTeamError` rather than
             silently running nothing (or, worse, running the full sweep the
-            caller meant to filter down).
+            caller meant to filter down). This is reachable from the SDK only:
+            the CLI maps blank/empty input back to ``None`` (``_split_csv``), so
+            no ``eq redteam run`` invocation can express "match nothing".
         max_turns: Maximum conversation turns for multi-turn attacks. Defaults
             to 5, or — when replaying via ``previous_run`` — to the turn budget
             the replayed run used. An explicit value always wins.
@@ -673,6 +675,18 @@ async def red_team(
     # callers get a loguru warning from _check_filter_results (post-filter, against
     # the actual dataset), plus a hard RedTeamError if the selection is fully empty.
 
+    # Snapshot the caller's raw category/vulnerability selection for the empty-run
+    # guard, before the resolution chain below defaults an unfiltered run to the
+    # full category sweep. Reading it off resolved_categories instead would make
+    # every default run look like a filter that selected all 36 categories, and a
+    # run that came back empty for an unrelated reason would be blamed on a filter
+    # the caller never set.
+    filter_selection: tuple[str, list[str]] | None = None
+    if vulnerabilities is not None:
+        filter_selection = ('vulnerabilities', sorted(vulnerabilities))
+    elif categories is not None:
+        filter_selection = ('categories', sorted(categories))
+
     resolved_vulns: list[Vulnerability] | None
     if replay is not None:
         # A replay's scope is whatever it recorded. Resolving vulnerabilities
@@ -825,6 +839,7 @@ async def red_team(
             if resolved_mode in (Pipeline.DYNAMIC, Pipeline.HYBRID):
                 run_result = await _run_dynamic_or_hybrid(
                     targets=targets,
+                    filter_selection=filter_selection,
                     agent_targets=agent_targets,
                     mode=resolved_mode,
                     name=name,
@@ -859,6 +874,7 @@ async def red_team(
             elif resolved_mode == Pipeline.STATIC:
                 run_result = await _run_static(
                     targets=targets,
+                    filter_selection=filter_selection,
                     agent_targets=agent_targets,
                     name=name,
                     categories=resolved_categories,
@@ -1267,20 +1283,6 @@ def _create_job_for_target(
 # ---------------------------------------------------------------------------
 
 
-def _category_selection(
-    categories: list[str] | None,
-    vulnerabilities: list[Vulnerability] | None,
-) -> list[str] | None:
-    """Render the explicit category/vulnerability selection, or None if unset.
-
-    Distinguishes "not set" from "set to nothing": an empty selection returns
-    ``[]``, which the empty-run guard treats as a filter that was applied.
-    """
-    if categories is None and vulnerabilities is None:
-        return None
-    return sorted([*(categories or []), *(v.value for v in vulnerabilities or [])])
-
-
 def _check_filter_results(
     datapoints: list[DataPoint],
     strategy_names: set[str] | None,
@@ -1288,7 +1290,7 @@ def _check_filter_results(
     *,
     names_apply: bool = True,
     present_methods: list[str] | None = None,
-    category_selection: list[str] | None = None,
+    filter_selection: tuple[str, list[str]] | None = None,
 ) -> None:
     """Surface strategy/delivery-method filter mismatches; fail on an empty run.
 
@@ -1309,11 +1311,16 @@ def _check_filter_results(
     (``you asked for 'crescendo', the dataset uses 'Crescendo attack'``) rather
     than a bare "zero datapoints".
 
-    ``category_selection`` carries the explicit category/vulnerability selection
-    (``None`` when unset, ``[]`` when set to nothing) so a category filter that
-    empties the run hits the same guard as a delivery filter instead of exiting 0.
+    ``filter_selection`` carries the caller's *raw* category-or-vulnerability
+    selection as ``(argument_name, values)`` — ``None`` when they set neither,
+    ``('categories', [])`` when they set one to nothing — so a category filter
+    that empties the run hits the same guard as a delivery filter instead of
+    exiting 0. It must come from the raw arguments rather than the resolved
+    ones: an unfiltered run defaults those to the full category sweep, which
+    would make every no-filter run look like a filter that selected everything
+    and blame it for an empty run the caller never narrowed.
     """
-    if strategy_names is None and delivery_methods is None and category_selection is None:
+    if strategy_names is None and delivery_methods is None and filter_selection is None:
         return
 
     matched_names: set[str] = set()
@@ -1356,9 +1363,13 @@ def _check_filter_results(
         methods_repr = (
             sorted(delivery_method_str(m) for m in delivery_methods) if delivery_methods is not None else None
         )
+        # Report the selection under the argument name the caller actually used —
+        # merging category codes and vulnerability IDs into one `categories=` list
+        # would hand back a vocabulary they never typed.
+        selection_repr = f'{filter_selection[0]}={filter_selection[1]}, ' if filter_selection is not None else ''
         msg = (
             'Filter selection produced zero datapoints — nothing to run. '
-            f'(categories={category_selection}, strategies={names_repr}, delivery_methods={methods_repr})'
+            f'({selection_repr}strategies={names_repr}, delivery_methods={methods_repr})'
         )
         if present_methods:
             msg += f' Delivery methods present in the dataset: {present_methods}.'
@@ -1368,6 +1379,7 @@ def _check_filter_results(
 async def _prepare_target(
     *,
     target: str,
+    filter_selection: tuple[str, list[str]] | None = None,
     mode: Pipeline,
     categories: list[str] | None,
     resolved_vulns: list[Vulnerability] | None,
@@ -1578,7 +1590,7 @@ async def _prepare_target(
                 all_datapoints,
                 resolved_strategy_names,
                 resolved_delivery_methods,
-                category_selection=_category_selection(categories, resolved_vulns),
+                filter_selection=filter_selection,
             )
 
         # Build the static job via shared helper
@@ -1620,7 +1632,7 @@ async def _prepare_target(
                 all_datapoints,
                 resolved_strategy_names,
                 resolved_delivery_methods,
-                category_selection=_category_selection(categories, resolved_vulns),
+                filter_selection=filter_selection,
             )
 
         # Build the dynamic dispatcher job
@@ -1662,6 +1674,7 @@ async def _prepare_target(
 async def _run_dynamic_or_hybrid(
     *,
     targets: list[str],
+    filter_selection: tuple[str, list[str]] | None = None,
     agent_targets: list[AgentTarget] | None = None,
     mode: Pipeline,
     name: str | None = None,
@@ -2044,6 +2057,7 @@ async def _run_dynamic_or_hybrid(
     # Step 3: Prepare the first target fully — generates shared datapoints.
     common_prepare_kwargs: dict[str, Any] = dict(
         mode=mode,
+        filter_selection=filter_selection,
         categories=categories,
         resolved_vulns=resolved_vulns,
         max_turns=max_turns,
@@ -2335,7 +2349,7 @@ async def _run_dynamic_or_hybrid(
                     at_all_dps,
                     resolved_strategy_names,
                     resolved_delivery_methods,
-                    category_selection=_category_selection(categories, resolved_vulns),
+                    filter_selection=filter_selection,
                 )
 
             prepared_targets.append(
@@ -2745,6 +2759,7 @@ async def _run_dynamic_or_hybrid(
 async def _run_static(
     *,
     targets: list[str],
+    filter_selection: tuple[str, list[str]] | None = None,
     agent_targets: list[AgentTarget] | None = None,
     name: str | None = None,
     categories: list[str] | None,
@@ -2839,7 +2854,11 @@ async def _run_static(
         if resolved_delivery_methods is not None and not data:
             from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
 
-            present_rows = load_owasp_agentic_dataset(dataset=dataset, categories=categories)
+            # categories=None, not the resolved selection: this reload exists to report
+            # what the dataset carries, and `categories=[]` now filters to nothing — so
+            # reusing it would empty the diagnostic and hand back the bare "zero
+            # datapoints" error this hint was added to avoid.
+            present_rows = load_owasp_agentic_dataset(dataset=dataset, categories=None)
             present_methods = sorted({m for dp in present_rows if (m := dp.inputs.get('delivery_method'))})
         _check_filter_results(
             data,
@@ -2847,7 +2866,7 @@ async def _run_static(
             resolved_delivery_methods,
             names_apply=False,
             present_methods=present_methods,
-            category_selection=_category_selection(categories, None),
+            filter_selection=filter_selection,
         )
         _save_stage(output_dir, '01_datapoints.json', json.dumps([dp.inputs for dp in data], indent=2, default=str))
 

--- a/tests/redteam/e2e/test_dynamic_pipeline.py
+++ b/tests/redteam/e2e/test_dynamic_pipeline.py
@@ -116,3 +116,38 @@ async def test_dynamic_memory_cleanup(
         )
 
     assert len(mock_backend_bundle.cleaned_entity_ids) > 0, 'Expected memory cleanup to be called'
+
+
+# Covers the re-widening fix in `_run_dynamic_or_hybrid` — the expensive path, where
+# reading `categories=[]` as "no filter" meant a full category sweep against a live
+# attacker model. The static equivalent lives in test_static_pipeline.py.
+@pytest.mark.parametrize(
+    ('categories', 'vulnerabilities'),
+    [([], None), (None, [])],
+    ids=['categories', 'vulnerabilities'],
+)
+@pytest.mark.asyncio
+async def test_dynamic_empty_filter_hard_fails_instead_of_sweeping_everything(
+    categories: list[str] | None,
+    vulnerabilities: list[str] | None,
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+) -> None:
+    """An empty selection must not re-widen to every category on the dynamic path."""
+    from evaluatorq.redteam.exceptions import RedTeamError
+
+    with _dynamic_patches(mock_backend_bundle), pytest.raises(RedTeamError, match='zero datapoints') as exc:
+        await red_team(
+            'agent:e2e-test-agent',
+            mode='dynamic',
+            categories=categories,
+            vulnerabilities=vulnerabilities,
+            generate_strategies=False,
+            parallelism=2,
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+        )
+
+    # The error names the argument the caller actually passed, not a merged
+    # `categories=` list carrying vocabulary they never typed.
+    expected = 'categories=[]' if categories is not None else 'vulnerabilities=[]'
+    assert expected in str(exc.value)

--- a/tests/redteam/e2e/test_static_pipeline.py
+++ b/tests/redteam/e2e/test_static_pipeline.py
@@ -178,6 +178,48 @@ async def test_static_unknown_delivery_method_passes_through_and_hard_fails(
     assert "direct-request" in message  # what the dataset actually carries
 
 
+# `strategies` is deliberately absent: strategy-name selection does not apply to
+# static rows (they carry no strategy name), so static warns and ignores it —
+# empty or not. The planner-side behaviour is covered in test_method_selection.py.
+# Selections are passed as explicit keywords rather than `**{name: value}`:
+# dict unpacking erases every other red_team() parameter's type for
+# basedpyright, which CI runs over tests as well as src.
+@pytest.mark.parametrize(
+    ("categories", "vulnerabilities", "delivery_methods"),
+    [([], None, None), (None, [], None), (None, None, [])],
+    ids=["categories", "vulnerabilities", "delivery_methods"],
+)
+@pytest.mark.asyncio
+async def test_static_empty_filter_hard_fails_instead_of_running_everything(
+    categories: list[str] | None,
+    vulnerabilities: list[str] | None,
+    delivery_methods: list[str] | None,
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """An empty selection must never be read as "no filter" on any of the four filters.
+
+    Before this, the static loader tested truthiness, so `categories=[]` or
+    `delivery_methods=[]` skipped filtering and ran the whole dataset at full
+    cost, exit 0, no warning — the exact opposite of what the caller asked for,
+    and the opposite of what the planner did with the same input.
+    """
+    from evaluatorq.redteam.exceptions import RedTeamError
+
+    with _static_patches(mock_backend_bundle), pytest.raises(RedTeamError, match="zero datapoints"):
+        await red_team(
+            "agent:e2e-static-model",
+            mode="static",
+            parallelism=2,
+            dataset=str(static_dataset_path),
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+            categories=categories,
+            vulnerabilities=vulnerabilities,
+            delivery_methods=delivery_methods,
+        )
+
+
 @pytest.mark.asyncio
 async def test_static_datapoint_capping(
     mock_llm_client: DeterministicAsyncOpenAI,

--- a/tests/redteam/e2e/test_static_pipeline.py
+++ b/tests/redteam/e2e/test_static_pipeline.py
@@ -204,6 +204,10 @@ async def test_static_empty_filter_hard_fails_instead_of_running_everything(
     `delivery_methods=[]` skipped filtering and ran the whole dataset at full
     cost, exit 0, no warning — the exact opposite of what the caller asked for,
     and the opposite of what the planner did with the same input.
+
+    The `vulnerabilities=[]` case reaches static via `red_team` collapsing it to
+    `resolved_categories=[]` — `_run_static` has no `vulnerabilities` parameter —
+    so it pins that collapse rather than static-side vulnerability handling.
     """
     from evaluatorq.redteam.exceptions import RedTeamError
 
@@ -238,3 +242,37 @@ async def test_static_datapoint_capping(
         )
 
     assert report.total_results == 1
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_empty_run_does_not_blame_a_filter(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """An unfiltered run that yields zero datapoints must not accuse a filter.
+
+    Regression: the empty-run guard took its category selection from
+    `resolved_categories`, which `red_team` has already defaulted to the full
+    category sweep when the caller filtered nothing. That made the selection
+    non-None on *every* default run, defeating the guard's early return — so an
+    empty run caused by something else entirely (modelled here by a loader that
+    returns no rows) died with "Filter selection produced zero datapoints"
+    listing all 36 category codes the caller never asked for.
+    """
+    with (
+        _static_patches(mock_backend_bundle),
+        patch(
+            "evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge.load_owasp_agentic_dataset",
+            return_value=[],
+        ),
+    ):
+        report = await red_team(
+            "agent:e2e-static-model",
+            mode="static",
+            parallelism=2,
+            dataset=str(static_dataset_path),
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+        )
+
+    assert report.total_results == 0

--- a/tests/redteam/test_method_selection.py
+++ b/tests/redteam/test_method_selection.py
@@ -423,6 +423,36 @@ class TestBridgeDeliveryFilter:
         kept = _apply_filters(dps, delivery_methods=['crescendo'])
         assert [dp.inputs['delivery_method'] for dp in kept] == ['crescendo']
 
+    # Selections are passed positionally-by-keyword rather than via **kwargs
+    # unpacking: a `**{name: value}` call erases every other parameter's type
+    # for basedpyright, which CI runs over tests as well as src.
+    @pytest.mark.parametrize(
+        ('categories', 'delivery_methods'),
+        [([], None), (None, [])],
+        ids=['categories', 'delivery_methods'],
+    )
+    def test_empty_selection_matches_nothing_not_everything(
+        self, categories: list[str] | None, delivery_methods: list[str] | None
+    ) -> None:
+        """An empty list means "match nothing", never "match everything".
+
+        The loader used to test truthiness, so an empty selection skipped the
+        filter and the full sweep ran — while the planner tested `is None` and
+        dropped every strategy for the same input. The loader now agrees with
+        the planner, and the caller gets zero datapoints (which the runner turns
+        into a RedTeamError) instead of a silent full-cost run.
+        """
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('base64'), self._dp('crescendo')]
+        assert _apply_filters(dps, categories=categories, delivery_methods=delivery_methods) == []
+
+    def test_none_selection_still_disables_the_filter(self) -> None:
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('base64'), self._dp('crescendo')]
+        assert _apply_filters(dps, categories=None, delivery_methods=None) == dps
+
     def test_delivery_filter_runs_before_num_samples_cap(self) -> None:
         # Regression: the cap must apply to the FILTERED set, not slice first.
         # crescendo row is last; cap=2 would slice it off if filtering ran after.

--- a/tests/redteam/test_method_selection.py
+++ b/tests/redteam/test_method_selection.py
@@ -513,3 +513,17 @@ class TestBridgeDeliveryFilter:
         assert load_owasp_agentic_dataset(dataset=_FIXTURE, delivery_methods=['base64']) == []
         # No filter → all rows load.
         assert len(load_owasp_agentic_dataset(dataset=_FIXTURE)) == 3
+
+
+class TestEmptyRunGuardScope:
+    """The empty-run guard must fire only for filters the caller actually set."""
+
+    def test_empty_selection_still_raises_and_names_the_argument(self) -> None:
+        from evaluatorq.redteam.exceptions import RedTeamError
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        with pytest.raises(RedTeamError, match='zero datapoints') as exc:
+            _check_filter_results([], None, None, filter_selection=('vulnerabilities', []))
+        # Reported under the caller's own argument name, not a merged `categories=`.
+        assert 'vulnerabilities=[]' in str(exc.value)
+        assert 'categories=' not in str(exc.value)


### PR DESCRIPTION
Rebased onto `main` now that #94 is merged.

## Problem

`categories=[]`, `vulnerabilities=[]` and `delivery_methods=[]` were read as **"no filter"** on the static path (truthiness checks) while the planner read the same input as `is None` and dropped everything. Passing an empty selection ran the **whole dataset at full cost and exited 0** — the opposite of what the caller asked for, and inconsistent between the two consumers of the same argument.

`strategy_registry.filter_strategies` already documented the correct rule ("Empty set filters out everything"); this aligns the rest of the pipeline to it.

## Semantics after this PR

Uniform across all four filters:

| Value | Meaning |
|---|---|
| `None` (default) | no filtering |
| `[]` | a real selection that matches nothing → run is empty → `RedTeamError` |
| `[...]` | filter to those values |

An empty run now raises `RedTeamError` naming the filters responsible, e.g.
`Filter selection produced zero datapoints — nothing to run. (categories=[], strategies=None, delivery_methods=None)`.

## Changes

- **`evaluatorq_bridge.py`** — 4 truthiness checks → `is not None` in `load_owasp_agentic_dataset` / `_apply_filters`.
- **`runner.py`**
  - `_run_dynamic_or_hybrid` no longer re-widens `categories=[]` back to the full category sweep (`categories or list_available_categories()`).
  - `previous_run` conflict detection and the vulnerability/category resolution chain use `is not None`.
  - `_check_filter_results` now also fires on an empty category/vulnerability selection instead of returning early, and reports the selection in the error.
- **Not changed:** `strategies` in static mode. Static dataset rows carry no strategy name, so a strategy filter is warned-and-ignored there regardless of whether it is empty. Planner-side behaviour is unchanged and already correct.

## Review follow-up (2nd commit)

Both reviewers found the same real defect and I reproduced it: the guard's category selection was re-derived inside the run functions from `resolved_categories`, which is already defaulted to the full sweep on an unfiltered run — so `None` never happened, the early return never fired, and an empty run caused by anything else got blamed on a 36-code filter the caller never set. The selection is now snapshotted once in `red_team()` from the raw arguments and threaded down.

Also: the error reports the argument name the caller actually used (no more merged `categories=` carrying vulnerability IDs); the delivery-method diagnostic reload passes `categories=None` so `categories=[]` no longer suppresses the hint it exists to produce; the dynamic path (the expensive one) now has coverage; and the `red_team()` docstring notes the empty-list semantics are SDK-only, since `_split_csv` maps blank CLI input back to `None`.

## Why `feat:` and not a breaking change

No caller who passes `None` or a non-empty list sees any difference. The only behaviour that changes is the empty-list case, which previously produced a silently wrong (and expensive) run — it had no defensible contract to break.

## Tests

- `_apply_filters` unit level: empty selection → `[]`; `None` → unfiltered.
- Static e2e: `categories=[]`, `vulnerabilities=[]`, `delivery_methods=[]` each raise `RedTeamError`.
- Full suite green; `ruff check src`, `ruff format --check src`, `basedpyright src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

