### PR TITLE
fix(redteam): survive orq-ai-sdk drift and send a memory scope for agent targets (RES-1177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,46 @@ jobs:
 
       - name: Test (unit only)
         run: uv run pytest -m 'not integration'
+
+  resolve-sdk-matrix:
+    name: Resolve SDK matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      versions: ${{ steps.resolve.outputs.versions }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve SDK versions
+        id: resolve
+        run: |
+          versions="$(python scripts/sdk_matrix.py)"
+          echo "versions=${versions}" >> "$GITHUB_OUTPUT"
+
+  sdk-compat:
+    name: SDK compatibility
+    needs: resolve-sdk-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: ${{ fromJson(needs.resolve-sdk-matrix.outputs.versions) }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Install SDK version
+        run: uv pip install "orq-ai-sdk==${{ matrix.sdk }}"
+
+      - name: Test SDK compatibility
+        run: uv run --no-sync pytest tests/redteam/test_orq_backend_context.py tests/redteam/test_contracts.py

--- a/scripts/sdk_matrix.py
+++ b/scripts/sdk_matrix.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Resolve the three newest stable minor releases of the Orq AI SDK."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from typing import Any
+
+PYPI_URL = 'https://pypi.org/pypi/orq-ai-sdk/json'
+VERSION_PATTERN = re.compile(r'^(\d+)\.(\d+)\.(\d+)$')
+
+
+def _resolve_versions(payload: dict[str, Any]) -> list[str]:
+    """Return the newest patch for each of the three newest stable minors."""
+    releases = payload.get('releases')
+    if not isinstance(releases, dict):
+        raise TypeError('PyPI response does not contain a releases object')
+
+    newest_by_minor: dict[tuple[int, int], tuple[int, str]] = {}
+    for version in releases:
+        match = VERSION_PATTERN.fullmatch(version)
+        if match is None:
+            continue
+
+        major, minor, patch = (int(part) for part in match.groups())
+        minor_key = (major, minor)
+        current = newest_by_minor.get(minor_key)
+        if current is None or patch > current[0]:
+            newest_by_minor[minor_key] = (patch, version)
+
+    newest_minors = sorted(newest_by_minor, reverse=True)
+    if len(newest_minors) < 3:
+        raise ValueError(f'PyPI response contains only {len(newest_minors)} stable SDK minors; need at least 3')
+
+    return [newest_by_minor[minor][1] for minor in newest_minors[:3]]
+
+
+def _self_check() -> None:
+    """Check numeric sorting, patch selection, and pre-release filtering."""
+    sample_payload = {
+        'releases': {
+            '4.9.0': [],
+            '4.10.0': [],
+            '4.10.1': [],
+            '4.11.2': [],
+            '4.11.10': [],
+            '4.12.9': [],
+            '4.12.17': [],
+            '4.13.0rc3': [],
+        }
+    }
+    assert _resolve_versions(sample_payload) == ['4.12.17', '4.11.10', '4.10.1']  # noqa: S101
+
+
+def main() -> int:
+    _self_check()
+
+    try:
+        with urllib.request.urlopen(PYPI_URL, timeout=30) as response:
+            payload = json.load(response)
+    except (OSError, TimeoutError) as exc:
+        print(f'Error: failed to fetch {PYPI_URL}: {exc}', file=sys.stderr)
+        return 1
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        print(f'Error: received invalid JSON from {PYPI_URL}: {exc}', file=sys.stderr)
+        return 1
+
+    try:
+        if not isinstance(payload, dict):
+            raise TypeError('PyPI response is not a JSON object')
+        versions = _resolve_versions(payload)
+    except (TypeError, ValueError) as exc:
+        print(f'Error: could not resolve a stable SDK matrix: {exc}', file=sys.stderr)
+        return 1
+
+    print(json.dumps(versions, separators=(',', ':')))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -7,7 +7,7 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime  # noqa: TC003 — runtime-required by pydantic manifest models
-from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, TypeAlias
 
 from loguru import logger
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_serializer, model_validator
@@ -862,11 +862,60 @@ class KnowledgeBaseInfo(BaseModel):
     description: str | None = Field(default=None, description='Knowledge base description')
 
 
+def _coerce_text(value: Any) -> str | None:
+    """Normalize one provider-supplied text field to ``str | None``.
+
+    ``str`` passes through untouched. ``bool``/``int`` are stringified — a
+    wrong-typed but real value is worth more than a dropped one. Everything
+    else is treated as absent, which covers ``None`` and the SDK placeholder
+    objects (orq-ai-sdk parks ``Unset()`` in unset optional fields, so a
+    ``getattr(obj, name, None)`` default never fires and the sentinel reaches
+    us instead of ``None``).
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bool, int)):
+        return str(value)
+    return None
+
+
 class AgentContext(BaseModel):
     """Extended agent information for context-aware attacks.
 
     Describes the target agent's configuration and capabilities.
+
+    Text fields carry one of three gates, applied by ``_normalize_text_fields``:
+
+    * ``key`` — strict. Never coerced: it identifies *which* agent is under
+      attack, so a bad value must fail loudly rather than resolve to something
+      plausible.
+    * ``system_prompt`` / ``instructions`` — always a ``str``, empty when not
+      supplied. These two are *mutually exclusive*: agents carry
+      ``instructions``, deployments carry ``system_prompt``, and a given target
+      fills one and leaves the other empty. Neither is ever ``None``, so
+      consumers can read them without a ``None`` guard; the empty one simply
+      falls through an ``instructions or system_prompt`` chain. Both empty is
+      also valid — a bring-your-own target we cannot introspect.
+    * everything else — ``str | None``. Genuinely absent for some target kinds:
+      a direct/OpenAI target has no orq ``id`` or ``workspace_id``, a
+      bring-your-own ``AgentTarget`` has no ``display_name``/``description``/
+      ``model`` we can introspect.
     """
+
+    _REQUIRED_TEXT_FIELDS: ClassVar[tuple[str, ...]] = ('system_prompt', 'instructions')
+    _LITERAL_FIELDS: ClassVar[dict[str, frozenset[str]]] = {
+        'target_kind': frozenset({'agent', 'deployment', 'direct', 'openai'}),
+        'agent_type': frozenset({'internal', 'a2a'}),
+        'engine': frozenset({'text', 'jinja', 'mustache'}),
+    }
+    _OPTIONAL_TEXT_FIELDS: ClassVar[tuple[str, ...]] = (
+        'id',
+        'workspace_id',
+        'display_name',
+        'description',
+        'model',
+        'version',
+    )
 
     key: str = Field(description='Agent identifier key')
     id: str | None = Field(default=None, description='Entity UUID (orq agent/deployment id), for deep-linking')
@@ -877,12 +926,40 @@ class AgentContext(BaseModel):
     )
     display_name: str | None = Field(default=None, description='Agent display name')
     description: str | None = Field(default=None, description='Agent description')
-    system_prompt: str | None = Field(default=None, description='Agent system prompt (used by deployments)')
-    instructions: str | None = Field(default=None, description='Agent behavioral instructions')
+    system_prompt: str = Field(
+        default='',
+        description="Deployment system prompt; empty when not supplied. Exclusive with 'instructions'.",
+    )
+    instructions: str = Field(
+        default='',
+        description="Agent behavioral instructions; empty when not supplied. Exclusive with 'system_prompt'.",
+    )
     tools: list[ToolInfo] = Field(default_factory=list, description='Available tools')
     memory_stores: list[MemoryStoreInfo] = Field(default_factory=list, description='Memory stores')
     knowledge_bases: list[KnowledgeBaseInfo] = Field(default_factory=list, description='Knowledge bases')
     model: str | None = Field(default=None, description='Primary model')
+    version: str | None = Field(
+        default=None,
+        description=(
+            'Target configuration version at scan time, for reproducibility: results only '
+            'describe the config that was attacked. None when the provider does not expose one.'
+        ),
+    )
+    skills: list[str] = Field(
+        default_factory=list,
+        description='Skill keys attached to the agent — a capability surface alongside tools',
+    )
+    agent_type: Literal['internal', 'a2a'] | None = Field(
+        default=None,
+        description=(
+            "Provider-declared agent type: 'a2a' agents delegate to other agents. Distinct from "
+            "'target_kind', which records how *we* reach the target. None when not exposed."
+        ),
+    )
+    engine: Literal['text', 'jinja', 'mustache'] | None = Field(
+        default=None,
+        description='Prompt template engine; a templated agent has a different injection surface than plain text',
+    )
     is_multi_agent: bool = Field(
         default=False,
         description=(
@@ -893,6 +970,42 @@ class AgentContext(BaseModel):
             'Defaults to False (conservative: do not run multi-agent attacks unless confirmed).'
         ),
     )
+
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_text_fields(cls, data: Any) -> Any:
+        """Coerce provider-supplied text fields before validation.
+
+        Context retrieval is enrichment — it feeds tool and memory-store names
+        into attack-strategy prompts — so a metadata field of the wrong type
+        must not be able to fail the whole run. ``key`` is deliberately left
+        out: it is identity, not metadata.
+
+        The required-text fields are normalized independently, never against
+        each other: ``system_prompt`` and ``instructions`` are mutually
+        exclusive, so a target supplying one and omitting the other is the
+        normal case and must not be treated as missing data.
+        """
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        for name in cls._OPTIONAL_TEXT_FIELDS:
+            if name in data:
+                data[name] = _coerce_text(data[name])
+        for name in cls._REQUIRED_TEXT_FIELDS:
+            if name in data:
+                data[name] = _coerce_text(data[name]) or ''
+        for name, allowed in cls._LITERAL_FIELDS.items():
+            if name in data:
+                value = data[name]
+                # Unknown members are dropped rather than raised on: providers add
+                # enum values faster than we can follow, and an unrecognized one is
+                # not worth failing an entire scan over.
+                data[name] = value if isinstance(value, str) and value in allowed else None
+        if 'skills' in data:
+            value = data['skills']
+            data['skills'] = [s for s in value if isinstance(s, str)] if isinstance(value, list) else []
+        return data
 
     @property
     def has_tools(self) -> bool:

--- a/src/evaluatorq/dashboard/report_tabs.py
+++ b/src/evaluatorq/dashboard/report_tabs.py
@@ -1819,8 +1819,10 @@ def _rt_agent_card(
     ctx = agent_ctx or {}
     display_name = ctx.get('display_name') or stats.get('display_name') or key
     model = ctx.get('model') or stats.get('model') or ''
+    version = ctx.get('version') or ''
     description = ctx.get('description') or ''
     tools = ctx.get('tools') or []
+    skills = ctx.get('skills') or []
     knowledge_bases = ctx.get('knowledge_bases') or []
 
     # Optional Studio deep-link — only for orq agent/deployment targets that
@@ -1848,7 +1850,9 @@ def _rt_agent_card(
     dial_html = dial(pct(asr), asr, radius=24, stroke=6, color=dial_color, sub='ASR')
 
     critical_chip = f'<span class="rt-agent-card-critical">{critical} critical</span>' if critical else ''
-    model_html = f'<div class="rt-agent-card-model">{esc(model)}</div>' if model else ''
+    # Version rides the model line: it answers "what exactly did we attack".
+    model_line = ' · '.join(p for p in (esc(model), f'v{esc(version)}' if version else '') if p)
+    model_html = f'<div class="rt-agent-card-model">{model_line}</div>' if model_line else ''
     description_html = f'<div class="rt-agent-card-desc">{esc(description)}</div>' if description else ''
 
     critical_style = 'color:var(--red-600)' if critical else ''
@@ -1866,7 +1870,11 @@ def _rt_agent_card(
         '</div>'
     )
 
-    chips_html = _rt_agent_card_chip_row('TOOLS', tools) + _rt_agent_card_chip_row('KNOWLEDGE', knowledge_bases)
+    chips_html = (
+        _rt_agent_card_chip_row('TOOLS', tools)
+        + _rt_agent_card_chip_row('SKILLS', skills)
+        + _rt_agent_card_chip_row('KNOWLEDGE', knowledge_bases)
+    )
 
     return (
         '<div class="rk-panel rt-agent-card">'

--- a/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -229,7 +229,7 @@ class OpenAIAgentTarget(AgentTarget):
             key=key,
             display_name=key,
             description='OpenAI Agents SDK target',
-            system_prompt=system_prompt,
+            system_prompt=system_prompt or '',
             tools=tools,
             model=model,
         )

--- a/src/evaluatorq/openresponses/target.py
+++ b/src/evaluatorq/openresponses/target.py
@@ -140,6 +140,10 @@ class OrqResponsesTarget(AgentTarget):
             # tag the request with the evaluatorq pipeline so its trace is
             # attributable to the run type. Both ride in the request body.
             body_extra = {**thread_body_param(), **pipeline_metadata_param()}
+            # Agents with memory tools reject the call outright without a memory
+            # scope ("memory_entity_id_required"), so forward ours when set.
+            if self.memory_entity_id:
+                body_extra['memory'] = {'entity_id': self.memory_entity_id}
             if body_extra:
                 kwargs['extra_body'] = {**kwargs.get('extra_body', {}), **body_extra}
 

--- a/src/evaluatorq/redteam/backends/base.py
+++ b/src/evaluatorq/redteam/backends/base.py
@@ -9,6 +9,7 @@ independently.
 
 from __future__ import annotations
 
+import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -145,7 +146,13 @@ class HybridAgentBackend(Backend):
         """Delegate to exec backend with ``agent/`` prefix for OrqResponses routing."""
         # Strip any existing prefix first so an already-prefixed key does not become
         # ``agent/agent/<key>``.
-        return self._exec.create_target(f'agent/{agent_key.removeprefix("agent/")}')
+        target = self._exec.create_target(f'agent/{agent_key.removeprefix("agent/")}')
+        # Hosted agents with memory tools reject calls that carry no memory scope.
+        # Mint one per target, matching ORQAgentTarget, so parallel jobs stay
+        # isolated and cleanup_memory has an id to delete.
+        if getattr(target, 'memory_entity_id', 'unset') is None:
+            target.memory_entity_id = f'red-team-{uuid.uuid4().hex[:12]}'
+        return target
 
     async def resolve_context(self, agent_key: str) -> AgentContext:
         """Delegate context resolution to the ORQ SDK backend (has its own cache)."""

--- a/src/evaluatorq/redteam/backends/base.py
+++ b/src/evaluatorq/redteam/backends/base.py
@@ -13,13 +13,15 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from loguru import logger
+from pydantic import ValidationError
 
 from evaluatorq.common.target_call import _coerce_to_agent_response as _coerce_to_agent_response
+from evaluatorq.contracts import AgentContext
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from evaluatorq.contracts import AgentContext, AgentTarget
+    from evaluatorq.contracts import AgentTarget
 
 
 def validate_agent_target(obj: object) -> None:
@@ -75,7 +77,21 @@ class Backend(ABC):
         if agent_key in self._ctx_cache:
             return self._ctx_cache[agent_key]
         probe = self.create_target(agent_key)
-        ctx = await probe.get_agent_context()
+        try:
+            ctx = await probe.get_agent_context()
+        except ValidationError as e:
+            # Context is enrichment (tool / memory-store / KB names for attack
+            # prompts), not a prerequisite for attacking. Degrade to a minimal
+            # context so provider metadata we cannot model never kills a run.
+            #
+            # Only ValidationError is caught, deliberately: an unreachable agent
+            # (bad ORQ_API_KEY, wrong ORQ_BASE_URL, 404 on the key) must still
+            # fail loudly — silently red-teaming nothing is worse than crashing.
+            logger.warning(
+                f'Could not model agent context for {agent_key}: {e} — '
+                'continuing with minimal context; attack strategies will use limited context'
+            )
+            ctx = AgentContext(key=agent_key)
         self._ctx_cache[agent_key] = ctx
         return ctx
 

--- a/src/evaluatorq/redteam/backends/openresponses.py
+++ b/src/evaluatorq/redteam/backends/openresponses.py
@@ -96,7 +96,7 @@ class OpenResponsesBackend(Backend):
             key=agent_key,
             display_name=agent_key,
             description='OpenResponses agent target',
-            system_prompt=self._instructions,
+            system_prompt=self._instructions or '',
             model=agent_key,
         )
         self._ctx_cache[agent_key] = ctx

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -394,15 +394,18 @@ class ORQAgentTarget(AgentTarget):
         )
 
         settings = getattr(agent_data, 'settings', None)
-        raw_tools = list(settings.tools) if settings and getattr(settings, 'tools', None) else []
+        raw_tools_value = getattr(settings, 'tools', None) if settings is not None else None
+        raw_tools = raw_tools_value if isinstance(raw_tools_value, list) else []
 
         raw_kb_ids: list[str] = []
-        if hasattr(agent_data, 'knowledge_bases') and agent_data.knowledge_bases:
-            raw_kb_ids = [getattr(kb, 'knowledge_id', None) or str(kb) for kb in agent_data.knowledge_bases]
+        raw_kbs = getattr(agent_data, 'knowledge_bases', None)
+        if isinstance(raw_kbs, list):
+            raw_kb_ids = [getattr(kb, 'knowledge_id', None) or str(kb) for kb in raw_kbs]
 
         raw_ms_ids: list[str] = []
-        if hasattr(agent_data, 'memory_stores') and agent_data.memory_stores:
-            raw_ms_ids = [ms if isinstance(ms, str) else getattr(ms, 'key', str(ms)) for ms in agent_data.memory_stores]
+        raw_memory_stores = getattr(agent_data, 'memory_stores', None)
+        if isinstance(raw_memory_stores, list):
+            raw_ms_ids = [ms if isinstance(ms, str) else getattr(ms, 'key', str(ms)) for ms in raw_memory_stores]
 
         enrichment_tasks: list[Any] = [self._enrich_knowledge_base(kb_id) for kb_id in raw_kb_ids]
         enrichment_tasks.extend(self._enrich_memory_store(ms_id) for ms_id in raw_ms_ids)
@@ -416,19 +419,36 @@ class ORQAgentTarget(AgentTarget):
         model_raw = getattr(agent_data, 'model', None)
         model_id = getattr(model_raw, 'id', None) if model_raw is not None else None
 
+        # orq-ai-sdk 4.12.x exposes `version`; 4.4.x exposed `version_hash`. Select by
+        # type, not truthiness: an unset SDK field holds a truthy `Unset()` sentinel, so
+        # an `or` chain would latch onto it and never reach the fallback.
+        version = getattr(agent_data, 'version', None)
+        if not isinstance(version, str):
+            version = getattr(agent_data, 'version_hash', None)
+
+        system_prompt: Any = getattr(agent_data, 'system_prompt', None)
+        instructions: Any = getattr(agent_data, 'instructions', None)
+        skills: Any = getattr(agent_data, 'skills', None)
         self._cached_context = AgentContext(
             key=self.agent_key,
             id=getattr(agent_data, 'id', None),
+            # Dropped from the agent-retrieve model in orq-ai-sdk 4.12.x — None here is
+            # expected upstream drift, not a local bug.
             workspace_id=getattr(agent_data, 'workspace_id', None),
             target_kind='agent',
             display_name=getattr(agent_data, 'display_name', None),
             description=getattr(agent_data, 'description', None),
-            system_prompt=getattr(agent_data, 'system_prompt', None),
-            instructions=getattr(agent_data, 'instructions', None),
+            system_prompt=system_prompt,
+            instructions=instructions,
             tools=tools,
             memory_stores=memory_stores,
             knowledge_bases=knowledge_bases,
             model=model_id,
+            version=version,
+            skills=skills,
+            # The SDK calls it `type`; `target_kind` already owns that name here.
+            agent_type=getattr(agent_data, 'type', None),
+            engine=getattr(agent_data, 'engine', None),
         )
         return self._cached_context
 

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -421,10 +421,17 @@ class ORQAgentTarget(AgentTarget):
 
         # orq-ai-sdk 4.12.x exposes `version`; 4.4.x exposed `version_hash`. Select by
         # type, not truthiness: an unset SDK field holds a truthy `Unset()` sentinel, so
-        # an `or` chain would latch onto it and never reach the fallback.
-        version = getattr(agent_data, 'version', None)
-        if not isinstance(version, str):
-            version = getattr(agent_data, 'version_hash', None)
+        # an `or` chain would latch onto it and never reach the fallback. Empty counts as
+        # absent — live 4.4.x agents carry `version_hash=''`, and reporting that as a
+        # version would disagree with the same agent read through a newer SDK.
+        version = next(
+            (
+                candidate
+                for candidate in (getattr(agent_data, 'version', None), getattr(agent_data, 'version_hash', None))
+                if isinstance(candidate, str) and candidate
+            ),
+            None,
+        )
 
         system_prompt: Any = getattr(agent_data, 'system_prompt', None)
         instructions: Any = getattr(agent_data, 'instructions', None)

--- a/src/evaluatorq/redteam/reports/export_html.py
+++ b/src/evaluatorq/redteam/reports/export_html.py
@@ -730,8 +730,10 @@ def _render_agent_context_html(section: ReportSection) -> str:
     for agent in agents:
         display_name = _esc(agent.get('display_name') or agent.get('key', 'unknown'))
         model = _esc(agent.get('model', ''))
+        version = _esc(agent.get('version') or '')
         description = _esc(agent.get('description', ''))
         tools: list[str] = agent.get('tools', [])
+        skills: list[str] = agent.get('skills') or []
         memory_stores: list[str] = agent.get('memory_stores', [])
         knowledge_bases: list[str] = agent.get('knowledge_bases', [])
 
@@ -740,7 +742,13 @@ def _render_agent_context_html(section: ReportSection) -> str:
             f'<h3>{display_name}</h3>',
         ]
         if model:
-            card_lines.append(f'<p class="meta"><strong>Model:</strong> {model}</p>')
+            meta = f'<strong>Model:</strong> {model}'
+            # Version rides the model line rather than claiming a row of its own.
+            if version:
+                meta += f' &middot; <strong>Version:</strong> {version}'
+            card_lines.append(f'<p class="meta">{meta}</p>')
+        elif version:
+            card_lines.append(f'<p class="meta"><strong>Version:</strong> {version}</p>')
         if description:
             card_lines.append(f'<p>{description}</p>')
 
@@ -754,6 +762,14 @@ def _render_agent_context_html(section: ReportSection) -> str:
                 for t in tools
             )
             chip_groups.append(f'<p><strong>Tools:</strong> {tool_chips}</p>')
+        if skills:
+            skill_chips = ''.join(
+                f'<span style="display:inline-block;background:var(--clay-tint);border:1px solid var(--clay);'
+                f'border-radius:12px;padding:.15rem .6rem;font-size:.8em;margin:.15rem .15rem .15rem 0">'
+                f'{_esc(s)}</span>'
+                for s in skills
+            )
+            chip_groups.append(f'<p><strong>Skills:</strong> {skill_chips}</p>')
         if memory_stores:
             mem_chips = ''.join(
                 f'<span style="display:inline-block;background:var(--olive-tint);border:1px solid var(--olive);'

--- a/src/evaluatorq/redteam/reports/export_md.py
+++ b/src/evaluatorq/redteam/reports/export_md.py
@@ -155,18 +155,24 @@ def _render_agent_context_section(section: ReportSection) -> str:
     for agent in agents:
         display_name = agent.get('display_name') or agent.get('key', 'unknown')
         model = agent.get('model', '')
+        version = agent.get('version') or ''
         description = agent.get('description', '')
         tools: list[str] = agent.get('tools', [])
+        skills: list[str] = agent.get('skills') or []
         memory_stores: list[str] = agent.get('memory_stores', [])
         knowledge_bases: list[str] = agent.get('knowledge_bases', [])
 
         lines.extend((f'### {display_name}', ''))
         if model:
             lines.append(f'**Model:** {model}  ')
+        if version:
+            lines.append(f'**Version:** {version}  ')
         if description:
             lines.append(f'**Description:** {description}  ')
         if tools:
             lines.append(f'**Tools:** {", ".join(tools)}  ')
+        if skills:
+            lines.append(f'**Skills:** {", ".join(skills)}  ')
         if memory_stores:
             lines.append(f'**Memory:** {", ".join(memory_stores)}  ')
         if knowledge_bases:

--- a/src/evaluatorq/redteam/reports/sections.py
+++ b/src/evaluatorq/redteam/reports/sections.py
@@ -638,18 +638,32 @@ def _build_agent_context_section(report: RedTeamReport) -> ReportSection | None:
                 'tools': [t.name for t in ctx.tools],
                 'memory_stores': [ms.key or ms.id for ms in ctx.memory_stores],
                 'knowledge_bases': [kb.name or kb.key or kb.id for kb in ctx.knowledge_bases],
+                # Config identity at scan time: results only describe what was attacked.
+                'version': ctx.version,
+                'skills': list(ctx.skills),
+                # Carried for downstream consumers; not rendered yet.
+                'agent_type': ctx.agent_type,
+                'engine': ctx.engine,
             })
     elif report.tested_agents:
-        # Minimal stubs — no detailed AgentContext available
+        # Minimal stubs — no detailed AgentContext available. Same key set as the
+        # branch above, so renderers can read every field without existence checks.
         agents.extend(
             {
                 'key': agent_key,
+                'id': None,
+                'workspace_id': None,
+                'target_kind': None,
                 'display_name': agent_key,
                 'model': '',
                 'description': '',
                 'tools': [],
                 'memory_stores': [],
                 'knowledge_bases': [],
+                'version': None,
+                'skills': [],
+                'agent_type': None,
+                'engine': None,
             }
             for agent_key in sorted(set(report.tested_agents))
         )

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -34,9 +34,13 @@ class AgentInfoSnapshot(TypedDict, total=False):
     description: str | None
     model: str | None
     tools: list[str]
+    skills: list[str]
     knowledge_bases: list[str]
     memory_stores: list[str]
     sub_agents: list[str]
+    version: str | None
+    agent_type: str | None
+    engine: str | None
     workspace_id: str | None
     workspace_key: str | None
     base_url: str

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -23,6 +23,7 @@ from typing import Any
 from evaluatorq.common.llm_client import orq_base_url as _orq_base_url
 from evaluatorq.common.replay import REPLAY_VERSION
 from evaluatorq.common.run_store_dir import get_store_dir
+from evaluatorq.contracts import _coerce_text
 from evaluatorq.simulation.types import AgentInfoSnapshot, SimulationRun
 
 logger = logging.getLogger(__name__)
@@ -47,48 +48,84 @@ async def fetch_agent_info(agent_key: str) -> AgentInfoSnapshot | None:
         orq_client = setup_orq_client(api_key)
         agent_data = await asyncio.to_thread(orq_client.agents.retrieve, agent_key=agent_key)
 
-        agent_id = getattr(agent_data, '_id', None) or getattr(agent_data, 'id', None)
+        agent_id = _coerce_text(getattr(agent_data, '_id', None))
+        if agent_id is None:
+            agent_id = _coerce_text(getattr(agent_data, 'id', None))
         model = getattr(agent_data, 'model', None)
-        model_id = getattr(model, 'id', None) if model is not None else None
+        model_id = _coerce_text(getattr(model, 'id', None)) if model is not None else None
 
         # Entries with no resolvable name are dropped rather than persisted as
         # None (the card would render them as literal "None" chips).
         settings = getattr(agent_data, 'settings', None)
         raw_tools = getattr(settings, 'tools', None) if settings is not None else None
-        tools = [n for t in raw_tools or [] if (n := getattr(t, 'display_name', None) or getattr(t, 'key', None))]
+        tools = []
+        if isinstance(raw_tools, list):
+            for tool in raw_tools:
+                name = _coerce_text(getattr(tool, 'display_name', None)) or _coerce_text(getattr(tool, 'key', None))
+                if name is not None:
+                    tools.append(name)
 
-        raw_kbs = getattr(agent_data, 'knowledge_bases', None) or []
-        knowledge_bases = [
-            n for kb in raw_kbs if (n := kb if isinstance(kb, str) else getattr(kb, 'knowledge_id', None))
-        ]
+        raw_kbs = getattr(agent_data, 'knowledge_bases', None)
+        knowledge_bases = []
+        if isinstance(raw_kbs, list):
+            for kb in raw_kbs:
+                name = _coerce_text(kb if isinstance(kb, str) else getattr(kb, 'knowledge_id', None))
+                if name is not None:
+                    knowledge_bases.append(name)
 
-        raw_stores = getattr(agent_data, 'memory_stores', None) or []
-        memory_stores = [n for ms in raw_stores if (n := ms if isinstance(ms, str) else getattr(ms, 'key', None))]
+        raw_stores = getattr(agent_data, 'memory_stores', None)
+        memory_stores = []
+        if isinstance(raw_stores, list):
+            for store in raw_stores:
+                name = _coerce_text(store if isinstance(store, str) else getattr(store, 'key', None))
+                if name is not None:
+                    memory_stores.append(name)
 
-        raw_sub_agents = getattr(agent_data, 'team_of_agents', None) or []
-        sub_agents = [
-            n for a in raw_sub_agents if (n := a.get('key') if isinstance(a, dict) else getattr(a, 'key', None))
-        ]
+        raw_sub_agents = getattr(agent_data, 'team_of_agents', None)
+        sub_agents = []
+        if isinstance(raw_sub_agents, list):
+            for sub_agent in raw_sub_agents:
+                name = _coerce_text(
+                    sub_agent.get('key') if isinstance(sub_agent, dict) else getattr(sub_agent, 'key', None)
+                )
+                if name is not None:
+                    sub_agents.append(name)
+
+        # Unset optional SDK fields hold a truthy `Unset()` placeholder rather than
+        # None. This snapshot is a plain TypedDict with no validator between it and
+        # `model_dump_json()`, so a placeholder reaching it would break the save.
+        # orq-ai-sdk 4.12.x renamed `version_hash` to `version`; pick by type, since
+        # the placeholder would satisfy an `or` chain.
+        version = getattr(agent_data, 'version', None)
+        if not isinstance(version, str):
+            version = getattr(agent_data, 'version_hash', None)
+        raw_skills = getattr(agent_data, 'skills', None)
+        skills = [s for s in raw_skills if isinstance(s, str)] if isinstance(raw_skills, list) else []
 
         from evaluatorq.dashboard.orq_links import orq_studio_url, studio_workspace_key
 
-        workspace_id = getattr(agent_data, 'workspace_id', None)
-        # Entity APIs expose workspace_id (a UUID). Studio links instead use
-        # the configured ORQ_WORKSPACE key, captured here for future reports.
-        workspace_key = studio_workspace_key(getattr(agent_data, 'workspace_key', None))
+        workspace_id = _coerce_text(getattr(agent_data, 'workspace_id', None))
+        # Entity APIs expose workspace_id (a UUID), which Studio routes reject; links
+        # use the configured ORQ_WORKSPACE key instead. The agent payload has never
+        # carried a workspace_key on any SDK version — do not re-add a fallback arg.
+        workspace_key = studio_workspace_key()
         base_url = os.getenv('ORQ_BASE_URL', 'https://my.orq.ai').rstrip('/')
         url = orq_studio_url(target_kind='agent', entity_id=agent_id, workspace_id=workspace_key, base_url=base_url)
 
         return {
             'key': agent_key,
             'id': agent_id,
-            'role': getattr(agent_data, 'role', None),
-            'description': getattr(agent_data, 'description', None),
+            'role': _coerce_text(getattr(agent_data, 'role', None)),
+            'description': _coerce_text(getattr(agent_data, 'description', None)),
             'model': model_id,
+            'version': _coerce_text(version),
             'tools': tools,
+            'skills': skills,
             'knowledge_bases': knowledge_bases,
             'memory_stores': memory_stores,
             'sub_agents': sub_agents,
+            'agent_type': _coerce_text(getattr(agent_data, 'type', None)),
+            'engine': _coerce_text(getattr(agent_data, 'engine', None)),
             'workspace_id': workspace_id,
             'workspace_key': workspace_key,
             'base_url': base_url,

--- a/src/evaluatorq/simulation/utils/run_store.py
+++ b/src/evaluatorq/simulation/utils/run_store.py
@@ -95,10 +95,16 @@ async def fetch_agent_info(agent_key: str) -> AgentInfoSnapshot | None:
         # None. This snapshot is a plain TypedDict with no validator between it and
         # `model_dump_json()`, so a placeholder reaching it would break the save.
         # orq-ai-sdk 4.12.x renamed `version_hash` to `version`; pick by type, since
-        # the placeholder would satisfy an `or` chain.
-        version = getattr(agent_data, 'version', None)
-        if not isinstance(version, str):
-            version = getattr(agent_data, 'version_hash', None)
+        # the placeholder would satisfy an `or` chain. Empty counts as absent — live
+        # 4.4.x agents carry `version_hash=''`.
+        version = next(
+            (
+                candidate
+                for candidate in (getattr(agent_data, 'version', None), getattr(agent_data, 'version_hash', None))
+                if isinstance(candidate, str) and candidate
+            ),
+            None,
+        )
         raw_skills = getattr(agent_data, 'skills', None)
         skills = [s for s in raw_skills if isinstance(s, str)] if isinstance(raw_skills, list) else []
 

--- a/tests/redteam/reports/test_rebuild_filtered.py
+++ b/tests/redteam/reports/test_rebuild_filtered.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from evaluatorq.contracts import AgentContext
 from evaluatorq.redteam.contracts import (
     AgentInfo,
     AttackInfo,
@@ -19,7 +20,7 @@ from evaluatorq.redteam.contracts import (
     UnifiedEvaluationResult,
 )
 from evaluatorq.redteam.reports.converters import compute_report_summary, rebuild_filtered_report
-from evaluatorq.redteam.reports.sections import build_report_sections
+from evaluatorq.redteam.reports.sections import _build_agent_context_section, build_report_sections
 
 
 def _make_result(
@@ -134,3 +135,20 @@ def test_multi_target_structure_preserved_after_rebuild() -> None:
     kinds = {s.kind for s in build_report_sections(rebuilt)}
     assert 'agent_comparison' in kinds
     assert 'agent_disagreements' in kinds
+
+
+def test_agent_context_section_has_the_same_keys_for_rich_and_minimal_reports() -> None:
+    results = [_make_result(agent_key='agent-a')]
+    rich_report = _make_report(results, tested_agents=[]).model_copy(
+        update={'agent_contexts': {'agent-a': AgentContext(key='agent-a')}}
+    )
+    minimal_report = _make_report(results, tested_agents=['agent-a'])
+
+    rich_section = _build_agent_context_section(rich_report)
+    minimal_section = _build_agent_context_section(minimal_report)
+
+    assert rich_section is not None
+    assert minimal_section is not None
+    rich_keys = set(rich_section.data['agents'][0].keys())
+    minimal_keys = set(minimal_section.data['agents'][0].keys())
+    assert rich_keys == minimal_keys

--- a/tests/redteam/test_contracts.py
+++ b/tests/redteam/test_contracts.py
@@ -12,6 +12,7 @@ from evaluatorq.contracts import (
     TextOutputItem,
     ToolCallOutputItem,
 )
+from evaluatorq.dashboard.library import load_model_cached
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AttackInfo,
@@ -28,7 +29,7 @@ from evaluatorq.redteam.contracts import (
     normalize_framework,
 )
 
-FIXTURES_DIR = Path(__file__).parent / "fixtures"
+FIXTURES_DIR = Path(__file__).parent / 'fixtures'
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +39,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 def _load_fixture(name: str) -> dict[str, Any]:
     path = FIXTURES_DIR / name
-    assert path.exists(), f"Fixture not found: {path}"
+    assert path.exists(), f'Fixture not found: {path}'
     return json.loads(path.read_text())
 
 
@@ -49,36 +50,36 @@ def _load_fixture(name: str) -> dict[str, Any]:
 
 class TestNormalizeCategory:
     def test_strips_owasp_prefix(self) -> None:
-        assert normalize_category("OWASP-ASI01") == "ASI01"
+        assert normalize_category('OWASP-ASI01') == 'ASI01'
 
     def test_no_prefix_unchanged(self) -> None:
-        assert normalize_category("ASI01") == "ASI01"
+        assert normalize_category('ASI01') == 'ASI01'
 
     def test_llm_prefix(self) -> None:
-        assert normalize_category("OWASP-LLM01") == "LLM01"
+        assert normalize_category('OWASP-LLM01') == 'LLM01'
 
 
 class TestInferFramework:
     def test_asi_category(self) -> None:
-        assert infer_framework("ASI01") == "OWASP-ASI"
+        assert infer_framework('ASI01') == 'OWASP-ASI'
 
     def test_llm_category(self) -> None:
-        assert infer_framework("LLM07") == "OWASP-LLM"
+        assert infer_framework('LLM07') == 'OWASP-LLM'
 
     def test_owasp_prefixed(self) -> None:
-        assert infer_framework("OWASP-ASI05") == "OWASP-ASI"
+        assert infer_framework('OWASP-ASI05') == 'OWASP-ASI'
 
     def test_unknown(self) -> None:
-        assert infer_framework("CUSTOM01") == "unknown"
+        assert infer_framework('CUSTOM01') == 'unknown'
 
 
 class TestNormalizeFramework:
     def test_agentic_alias(self) -> None:
-        result = normalize_framework("OWASP-AGENTIC")
+        result = normalize_framework('OWASP-AGENTIC')
         assert result == Framework.OWASP_ASI
 
     def test_direct_value(self) -> None:
-        result = normalize_framework("OWASP-LLM")
+        result = normalize_framework('OWASP-LLM')
         assert result == Framework.OWASP_LLM
 
 
@@ -90,30 +91,39 @@ class TestNormalizeFramework:
 class TestDynamicFixture:
     @pytest.fixture()
     def dynamic_report_data(self) -> dict[str, Any]:
-        return _load_fixture("dynamic_report.json")
+        return _load_fixture('dynamic_report.json')
 
     def test_parses_as_report(self, dynamic_report_data: dict[str, Any]) -> None:
         report = RedTeamReport.model_validate(dynamic_report_data)
-        assert report.pipeline == "dynamic"
-        assert report.version == "2.0.0"
-        assert len(report.results) == dynamic_report_data["total_results"]
+        assert report.pipeline == 'dynamic'
+        assert report.version == '2.0.0'
+        assert len(report.results) == dynamic_report_data['total_results']
 
     def test_agent_context_present(self, dynamic_report_data: dict[str, Any]) -> None:
         report = RedTeamReport.model_validate(dynamic_report_data)
         assert report.agent_contexts
-        ctx = report.agent_contexts["domain-search-assistant"]
+        ctx = report.agent_contexts['domain-search-assistant']
         assert isinstance(ctx, AgentContext)
-        assert ctx.key == "domain-search-assistant"
+        assert ctx.key == 'domain-search-assistant'
         assert ctx.has_tools
         assert ctx.has_memory
+
+    def test_legacy_fixture_uses_defaults_for_new_agent_context_fields(self) -> None:
+        report = load_model_cached(FIXTURES_DIR / 'dynamic_report.json', RedTeamReport.model_validate)
+        ctx = report.agent_contexts['domain-search-assistant']
+
+        assert ctx.version is None
+        assert ctx.skills == []
+        assert ctx.agent_type is None
+        assert ctx.engine is None
 
     def test_result_attack_info(self, dynamic_report_data: dict[str, Any]) -> None:
         report = RedTeamReport.model_validate(dynamic_report_data)
         for result in report.results:
             assert isinstance(result, RedTeamResult)
             assert isinstance(result.attack, AttackInfo)
-            assert result.attack.category in ("ASI01", "ASI05", "ASI06", "LLM01", "LLM02")
-            assert result.attack.framework in ("OWASP-ASI", "OWASP-LLM")
+            assert result.attack.category in ('ASI01', 'ASI05', 'ASI06', 'LLM01', 'LLM02')
+            assert result.attack.framework in ('OWASP-ASI', 'OWASP-LLM')
 
     def test_evaluation_semantics(self, dynamic_report_data: dict[str, Any]) -> None:
         """passed=True means RESISTANT, passed=False means VULNERABLE."""
@@ -128,8 +138,8 @@ class TestDynamicFixture:
         report = RedTeamReport.model_validate(dynamic_report_data)
         has_vuln = any(r.vulnerable for r in report.results)
         has_resistant = any(not r.vulnerable for r in report.results)
-        assert has_vuln, "Fixture should have at least one vulnerable result"
-        assert has_resistant, "Fixture should have at least one resistant result"
+        assert has_vuln, 'Fixture should have at least one vulnerable result'
+        assert has_resistant, 'Fixture should have at least one resistant result'
 
     def test_round_trip_serialization(self, dynamic_report_data: dict[str, Any]) -> None:
         report = RedTeamReport.model_validate(dynamic_report_data)
@@ -150,11 +160,11 @@ class TestDynamicFixture:
 class TestHybridFixture:
     @pytest.fixture()
     def hybrid_report_data(self) -> dict[str, Any]:
-        return _load_fixture("hybrid_report.json")
+        return _load_fixture('hybrid_report.json')
 
     def test_parses_as_report(self, hybrid_report_data: dict[str, Any]) -> None:
         report = RedTeamReport.model_validate(hybrid_report_data)
-        assert report.pipeline == "hybrid"
+        assert report.pipeline == 'hybrid'
         assert len(report.results) > 0
 
     def test_mixed_execution_details(self, hybrid_report_data: dict[str, Any]) -> None:
@@ -183,13 +193,13 @@ class TestTokenUsage:
         assert usage.calls == 0
 
     def test_from_dict(self) -> None:
-        usage = TokenUsage.model_validate({"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+        usage = TokenUsage.model_validate({'prompt_tokens': 100, 'completion_tokens': 50, 'total_tokens': 150})
         assert usage.prompt_tokens == 100
 
 
 class TestAgentContext:
     def test_properties(self) -> None:
-        ctx = AgentContext(key="test-agent")
+        ctx = AgentContext(key='test-agent')
         assert not ctx.has_tools
         assert not ctx.has_memory
         assert not ctx.has_knowledge
@@ -199,8 +209,8 @@ class TestAgentContext:
 class TestCategorySummary:
     def test_basic(self) -> None:
         summary = CategorySummary(
-            category="ASI01",
-            category_name="Agent Goal Hijacking",
+            category='ASI01',
+            category_name='Agent Goal Hijacking',
             total_attacks=10,
             vulnerabilities_found=3,
             resistance_rate=0.7,
@@ -208,7 +218,7 @@ class TestCategorySummary:
         assert summary.resistance_rate == 0.7
 
 
-def _turn(prompt: str = "hi", reply: str = "ok") -> Turn:
+def _turn(prompt: str = 'hi', reply: str = 'ok') -> Turn:
     return Turn(
         attacker=AgentResponse(text=prompt),
         target=AgentResponse(text=reply),
@@ -218,61 +228,61 @@ def _turn(prompt: str = "hi", reply: str = "ok") -> Turn:
 class TestAttackOutput:
     def test_construction_with_all_fields(self) -> None:
         output = AttackOutput(
-            turns=[_turn(), _turn(), _turn(reply="Here is the secret")],
+            turns=[_turn(), _turn(), _turn(reply='Here is the secret')],
             objective_achieved=True,
-            category="ASI01",
-            vulnerability="agent-goal-hijacking",
+            category='ASI01',
+            vulnerability='agent-goal-hijacking',
         )
-        assert output.category == "ASI01"
-        assert output.vulnerability == "agent-goal-hijacking"
+        assert output.category == 'ASI01'
+        assert output.vulnerability == 'agent-goal-hijacking'
         assert output.n_turns == 3
-        assert output.final_response == "Here is the secret"
+        assert output.final_response == 'Here is the secret'
         assert output.objective_achieved is True
 
     def test_defaults_for_category_and_vulnerability(self) -> None:
         output = AttackOutput(turns=[_turn()])
-        assert output.category == ""
-        assert output.vulnerability == ""
+        assert output.category == ''
+        assert output.vulnerability == ''
         assert output.objective_achieved is False
-        assert output.final_response == "ok"
+        assert output.final_response == 'ok'
 
     def test_model_validate_from_dict(self) -> None:
         data = {
-            "turns": [
+            'turns': [
                 {
-                    "attacker": {"generated_prompt": "hi"},
-                    "target": {"output": [{"type": "output_text", "text": "yo", "annotations": []}]},
+                    'attacker': {'generated_prompt': 'hi'},
+                    'target': {'output': [{'type': 'output_text', 'text': 'yo', 'annotations': []}]},
                 },
                 {
-                    "attacker": {"generated_prompt": "again"},
-                    "target": {"output": [{"type": "output_text", "text": "stop", "annotations": []}]},
+                    'attacker': {'generated_prompt': 'again'},
+                    'target': {'output': [{'type': 'output_text', 'text': 'stop', 'annotations': []}]},
                 },
             ],
-            "category": "LLM01",
-            "vulnerability": "prompt-injection",
+            'category': 'LLM01',
+            'vulnerability': 'prompt-injection',
         }
         output = AttackOutput.model_validate(data)
-        assert output.category == "LLM01"
-        assert output.vulnerability == "prompt-injection"
+        assert output.category == 'LLM01'
+        assert output.vulnerability == 'prompt-injection'
         assert output.n_turns == 2
 
     def test_model_validate_with_missing_optional_fields(self) -> None:
-        data = {"turns": [{"attacker": {"generated_prompt": "x"}, "target": {"output": []}}]}
+        data = {'turns': [{'attacker': {'generated_prompt': 'x'}, 'target': {'output': []}}]}
         output = AttackOutput.model_validate(data)
-        assert output.category == ""
-        assert output.vulnerability == ""
+        assert output.category == ''
+        assert output.vulnerability == ''
         assert output.error is None
         assert output.token_usage is None
 
     def test_inherits_orchestrator_result_fields(self) -> None:
         output = AttackOutput(
             turns=[_turn()],
-            error="content_filter blocked",
-            error_type="content_filter",
+            error='content_filter blocked',
+            error_type='content_filter',
             token_usage=TokenUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
         )
-        assert output.error == "content_filter blocked"
-        assert output.error_type == "content_filter"
+        assert output.error == 'content_filter blocked'
+        assert output.error_type == 'content_filter'
         assert output.token_usage is not None
         assert output.token_usage.total_tokens == 150
         assert isinstance(output, OrchestratorResult)
@@ -285,7 +295,7 @@ class TestChatCompletionsOrdering:
         return OrchestratorResult(
             turns=[
                 Turn(
-                    attacker=AgentResponse(text="please call tools"),
+                    attacker=AgentResponse(text='please call tools'),
                     target=AgentResponse(output=output_items),
                 )
             ]
@@ -293,92 +303,92 @@ class TestChatCompletionsOrdering:
 
     def test_text_only_joins_into_single_assistant_message(self) -> None:
         result = self._build([
-            TextOutputItem(text="Hello, ", annotations=[]),
-            TextOutputItem(text="world.", annotations=[]),
+            TextOutputItem(text='Hello, ', annotations=[]),
+            TextOutputItem(text='world.', annotations=[]),
         ])
         msgs = result.chat_completions
         assert len(msgs) == 2
-        assert msgs[0].role == "user"
-        assert msgs[1].role == "assistant"
-        assert msgs[1].content == "Hello, world."
+        assert msgs[0].role == 'user'
+        assert msgs[1].role == 'assistant'
+        assert msgs[1].content == 'Hello, world.'
         assert msgs[1].tool_calls is None
 
     def test_tool_call_without_result_emits_assistant_only(self) -> None:
         result = self._build([
-            ToolCallOutputItem(call_id="call_1", name="search", arguments='{"q": "x"}'),
+            ToolCallOutputItem(call_id='call_1', name='search', arguments='{"q": "x"}'),
         ])
         msgs = result.chat_completions
-        assert [m.role for m in msgs] == ["user", "assistant"]
+        assert [m.role for m in msgs] == ['user', 'assistant']
         assistant = msgs[1]
         assert assistant.content is None
         assert assistant.tool_calls is not None and len(assistant.tool_calls) == 1
-        assert assistant.tool_calls[0].id == "call_1"
-        assert assistant.tool_calls[0].function.name == "search"
+        assert assistant.tool_calls[0].id == 'call_1'
+        assert assistant.tool_calls[0].function.name == 'search'
         assert assistant.tool_calls[0].function.arguments == '{"q": "x"}'
 
     def test_tool_call_with_result_emits_assistant_then_tool(self) -> None:
         result = self._build([
-            ToolCallOutputItem(call_id="call_2", name="lookup", arguments="{}", result="found it"),
+            ToolCallOutputItem(call_id='call_2', name='lookup', arguments='{}', result='found it'),
         ])
         msgs = result.chat_completions
-        assert [m.role for m in msgs] == ["user", "assistant", "tool"]
+        assert [m.role for m in msgs] == ['user', 'assistant', 'tool']
         tool_msg = msgs[2]
-        assert tool_msg.tool_call_id == "call_2"
-        assert tool_msg.name == "lookup"
-        assert tool_msg.content == "found it"
+        assert tool_msg.tool_call_id == 'call_2'
+        assert tool_msg.name == 'lookup'
+        assert tool_msg.content == 'found it'
 
     def test_interleaved_text_and_tool_calls_preserve_order(self) -> None:
         result = self._build([
-            TextOutputItem(text="Thinking...", annotations=[]),
-            ToolCallOutputItem(call_id="c1", name="search", arguments="{}", result="r1"),
-            TextOutputItem(text="Now another:", annotations=[]),
-            ToolCallOutputItem(call_id="c2", name="fetch", arguments="{}"),
-            TextOutputItem(text="Done.", annotations=[]),
+            TextOutputItem(text='Thinking...', annotations=[]),
+            ToolCallOutputItem(call_id='c1', name='search', arguments='{}', result='r1'),
+            TextOutputItem(text='Now another:', annotations=[]),
+            ToolCallOutputItem(call_id='c2', name='fetch', arguments='{}'),
+            TextOutputItem(text='Done.', annotations=[]),
         ])
         msgs = result.chat_completions
         assert [m.role for m in msgs] == [
-            "user",        # attacker prompt
-            "assistant",   # "Thinking..."
-            "assistant",   # tool_call c1
-            "tool",        # result for c1
-            "assistant",   # "Now another:"
-            "assistant",   # tool_call c2 (no result)
-            "assistant",   # "Done."
+            'user',  # attacker prompt
+            'assistant',  # "Thinking..."
+            'assistant',  # tool_call c1
+            'tool',  # result for c1
+            'assistant',  # "Now another:"
+            'assistant',  # tool_call c2 (no result)
+            'assistant',  # "Done."
         ]
-        assert msgs[1].content == "Thinking..."
+        assert msgs[1].content == 'Thinking...'
         assert msgs[1].tool_calls is None
         assert msgs[2].content is None
         assert msgs[2].tool_calls is not None
-        assert msgs[2].tool_calls[0].id == "c1"
-        assert msgs[3].tool_call_id == "c1"
-        assert msgs[3].content == "r1"
-        assert msgs[4].content == "Now another:"
+        assert msgs[2].tool_calls[0].id == 'c1'
+        assert msgs[3].tool_call_id == 'c1'
+        assert msgs[3].content == 'r1'
+        assert msgs[4].content == 'Now another:'
         assert msgs[5].tool_calls is not None
-        assert msgs[5].tool_calls[0].id == "c2"
-        assert msgs[6].content == "Done."
+        assert msgs[5].tool_calls[0].id == 'c2'
+        assert msgs[6].content == 'Done.'
 
     def test_reasoning_items_are_dropped(self) -> None:
         result = self._build([
-            ReasoningOutputItem(text="internal thought"),
-            TextOutputItem(text="visible answer", annotations=[]),
-            ReasoningOutputItem(text="another thought"),
+            ReasoningOutputItem(text='internal thought'),
+            TextOutputItem(text='visible answer', annotations=[]),
+            ReasoningOutputItem(text='another thought'),
         ])
         msgs = result.chat_completions
-        assert [m.role for m in msgs] == ["user", "assistant"]
-        assert msgs[1].content == "visible answer"
+        assert [m.role for m in msgs] == ['user', 'assistant']
+        assert msgs[1].content == 'visible answer'
 
     def test_empty_output_falls_back_to_target_text(self) -> None:
         result = OrchestratorResult(
             turns=[
                 Turn(
-                    attacker=AgentResponse(text="ping"),
+                    attacker=AgentResponse(text='ping'),
                     target=AgentResponse(output=[]),
                 )
             ]
         )
         msgs = result.chat_completions
-        assert [m.role for m in msgs] == ["user", "assistant"]
-        assert msgs[1].content == ""
+        assert [m.role for m in msgs] == ['user', 'assistant']
+        assert msgs[1].content == ''
 
 
 # ===========================================================================
@@ -389,18 +399,21 @@ class TestChatCompletionsOrdering:
 def test_redteam_result_has_no_tool_calls_per_turn_field():
     """tool_calls_per_turn is dead schema — removed in favor of per-Turn access."""
     from evaluatorq.redteam.contracts import RedTeamResult
+
     assert 'tool_calls_per_turn' not in RedTeamResult.model_fields
 
 
 def test_job_output_payload_has_no_tool_calls_per_turn_field():
     """tool_calls_per_turn dropped from JobOutputPayload; legacy JSONs absorbed via extra='allow'."""
     from evaluatorq.redteam.contracts import JobOutputPayload
+
     assert 'tool_calls_per_turn' not in JobOutputPayload.model_fields
 
 
 def test_job_output_payload_tolerates_legacy_tool_calls_per_turn_key():
     """Existing run JSONs with the legacy key must still deserialize cleanly."""
     from evaluatorq.redteam.contracts import JobOutputPayload
+
     payload = JobOutputPayload.model_validate({
         'conversation': [],
         'final_response': 'ok',

--- a/tests/redteam/test_orq_backend_context.py
+++ b/tests/redteam/test_orq_backend_context.py
@@ -1,0 +1,247 @@
+"""Agent-context retrieval must survive provider metadata it cannot model (RES-1177).
+
+An orq POC died in the ``context_retrieval`` stage before a single attack was
+sent: the orq SDK leaves unset optional fields holding an ``Unset()`` placeholder
+rather than ``None``, so ``getattr(agent, name, None)`` returns the sentinel and
+it lands in a ``str``-typed ``AgentContext`` field. Context is enrichment, so
+neither the sentinel nor a failure to model it may end a run — but an
+unreachable agent still must.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from evaluatorq.contracts import AgentContext
+from evaluatorq.redteam.backends.orq import ORQAgentTarget, ORQBackend
+
+
+class _Unset:
+    """Stand-in for ``orq_ai_sdk.types.basemodel.Unset``.
+
+    Reproduced locally so the test pins our handling of *any* placeholder
+    object, and does not silently start passing if the SDK renames its own.
+    """
+
+    def __repr__(self) -> str:
+        return 'Unset()'
+
+
+def _agent_payload(**overrides):
+    payload = {
+        'id': 'agent-uuid-1',
+        'workspace_id': 'ws-42',
+        'display_name': 'Thales Engineering Companion',
+        'description': 'desc',
+        'system_prompt': _Unset(),
+        'instructions': 'be helpful',
+        'settings': SimpleNamespace(tools=[]),
+        'knowledge_bases': [],
+        'memory_stores': [],
+        'model': SimpleNamespace(id='openai/gpt-4o'),
+    }
+    payload.update(overrides)
+    return SimpleNamespace(**payload)
+
+
+class _FakeAgents:
+    def __init__(self, agent):
+        self._agent = agent
+
+    def retrieve(self, agent_key):  # noqa: ARG002 - signature mirrors the SDK
+        return self._agent
+
+
+class _FakeClient:
+    def __init__(self, agent=None):
+        self.agents = _FakeAgents(agent if agent is not None else _agent_payload())
+
+
+def test_unset_placeholder_does_not_abort_context_retrieval():
+    """The exact RES-1177 crash: ``system_prompt`` present but holding a sentinel."""
+    target = ORQAgentTarget(agent_key='thales-engineering-companion-2', orq_client=_FakeClient())
+    ctx = asyncio.run(target.get_agent_context())
+
+    assert ctx.system_prompt == ''
+    # Enrichment around the bad field survives — the point of the fix is to keep
+    # the context, not merely to stop the exception.
+    assert ctx.display_name == 'Thales Engineering Companion'
+    assert ctx.model == 'openai/gpt-4o'
+
+
+def test_unset_collection_placeholders_are_treated_as_empty():
+    agent = _agent_payload(
+        settings=SimpleNamespace(tools=_Unset()),
+        knowledge_bases=_Unset(),
+        memory_stores=_Unset(),
+    )
+
+    ctx = asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+    assert ctx.tools == []
+    assert ctx.knowledge_bases == []
+    assert ctx.memory_stores == []
+
+
+def test_int_and_bool_metadata_are_stringified_not_dropped():
+    agent = _agent_payload(description=42, display_name=True)
+    ctx = asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+    assert ctx.description == '42'
+    assert ctx.display_name == 'True'
+
+
+def test_required_text_fields_are_never_none():
+    agent = _agent_payload(system_prompt=None, instructions=_Unset())
+    ctx = asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+    assert ctx.system_prompt == ''
+    assert ctx.instructions == ''
+
+
+@pytest.mark.parametrize(
+    ('system_prompt', 'instructions'),
+    [
+        (_Unset(), 'agent behavioral instructions'),  # agent: instructions only
+        ('deployment system prompt', _Unset()),  # deployment: system_prompt only
+        (_Unset(), _Unset()),  # bring-your-own target: neither introspectable
+    ],
+)
+def test_system_prompt_and_instructions_are_mutually_exclusive(system_prompt, instructions):
+    """Supplying one and omitting the other is the normal case, not missing data.
+
+    Agents carry ``instructions``, deployments carry ``system_prompt``. Neither
+    field may be promoted to mandatory, and the empty one must read as ``''``
+    so an ``instructions or system_prompt`` chain falls through cleanly.
+    """
+    agent = _agent_payload(system_prompt=system_prompt, instructions=instructions)
+    ctx = asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+    expected_prompt = system_prompt if isinstance(system_prompt, str) else ''
+    expected_instructions = instructions if isinstance(instructions, str) else ''
+    assert ctx.system_prompt == expected_prompt
+    assert ctx.instructions == expected_instructions
+    assert (ctx.instructions or ctx.system_prompt) == (expected_instructions or expected_prompt)
+
+
+def test_both_directive_fields_populated_is_allowed():
+    """Exclusivity is how targets behave, not a rule we enforce.
+
+    Rejecting a payload that fills both would re-introduce a fatal error in the
+    enrichment path — the exact failure mode RES-1177 is about.
+    """
+    agent = _agent_payload(system_prompt='sp', instructions='ins')
+    ctx = asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+    assert ctx.system_prompt == 'sp'
+    assert ctx.instructions == 'ins'
+
+
+def test_optional_text_fields_stay_none_when_absent():
+    agent = _agent_payload(id=_Unset(), workspace_id=None, description=_Unset())
+    ctx = asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+    assert ctx.id is None
+    assert ctx.workspace_id is None
+    assert ctx.description is None
+
+
+def _ctx(**overrides):
+    agent = _agent_payload(**overrides)
+    return asyncio.run(ORQAgentTarget(agent_key='k', orq_client=_FakeClient(agent)).get_agent_context())
+
+
+def test_version_read_from_new_sdk_field():
+    """orq-ai-sdk 4.12.x shape: ``version`` present, ``version_hash`` gone."""
+    assert _ctx(version='v7').version == 'v7'
+
+
+def test_version_falls_back_to_version_hash_on_old_sdk():
+    """orq-ai-sdk 4.4.x shape: ``version`` absent, ``version_hash`` present."""
+    assert _ctx(version_hash='ab12cd').version == 'ab12cd'
+
+
+def test_unset_version_falls_through_to_version_hash():
+    """The placeholder is *truthy*, so an ``or`` chain would stop at it and never
+    reach the fallback. Selection has to be by type."""
+    assert _ctx(version=_Unset(), version_hash='ab12cd').version == 'ab12cd'
+
+
+def test_unset_version_with_no_fallback_is_none():
+    assert _ctx(version=_Unset()).version is None
+
+
+def test_new_capability_fields_are_populated():
+    ctx = _ctx(skills=['refund', 'lookup'], type='a2a', engine='jinja')
+
+    assert ctx.skills == ['refund', 'lookup']
+    assert ctx.agent_type == 'a2a'  # SDK calls this field 'type'
+    assert ctx.engine == 'jinja'
+
+
+def test_old_sdk_payload_omitting_new_fields_is_fine():
+    """The version CI installs (the pin floor) exposes none of these."""
+    ctx = _ctx()
+
+    assert ctx.version is None
+    assert ctx.skills == []
+    assert ctx.agent_type is None
+    assert ctx.engine is None
+
+
+def test_unknown_literal_members_are_dropped_not_raised():
+    """Providers add enum values faster than we follow; an unrecognized one is not
+    worth failing a scan over."""
+    ctx = _ctx(type='swarm', engine=_Unset())
+
+    assert ctx.agent_type is None
+    assert ctx.engine is None
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [(_Unset(), []), (None, []), (['a', 3, None], ['a']), ('not-a-list', [])],
+)
+def test_skills_tolerates_bad_shapes(raw, expected):
+    assert _ctx(skills=raw).skills == expected
+
+
+def test_key_is_not_coerced():
+    """Identity is strict: a bad key must fail, not resolve to something plausible."""
+    with pytest.raises(ValidationError):
+        AgentContext(key=_Unset())  # type: ignore[arg-type]
+
+
+def test_resolve_context_degrades_on_validation_error(monkeypatch):
+    async def _boom(self):
+        raise ValidationError.from_exception_data('AgentContext', [])
+
+    monkeypatch.setattr(ORQAgentTarget, 'get_agent_context', _boom)
+    backend = ORQBackend(orq_client=_FakeClient())
+
+    ctx = asyncio.run(backend.resolve_context('thales-engineering-companion-2'))
+
+    assert ctx == AgentContext(key='thales-engineering-companion-2')
+
+
+def test_resolve_context_reraises_api_errors():
+    """Guard against widening the ``except``: red-teaming nothing beats no error."""
+
+    class _AuthError(Exception):
+        pass
+
+    async def _boom(self):
+        raise _AuthError('401 Unauthorized')
+
+    class _BadAgents:
+        def retrieve(self, agent_key):  # noqa: ARG002 - signature mirrors the SDK
+            raise _AuthError('401 Unauthorized')
+
+    backend = ORQBackend(orq_client=SimpleNamespace(agents=_BadAgents()))
+
+    with pytest.raises(_AuthError):
+        asyncio.run(backend.resolve_context('unreachable-agent'))

--- a/tests/redteam/test_orq_backend_context.py
+++ b/tests/redteam/test_orq_backend_context.py
@@ -175,6 +175,13 @@ def test_unset_version_with_no_fallback_is_none():
     assert _ctx(version=_Unset()).version is None
 
 
+def test_empty_version_counts_as_absent():
+    """Live 4.4.x agents carry ``version_hash=''``. Reporting that as a version
+    would disagree with the same agent read through a newer SDK."""
+    assert _ctx(version='', version_hash='').version is None
+    assert _ctx(version='', version_hash='ab12cd').version == 'ab12cd'
+
+
 def test_new_capability_fields_are_populated():
     ctx = _ctx(skills=['refund', 'lookup'], type='a2a', engine='jinja')
 

--- a/tests/redteam/test_orq_backend_context.py
+++ b/tests/redteam/test_orq_backend_context.py
@@ -220,7 +220,7 @@ def test_skills_tolerates_bad_shapes(raw, expected):
 def test_key_is_not_coerced():
     """Identity is strict: a bad key must fail, not resolve to something plausible."""
     with pytest.raises(ValidationError):
-        AgentContext(key=_Unset())  # type: ignore[arg-type]
+        AgentContext(key=_Unset())  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
 
 def test_resolve_context_degrades_on_validation_error(monkeypatch):

--- a/tests/simulation/test_agent_info.py
+++ b/tests/simulation/test_agent_info.py
@@ -148,16 +148,19 @@ async def test_fetch_agent_info_sanitizes_unset_optional_fields(monkeypatch: pyt
 
     assert snapshot is not None
     json.dumps(snapshot)
-    assert snapshot['version'] is None
-    assert snapshot['skills'] == []
-    assert snapshot['agent_type'] is None
-    assert snapshot['engine'] is None
-    assert snapshot['workspace_id'] is None
-    assert snapshot['id'] is None
-    assert snapshot['tools'] == []
-    assert snapshot['knowledge_bases'] == []
-    assert snapshot['memory_stores'] == []
-    assert snapshot['sub_agents'] == []
+    # Read through a plain dict: every AgentInfoSnapshot key is optional
+    # (`total=False`), so subscripting the TypedDict directly is a type error.
+    flat: dict[str, Any] = dict(snapshot)
+    assert flat['version'] is None
+    assert flat['skills'] == []
+    assert flat['agent_type'] is None
+    assert flat['engine'] is None
+    assert flat['workspace_id'] is None
+    assert flat['id'] is None
+    assert flat['tools'] == []
+    assert flat['knowledge_bases'] == []
+    assert flat['memory_stores'] == []
+    assert flat['sub_agents'] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/simulation/test_agent_info.py
+++ b/tests/simulation/test_agent_info.py
@@ -1,5 +1,6 @@
 """Unit tests for the agent_info snapshot: fetch_agent_info() mapping/failure
 paths and SimulationRun round-trip/back-compat."""
+
 from __future__ import annotations
 
 import json
@@ -16,67 +17,94 @@ from evaluatorq.simulation.utils.run_store import fetch_agent_info
 # ---------------------------------------------------------------------------
 
 
-def _agent_payload() -> SimpleNamespace:
-    return SimpleNamespace(
-        _id="01K8N1KMM5TBD3BTT2N2J5N0DK",
-        key="simple-agent-1",
-        workspace_id="624ccbbd-a482-40e2-b3d9-3621e09da1f8",
-        description="A helpful assistant for general tasks",
-        role="Assistant",
-        model=SimpleNamespace(id="openai/gpt-4o"),
-        knowledge_bases=[],
-        memory_stores=[],
-        team_of_agents=[SimpleNamespace(key="youth-agent", role="The youth agent")],
-        settings=SimpleNamespace(
+class _Unset:
+    """Stand-in for the truthy placeholder used by the provider SDK."""
+
+
+def _agent_payload(**overrides: Any) -> SimpleNamespace:
+    payload = {
+        '_id': '01K8N1KMM5TBD3BTT2N2J5N0DK',
+        'key': 'simple-agent-1',
+        'workspace_id': '624ccbbd-a482-40e2-b3d9-3621e09da1f8',
+        'description': 'A helpful assistant for general tasks',
+        'role': 'Assistant',
+        'version': 'v7',
+        'skills': ['lookup', 'refund'],
+        'type': 'a2a',
+        'engine': 'jinja',
+        'model': SimpleNamespace(id='openai/gpt-4o'),
+        'knowledge_bases': [],
+        'memory_stores': [],
+        'team_of_agents': [SimpleNamespace(key='youth-agent', role='The youth agent')],
+        'settings': SimpleNamespace(
             tools=[
                 SimpleNamespace(
-                    id="01JK...",
-                    key="orq_current_date",
-                    action_type="orq_current_date",
-                    display_name="Current Date & Time",
+                    id='01JK...',
+                    key='orq_current_date',
+                    action_type='orq_current_date',
+                    display_name='Current Date & Time',
                 )
             ]
         ),
-    )
+    }
+    payload.update(overrides)
+    return SimpleNamespace(**payload)
+
+
+class _FakeAgents:
+    def __init__(self, agent: SimpleNamespace):
+        self._agent = agent
+
+    def retrieve(self, agent_key: str) -> SimpleNamespace:
+        return self._agent
+
+
+class _FakeClient:
+    def __init__(self, agent: SimpleNamespace | None = None):
+        self.agents = _FakeAgents(agent if agent is not None else _agent_payload())
 
 
 @pytest.mark.asyncio
 async def test_fetch_agent_info_maps_payload(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ORQ_API_KEY", "test-key")
-    monkeypatch.setenv("ORQ_WORKSPACE", "research")
-    monkeypatch.delenv("ORQ_BASE_URL", raising=False)
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
+    monkeypatch.setenv('ORQ_WORKSPACE', 'research')
+    monkeypatch.delenv('ORQ_BASE_URL', raising=False)
 
     class _Agents:
         def retrieve(self, agent_key: str) -> SimpleNamespace:
-            assert agent_key == "simple-agent-1"
+            assert agent_key == 'simple-agent-1'
             return _agent_payload()
 
     fake_client = SimpleNamespace(agents=_Agents())
-    monkeypatch.setattr("evaluatorq.fetch_data.setup_orq_client", lambda api_key: fake_client)
+    monkeypatch.setattr('evaluatorq.fetch_data.setup_orq_client', lambda _api_key: fake_client)
 
-    info = await fetch_agent_info("simple-agent-1")
+    info = await fetch_agent_info('simple-agent-1')
 
     assert info is not None
-    assert info.get("key") == "simple-agent-1"
-    assert info.get("id") == "01K8N1KMM5TBD3BTT2N2J5N0DK"
-    assert info.get("role") == "Assistant"
-    assert info.get("description") == "A helpful assistant for general tasks"
-    assert info.get("model") == "openai/gpt-4o"
-    assert info.get("tools") == ["Current Date & Time"]
-    assert info.get("knowledge_bases") == []
-    assert info.get("memory_stores") == []
-    assert info.get("sub_agents") == ["youth-agent"]
-    assert info.get("workspace_id") == "624ccbbd-a482-40e2-b3d9-3621e09da1f8"
-    assert info.get("workspace_key") == "research"
-    assert info.get("url") == "https://my.orq.ai/research/agents/01K8N1KMM5TBD3BTT2N2J5N0DK"
-    assert "instructions" not in info
-    assert "system_prompt" not in info
+    assert info.get('key') == 'simple-agent-1'
+    assert info.get('id') == '01K8N1KMM5TBD3BTT2N2J5N0DK'
+    assert info.get('role') == 'Assistant'
+    assert info.get('description') == 'A helpful assistant for general tasks'
+    assert info.get('model') == 'openai/gpt-4o'
+    assert info.get('version') == 'v7'
+    assert info.get('skills') == ['lookup', 'refund']
+    assert info.get('agent_type') == 'a2a'
+    assert info.get('engine') == 'jinja'
+    assert info.get('tools') == ['Current Date & Time']
+    assert info.get('knowledge_bases') == []
+    assert info.get('memory_stores') == []
+    assert info.get('sub_agents') == ['youth-agent']
+    assert info.get('workspace_id') == '624ccbbd-a482-40e2-b3d9-3621e09da1f8'
+    assert info.get('workspace_key') == 'research'
+    assert info.get('url') == 'https://my.orq.ai/research/agents/01K8N1KMM5TBD3BTT2N2J5N0DK'
+    assert 'instructions' not in info
+    assert 'system_prompt' not in info
 
 
 @pytest.mark.asyncio
 async def test_fetch_agent_info_no_api_key_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ORQ_API_KEY", raising=False)
-    assert await fetch_agent_info("simple-agent-1") is None
+    monkeypatch.delenv('ORQ_API_KEY', raising=False)
+    assert await fetch_agent_info('simple-agent-1') is None
 
 
 # ---------------------------------------------------------------------------
@@ -86,16 +114,50 @@ async def test_fetch_agent_info_no_api_key_returns_none(monkeypatch: pytest.Monk
 
 @pytest.mark.asyncio
 async def test_fetch_agent_info_retrieve_raises_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
 
     class _Agents:
         def retrieve(self, agent_key: str) -> Any:
-            raise RuntimeError("boom")
+            raise RuntimeError('boom')
 
     fake_client = SimpleNamespace(agents=_Agents())
-    monkeypatch.setattr("evaluatorq.fetch_data.setup_orq_client", lambda api_key: fake_client)
+    monkeypatch.setattr('evaluatorq.fetch_data.setup_orq_client', lambda _api_key: fake_client)
 
-    assert await fetch_agent_info("simple-agent-1") is None
+    assert await fetch_agent_info('simple-agent-1') is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_agent_info_sanitizes_unset_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
+    agent = _agent_payload(
+        version=_Unset(),
+        skills=_Unset(),
+        type=_Unset(),
+        engine=_Unset(),
+        workspace_id=_Unset(),
+        _id=_Unset(),
+        id=_Unset(),
+        settings=SimpleNamespace(tools=_Unset()),
+        knowledge_bases=_Unset(),
+        memory_stores=_Unset(),
+        team_of_agents=_Unset(),
+    )
+    monkeypatch.setattr('evaluatorq.fetch_data.setup_orq_client', lambda _api_key: _FakeClient(agent))
+
+    snapshot = await fetch_agent_info('simple-agent-1')
+
+    assert snapshot is not None
+    json.dumps(snapshot)
+    assert snapshot['version'] is None
+    assert snapshot['skills'] == []
+    assert snapshot['agent_type'] is None
+    assert snapshot['engine'] is None
+    assert snapshot['workspace_id'] is None
+    assert snapshot['id'] is None
+    assert snapshot['tools'] == []
+    assert snapshot['knowledge_bases'] == []
+    assert snapshot['memory_stores'] == []
+    assert snapshot['sub_agents'] == []
 
 
 # ---------------------------------------------------------------------------
@@ -107,30 +169,30 @@ def _minimal_run_kwargs() -> dict[str, Any]:
     from datetime import datetime, timezone
 
     return {
-        "run_name": "r",
-        "created_at": datetime.now(tz=timezone.utc),
-        "mode": "run",
-        "target_kind": "orq_agent",
-        "evaluator_names": [],
-        "total_results": 0,
-        "scorer_averages": {},
-        "results": [],
+        'run_name': 'r',
+        'created_at': datetime.now(tz=timezone.utc),
+        'mode': 'run',
+        'target_kind': 'orq_agent',
+        'evaluator_names': [],
+        'total_results': 0,
+        'scorer_averages': {},
+        'results': [],
     }
 
 
 def test_simulation_run_agent_info_round_trips_via_json() -> None:
     agent_info: AgentInfoSnapshot = {
-        "key": "simple-agent-1",
-        "id": "01K8N1KMM5TBD3BTT2N2J5N0DK",
-        "role": "Assistant",
-        "description": "desc",
-        "model": "openai/gpt-4o",
-        "tools": ["Current Date & Time"],
-        "knowledge_bases": [],
-        "memory_stores": [],
-        "sub_agents": ["youth-agent"],
-        "base_url": "https://my.orq.ai",
-        "url": "https://my.orq.ai/project/agents/01K8N1KMM5TBD3BTT2N2J5N0DK",
+        'key': 'simple-agent-1',
+        'id': '01K8N1KMM5TBD3BTT2N2J5N0DK',
+        'role': 'Assistant',
+        'description': 'desc',
+        'model': 'openai/gpt-4o',
+        'tools': ['Current Date & Time'],
+        'knowledge_bases': [],
+        'memory_stores': [],
+        'sub_agents': ['youth-agent'],
+        'base_url': 'https://my.orq.ai',
+        'url': 'https://my.orq.ai/project/agents/01K8N1KMM5TBD3BTT2N2J5N0DK',
     }
     run = SimulationRun(agent_info=agent_info, **_minimal_run_kwargs())
 
@@ -141,7 +203,7 @@ def test_simulation_run_agent_info_round_trips_via_json() -> None:
 
 def test_simulation_run_without_agent_info_field_is_back_compat() -> None:
     kwargs = _minimal_run_kwargs()
-    kwargs["created_at"] = kwargs["created_at"].isoformat()
+    kwargs['created_at'] = kwargs['created_at'].isoformat()
     payload = json.dumps(kwargs)
 
     loaded = SimulationRun.model_validate_json(payload)


### PR DESCRIPTION
A customer POC died in the red-team `context_retrieval` stage before a single attack was sent. Two independent defects, both fixed and verified live against a real agent on the research workspace.

## 1. RES-1177 — `Unset()` sentinel kills the run

`orq-ai-sdk` parks a **truthy** `Unset()` placeholder in unset optional fields, so `getattr(obj, name, None)` returns the sentinel instead of `None` — and `or` chains latch onto it too. It landed in a `str`-typed `AgentContext` field and the `ValidationError` ended the whole run.

Only reproduces on newer SDKs. `pyproject.toml` pins a floor (`>=4.4.7`), so CI installed 4.4.7 and stayed green while fresh installs resolved 4.12.x and crashed. Diffing the agent-retrieve model 4.4.7 → 4.12.17:

| | fields |
|---|---|
| removed | `workspace_id`, `version_hash` |
| added | `version`, `skills`, `type`, `engine` |

- `AgentContext` normalizes provider text in one `model_validator(mode="before")`: keeps `str`, stringifies `bool`/`int`, else `None`. Three field groups — strict (`key`), required-text (`system_prompt`/`instructions`, default `""`, mutually exclusive), optional-text. Unknown enum members drop to `None` rather than raising.
- `Backend.resolve_context` catches `ValidationError` **only** and degrades to a minimal context. Auth/HTTP/404 still propagate — red-teaming nothing is worse than an error.
- The four new fields are captured on both the red-team and simulation surfaces; `version` and `skills` render, `agent_type`/`engine` are record-only for now.
- CI gains an `sdk-compat` job resolving the newest patch of the last three SDK minors at run time, so the next upstream field removal is caught by us, not by a customer.

Backward compatible: every new field has a default, and `dashboard/library.py` `_validate_model` has no try/except — a required field would have broken every previously saved report.

## 2. Every agent with memory tools failed every turn

Found while doing the end-to-end verification run. `OrqResponsesTarget` held a `memory_entity_id` but never forwarded it, and `HybridAgentBackend` never minted one, so hosted agents with memory tools returned HTTP 400 `memory_entity_id_required` on every call — retries exhausted, attack reported as inconclusive. Now forwards `memory.entity_id` and mints a per-target id, matching `ORQAgentTarget`.

## Verification

- 1992 passed, 2 skipped; ruff + basedpyright clean.
- Targeted tests pass on **both** orq-ai-sdk 4.12.17 and 4.4.7.
- Live against `domain-search-assistant`: context enrichment intact on both SDKs (6 tools, 1 memory store, 1 knowledge base), and the previously-failing turn now returns a real response.

## Follow-ups (separate tickets)

- Recovering a usable workspace slug now that 4.12.x dropped `workspace_id`.
- Rendering `agent_type`/`engine`, and whether `agent_type == "a2a"` should feed `is_multi_agent` instead of the LLM classifier.
- A report-level schema/format version stamp.

/cc @arianpasquali

🤖 Generated with [Claude Code](https://claude.com/claude-code)