### PR TITLE
feat(evaluatorq): surface upload diagnostics in _send_cleaned_results (RES-823)

### DIFF
--- a/src/evaluatorq/evaluatorq.py
+++ b/src/evaluatorq/evaluatorq.py
@@ -369,7 +369,7 @@ async def evaluatorq(
 
         # Upload results to Orq platform if API key is available
         if orq_api_key and _send_results:
-            experiment_url = await send_results_to_orq(
+            upload_response = await send_results_to_orq(
                 orq_api_key,
                 name,
                 description,
@@ -382,8 +382,8 @@ async def evaluatorq(
             )
             # Hand the created experiment's URL back to callers that opted in with a
             # sink list (e.g. simulation persists it on the SimulationRun report).
-            if _experiment_url_out is not None and experiment_url:
-                _experiment_url_out.append(experiment_url)
+            if _experiment_url_out is not None and upload_response is not None and upload_response.experiment_url:
+                _experiment_url_out.append(upload_response.experiment_url)
 
         # Check for pass failures and exit if any. In no-inference mode a row that has no
         # usable recorded response surfaces as a job error rather than an evaluator score,

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -1584,9 +1584,7 @@ class RedTeamReport(BaseModel):
         'shared by every attack\'s thread_id; powers the dashboard "View all run traces" '
         'deep-link. None for older reports.',
     )
-    uploaded_count: int | None = Field(
-        default=None, description='Cleaned result rows sent to the Orq platform'
-    )
+    uploaded_count: int | None = Field(default=None, description='Cleaned result rows sent to the Orq platform')
     rows_created: int | None = Field(
         default=None,
         description='Rows the Orq platform actually registered; a value below uploaded_count explains a smaller Explorer sample count',

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -1584,10 +1584,16 @@ class RedTeamReport(BaseModel):
         'shared by every attack\'s thread_id; powers the dashboard "View all run traces" '
         'deep-link. None for older reports.',
     )
-    uploaded_count: int | None = Field(default=None, description='Cleaned result rows sent to the Orq platform')
+    uploaded_count: int | None = Field(
+        default=None,
+        description='Cleaned result rows sent to the Orq platform. None when the upload was skipped '
+        '(no API key) or the report predates this field; 0 when every row was stripped in cleaning.',
+    )
     rows_created: int | None = Field(
         default=None,
-        description='Rows the Orq platform actually registered; a value below uploaded_count explains a smaller Explorer sample count',
+        description='Rows the Orq platform actually registered; a value below uploaded_count explains a smaller '
+        'Explorer sample count. None when the upload failed or was skipped (uploaded_count then records the '
+        'attempt) or the report predates this field — None with a set uploaded_count means "not confirmed".',
     )
 
     @field_validator('pipeline', mode='before')

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -1584,6 +1584,13 @@ class RedTeamReport(BaseModel):
         'shared by every attack\'s thread_id; powers the dashboard "View all run traces" '
         'deep-link. None for older reports.',
     )
+    uploaded_count: int | None = Field(
+        default=None, description='Cleaned result rows sent to the Orq platform'
+    )
+    rows_created: int | None = Field(
+        default=None,
+        description='Rows the Orq platform actually registered; a value below uploaded_count explains a smaller Explorer sample count',
+    )
 
     @field_validator('pipeline', mode='before')
     @classmethod

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -233,9 +233,7 @@ async def _send_cleaned_results(
             logger.debug('No cleaned results to send to Orq platform')
         return
 
-    logger.info(
-        f'Uploading {len(cleaned)} cleaned result(s) to Orq platform ({len(results)} raw report rows)'
-    )
+    logger.info(f'Uploading {len(cleaned)} cleaned result(s) to Orq platform ({len(results)} raw report rows)')
     if report is not None:
         # Recorded before the attempt so even an exception path leaves the
         # attempt count in the persisted JSON.

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -190,8 +190,10 @@ async def _send_cleaned_results(
     empty job results so the experiment shows one clean row per datapoint
     without duplication.
 
-    If *report* is provided, ``report.experiment_url`` is set to the URL
-    returned by the platform on a successful upload.
+    If *report* is provided, the upload diagnostics are persisted on it:
+    ``experiment_url``, ``uploaded_count`` (cleaned rows sent), and
+    ``rows_created`` (rows the platform actually registered) — so a local
+    JSON is enough to diagnose an Explorer sample-count mismatch.
 
     ``inference_client`` is the client used for inference; its Orq host is
     resolved once and forwarded so results upload to the same server inference
@@ -217,15 +219,32 @@ async def _send_cleaned_results(
         cleaned.append(clean)
 
     if not cleaned:
-        logger.debug('No cleaned results to send to Orq platform')
+        if report is not None:
+            report.uploaded_count = 0
+        if results:
+            # The worst-case "0 samples in Explorer" mismatch: rows existed
+            # locally but every job output was None, so nothing is uploaded
+            # and no experiment will exist. Surface it loudly, not at DEBUG.
+            logger.warning(
+                f'All {len(results)} result row(s) had no real output — nothing uploaded '
+                f'to Orq; the experiment will not exist in the Explorer.'
+            )
+        else:
+            logger.debug('No cleaned results to send to Orq platform')
         return
 
-    logger.debug(f'Sending {len(cleaned)} cleaned results to Orq platform (stripped from {len(results)} raw)')
+    logger.info(
+        f'Uploading {len(cleaned)} cleaned result(s) to Orq platform ({len(results)} raw report rows)'
+    )
+    if report is not None:
+        # Recorded before the attempt so even an exception path leaves the
+        # attempt count in the persisted JSON.
+        report.uploaded_count = len(cleaned)
     # Resolve the upload host before the try, so a resolution failure surfaces on
     # its own rather than being caught below and mislabelled as an upload failure.
     upload_base_url = resolve_results_base_url(inference_client)
     try:
-        experiment_url = await send_results_to_orq(
+        response = await send_results_to_orq(
             api_key=api_key,
             evaluation_name=name,
             evaluation_description=description,
@@ -235,8 +254,17 @@ async def _send_cleaned_results(
             end_time=datetime.now(tz=timezone.utc),
             base_url=upload_base_url,
         )
-        if report is not None and experiment_url:
-            report.experiment_url = experiment_url
+        if response is None:
+            return
+        # send_results_to_orq already warns when rows_created < uploaded.
+        logger.info(
+            f'Orq registered {response.rows_created}/{len(cleaned)} uploaded row(s)'
+            + (f' — {response.experiment_url}' if response.experiment_url else '')
+        )
+        if report is not None:
+            report.rows_created = response.rows_created
+            if response.experiment_url:
+                report.experiment_url = response.experiment_url
     except Exception as e:
         logger.error(f'Failed to upload {len(cleaned)} results to Orq platform: {e}. Results have been saved locally.')
 

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -233,6 +233,13 @@ async def _send_cleaned_results(
             logger.debug('No cleaned results to send to Orq platform')
         return
 
+    if len(cleaned) < len(results):
+        # A partial cleaning drop is a legitimate Explorer-mismatch cause
+        # upstream of the platform gap — surface it at WARNING, not INFO.
+        logger.warning(
+            f'{len(results) - len(cleaned)} of {len(results)} result row(s) had no real '
+            f'output and were dropped before upload; {len(cleaned)} will be uploaded.'
+        )
     logger.info(f'Uploading {len(cleaned)} cleaned result(s) to Orq platform ({len(results)} raw report rows)')
     if report is not None:
         # Recorded before the attempt so even an exception path leaves the
@@ -253,6 +260,14 @@ async def _send_cleaned_results(
             base_url=upload_base_url,
         )
         if response is None:
+            # send_results_to_orq swallows its own errors (raise_on_error=False)
+            # and returns None; without this line the most common failure — the
+            # platform rejecting the upload — would exit the runner wordless.
+            logger.warning(
+                f'Upload of {len(cleaned)} result(s) to Orq was not confirmed '
+                f'(see the send_results error above); rows_created stays unset. '
+                f'Results have been saved locally.'
+            )
             return
         # send_results_to_orq already warns when rows_created < uploaded.
         logger.info(
@@ -263,8 +278,11 @@ async def _send_cleaned_results(
             report.rows_created = response.rows_created
             if response.experiment_url:
                 report.experiment_url = response.experiment_url
-    except Exception as e:
-        logger.error(f'Failed to upload {len(cleaned)} results to Orq platform: {e}. Results have been saved locally.')
+    except Exception:
+        # With raise_on_error=False the upload call swallows its own errors, so
+        # anything landing here is a bug in the diagnostics block above — keep
+        # the traceback instead of mislabelling it as an upload failure.
+        logger.exception(f'Error while recording upload diagnostics for {len(cleaned)} uploaded result(s)')
 
 
 def _datapoint_breakdown(datapoints: list[Any]) -> dict[str, int]:

--- a/src/evaluatorq/send_results.py
+++ b/src/evaluatorq/send_results.py
@@ -53,7 +53,7 @@ async def send_results_to_orq(
     path: str | None = None,
     base_url: str | None = None,
     raise_on_error: bool = False,
-) -> str | None:
+) -> OrqResponse | None:
     """
     Send evaluation results to Orq platform.
 
@@ -74,8 +74,10 @@ async def send_results_to_orq(
         raise_on_error: Raise upload errors instead of treating upload as best-effort.
 
     Returns:
-        The experiment URL from the Orq platform on success, or ``None`` if the
-        upload failed or the platform did not return a URL.
+        The full ``OrqResponse`` (``experiment_url``, ``rows_created``,
+        ``experiment_name``, ``sheet_id``, ...) on success, or ``None`` if the
+        upload failed. Callers that only need the URL read
+        ``response.experiment_url``.
     """
     try:
         # Calculate duration in milliseconds
@@ -152,10 +154,21 @@ async def send_results_to_orq(
                 orq_result.experiment_name,
                 orq_result.rows_created,
             )
+            if orq_result.rows_created < len(results):
+                # The "missing samples" footgun: the platform registered fewer
+                # rows than we uploaded. One loud line with both numbers + URL.
+                logger.warning(
+                    "Orq registered {} of {} uploaded rows for experiment {!r} — "
+                    "some results will be missing from the Explorer. URL: {}",
+                    orq_result.rows_created,
+                    len(results),
+                    orq_result.experiment_name,
+                    orq_result.experiment_url or "<no url returned>",
+                )
             if orq_result.experiment_url:
                 logger.info('View your evaluation at: {}', orq_result.experiment_url)
 
-            return orq_result.experiment_url
+            return orq_result
 
     except SendResultsError:
         raise

--- a/src/evaluatorq/send_results.py
+++ b/src/evaluatorq/send_results.py
@@ -158,12 +158,12 @@ async def send_results_to_orq(
                 # The "missing samples" footgun: the platform registered fewer
                 # rows than we uploaded. One loud line with both numbers + URL.
                 logger.warning(
-                    "Orq registered {} of {} uploaded rows for experiment {!r} — "
-                    "some results will be missing from the Explorer. URL: {}",
+                    'Orq registered {} of {} uploaded rows for experiment {!r} — '
+                    'some results will be missing from the Explorer. URL: {}',
                     orq_result.rows_created,
                     len(results),
                     orq_result.experiment_name,
-                    orq_result.experiment_url or "<no url returned>",
+                    orq_result.experiment_url or '<no url returned>',
                 )
             if orq_result.experiment_url:
                 logger.info('View your evaluation at: {}', orq_result.experiment_url)

--- a/tests/redteam/test_send_cleaned_results.py
+++ b/tests/redteam/test_send_cleaned_results.py
@@ -12,10 +12,21 @@ import pytest
 
 from evaluatorq.redteam.contracts import Pipeline, RedTeamReport, ReportSummary
 from evaluatorq.redteam.runner import _send_cleaned_results
+from evaluatorq.send_results import OrqResponse
 from evaluatorq.types import DataPoint, DataPointResult, JobResult
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
+
+
+def _make_response(rows_created: int = 1, url: str | None = "https://orq.example/experiments/abc") -> OrqResponse:
+    return OrqResponse(
+        sheet_id="sheet-1",
+        manifest_id="manifest-1",
+        experiment_name="n",
+        rows_created=rows_created,
+        experiment_url=url,
+    )
 
 
 def _make_report() -> RedTeamReport:
@@ -49,7 +60,7 @@ async def test_sets_experiment_url_on_success() -> None:
         patch(
             "evaluatorq.redteam.runner.send_results_to_orq",
             new_callable=AsyncMock,
-            return_value="https://orq.example/experiments/abc",
+            return_value=_make_response(),
         ),
     ):
         await _send_cleaned_results(
@@ -162,3 +173,213 @@ async def test_base_url_falls_back_to_env_without_client() -> None:
         )
     assert spy.await_args is not None
     assert spy.await_args.kwargs["base_url"] == "https://my.staging.orq.ai"
+
+
+@pytest.mark.asyncio
+async def test_persists_upload_diagnostics_on_report() -> None:
+    """uploaded_count + rows_created land on the report alongside the URL, so a
+    local JSON is enough to diagnose an Explorer sample-count mismatch."""
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=_make_response(rows_created=1),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 1
+    assert report.rows_created == 1
+    assert report.experiment_url == "https://orq.example/experiments/abc"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_none_when_upload_returns_none() -> None:
+    """A failed upload leaves rows_created unset but records the attempt count."""
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 1
+    assert report.rows_created is None
+    assert report.experiment_url is None
+
+
+@pytest.mark.asyncio
+async def test_url_persisted_even_when_rows_created_gap() -> None:
+    """A rows_created < uploaded gap still persists all three diagnostics."""
+    report = _make_report()
+    results = [_make_result(), _make_result()]
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=_make_response(rows_created=1),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=results,
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 2
+    assert report.rows_created == 1
+    assert report.experiment_url == "https://orq.example/experiments/abc"
+
+
+@pytest.mark.asyncio
+async def test_report_json_roundtrips_diagnostics() -> None:
+    """The new optional fields serialize into the run JSON and old JSONs
+    without them still validate."""
+    report = _make_report()
+    report.uploaded_count = 17
+    report.rows_created = 8
+    data = report.model_dump(mode="json")
+    assert data["uploaded_count"] == 17
+    assert data["rows_created"] == 8
+    # backward compat: a legacy payload without the new keys still validates
+    data.pop("uploaded_count")
+    data.pop("rows_created")
+    legacy = RedTeamReport.model_validate(data)
+    assert legacy.uploaded_count is None
+    assert legacy.rows_created is None
+
+
+@pytest.mark.asyncio
+async def test_all_rows_stripped_warns_and_records_zero_uploaded() -> None:
+    """Raw rows that all strip to nothing must warn loudly (not DEBUG) and
+    persist uploaded_count=0 — the worst-case '0 samples in Explorer' path."""
+    from loguru import logger as _logger
+
+    report = _make_report()
+    stripped = DataPointResult(
+        data_point=DataPoint(inputs={"x": 1}),
+        job_results=[JobResult(job_name="j", output=None)],  # pyright: ignore[reportArgumentType]
+    )
+    lines: list[str] = []
+    handler_id = _logger.add(lambda m: lines.append(str(m)), level="WARNING", format="{message}")
+    try:
+        with (
+            patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+            patch(
+                "evaluatorq.redteam.runner.send_results_to_orq",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            await _send_cleaned_results(
+                results=[stripped],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+                report=report,
+            )
+    finally:
+        _logger.remove(handler_id)
+    mock_send.assert_not_awaited()
+    assert report.uploaded_count == 0
+    assert report.rows_created is None
+    warnings = [ln for ln in lines if "nothing uploaded" in ln]
+    assert len(warnings) == 1
+    assert "1 result row" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_empty_results_stays_quiet() -> None:
+    """No raw rows at all is not a mismatch — no warning, uploaded_count=0."""
+    from loguru import logger as _logger
+
+    report = _make_report()
+    lines: list[str] = []
+    handler_id = _logger.add(lambda m: lines.append(str(m)), level="WARNING", format="{message}")
+    try:
+        with patch.dict(os.environ, {"ORQ_API_KEY": "test"}):
+            await _send_cleaned_results(
+                results=[],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+                report=report,
+            )
+    finally:
+        _logger.remove(handler_id)
+    assert report.uploaded_count == 0
+    assert not lines
+
+
+@pytest.mark.asyncio
+async def test_uploaded_count_recorded_when_upload_raises() -> None:
+    """The attempt count survives an upload exception in the persisted report."""
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 1
+    assert report.rows_created is None
+
+
+@pytest.mark.asyncio
+async def test_auto_saved_run_json_contains_diagnostics(tmp_path) -> None:
+    """The runs-index JSON written by _auto_save_run carries the diagnostics
+    after _send_cleaned_results mutates the report (guards the mutate-before-
+    save ordering the pipelines rely on)."""
+    import json as _json
+
+    from evaluatorq.redteam import runner as runner_mod
+
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=_make_response(rows_created=1),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    with patch.object(runner_mod, "get_runs_dir", return_value=tmp_path):
+        path = runner_mod._auto_save_run(report, name="diag-test")
+    assert path is not None
+    data = _json.loads(path.read_text())
+    assert data["uploaded_count"] == 1
+    assert data["rows_created"] == 1
+    assert data["experiment_url"] == "https://orq.example/experiments/abc"

--- a/tests/redteam/test_send_cleaned_results.py
+++ b/tests/redteam/test_send_cleaned_results.py
@@ -383,3 +383,103 @@ async def test_auto_saved_run_json_contains_diagnostics(tmp_path) -> None:
     assert data["uploaded_count"] == 1
     assert data["rows_created"] == 1
     assert data["experiment_url"] == "https://orq.example/experiments/abc"
+
+
+def _make_empty_result() -> DataPointResult:
+    """A row whose only job output is None — stripped during cleaning."""
+    return DataPointResult(
+        data_point=DataPoint(inputs={"x": 2}),
+        job_results=[JobResult(job_name="j", output=None)],  # pyright: ignore[reportArgumentType]
+    )
+
+
+def _capture_loguru() -> tuple[list[str], int]:
+    from loguru import logger as _logger
+
+    lines: list[str] = []
+    handler_id = _logger.add(lambda m: lines.append(str(m)), level="DEBUG")
+    return lines, handler_id
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_upload_warns_instead_of_silent_return() -> None:
+    """send_results_to_orq returning None (it swallowed an upload error) must
+    leave a WARNING, not exit wordless after the 'Uploading N...' line."""
+    from loguru import logger as _logger
+
+    report = _make_report()
+    lines, handler_id = _capture_loguru()
+    try:
+        with (
+            patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+            patch(
+                "evaluatorq.redteam.runner.send_results_to_orq",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await _send_cleaned_results(
+                results=[_make_result()],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+                report=report,
+            )
+    finally:
+        _logger.remove(handler_id)
+    warnings = [ln for ln in lines if "was not confirmed" in ln]
+    assert len(warnings) == 1
+    assert report.uploaded_count == 1
+    assert report.rows_created is None
+
+
+@pytest.mark.asyncio
+async def test_partial_cleaning_drop_warns() -> None:
+    """A partial drop (some rows stripped, some uploaded) warns with both counts."""
+    from loguru import logger as _logger
+
+    lines, handler_id = _capture_loguru()
+    try:
+        with (
+            patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+            patch(
+                "evaluatorq.redteam.runner.send_results_to_orq",
+                new_callable=AsyncMock,
+                return_value=_make_response(rows_created=1),
+            ),
+        ):
+            await _send_cleaned_results(
+                results=[_make_result(), _make_empty_result(), _make_empty_result()],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+            )
+    finally:
+        _logger.remove(handler_id)
+    drop_warnings = [ln for ln in lines if "2 of 3 result row(s) had no real" in ln]
+    assert len(drop_warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_cleaning_drop_warning_when_all_rows_survive() -> None:
+    from loguru import logger as _logger
+
+    lines, handler_id = _capture_loguru()
+    try:
+        with (
+            patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+            patch(
+                "evaluatorq.redteam.runner.send_results_to_orq",
+                new_callable=AsyncMock,
+                return_value=_make_response(rows_created=1),
+            ),
+        ):
+            await _send_cleaned_results(
+                results=[_make_result()],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+            )
+    finally:
+        _logger.remove(handler_id)
+    assert not [ln for ln in lines if "had no real output and were dropped" in ln]

--- a/tests/test_evaluatorq_upload_sink.py
+++ b/tests/test_evaluatorq_upload_sink.py
@@ -1,0 +1,67 @@
+"""evaluatorq() reads experiment_url off the OrqResponse and feeds the sink."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import evaluatorq.evaluatorq  # noqa: F401  populate sys.modules; the package attr is shadowed by the function
+from evaluatorq import DataPoint, evaluatorq
+from evaluatorq.send_results import OrqResponse
+
+# evaluatorq.evaluatorq resolves to the re-exported function, not the submodule,
+# so patch the module object directly (3.10's mock can't resolve the shadowed path).
+_EQ_MOD = sys.modules["evaluatorq.evaluatorq"]
+
+
+async def _job(data: DataPoint, _row: int) -> dict[str, Any]:
+    return {"name": "j", "output": "ok"}
+
+
+def _response(url: str | None) -> OrqResponse:
+    return OrqResponse(
+        sheet_id="s1",
+        manifest_id="m1",
+        experiment_name="run",
+        rows_created=1,
+        experiment_url=url,
+    )
+
+
+async def _run_with_upload_response(response: OrqResponse | None) -> list[str]:
+    sink: list[str] = []
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch.object(_EQ_MOD, "send_results_to_orq", AsyncMock(return_value=response)),
+    ):
+        await evaluatorq(
+            "run",
+            data=[DataPoint(inputs={"x": 1})],
+            jobs=[_job],
+            print_results=False,
+            _experiment_url_out=sink,
+        )
+    return sink
+
+
+@pytest.mark.asyncio
+async def test_sink_receives_experiment_url_from_orq_response() -> None:
+    """The happy path: a real OrqResponse lands its URL in the caller's sink."""
+    sink = await _run_with_upload_response(_response("https://my.orq.ai/e/abc"))
+    assert sink == ["https://my.orq.ai/e/abc"]
+
+
+@pytest.mark.asyncio
+async def test_sink_untouched_when_upload_unconfirmed() -> None:
+    sink = await _run_with_upload_response(None)
+    assert sink == []
+
+
+@pytest.mark.asyncio
+async def test_sink_untouched_when_response_has_no_url() -> None:
+    sink = await _run_with_upload_response(_response(None))
+    assert sink == []

--- a/tests/test_send_results.py
+++ b/tests/test_send_results.py
@@ -20,7 +20,7 @@ from evaluatorq.types import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def build_results():
     """Factory fixture that creates a single DataPointResult with given score and error."""
 
@@ -564,3 +564,133 @@ class TestSendResultsBaseUrl:
             end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
         )
         assert captured["url"] == "https://my.staging.orq.ai/v2/spreadsheets/evaluations/receive"
+
+
+class TestUploadDiagnostics:
+    """RES-823: the full OrqResponse is returned and upload gaps warn loudly."""
+
+    @staticmethod
+    def _fake_post(rows_created: int, url: str | None = "https://my.orq.ai/e/abc"):
+        async def fake_post(self: httpx.AsyncClient, *args: Any, **kwargs: Any) -> httpx.Response:
+            request = httpx.Request("POST", "https://my.orq.ai/v2/spreadsheets/evaluations/receive")
+            body = {
+                "sheet_id": "s1",
+                "manifest_id": "m1",
+                "experiment_name": "eval",
+                "rows_created": rows_created,
+            }
+            if url is not None:
+                body["experiment_url"] = url
+            return httpx.Response(200, request=request, json=body)
+
+        return fake_post
+
+    @staticmethod
+    def _capture_loguru() -> tuple[list[str], int]:
+        from loguru import logger as _logger
+
+        lines: list[str] = []
+        handler_id = _logger.add(
+            lambda message: lines.append(str(message)), level="WARNING", format="{message}"
+        )
+        return lines, handler_id
+
+    @pytest.mark.asyncio
+    async def test_success_returns_full_orq_response(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=1))
+        response = await send_results_to_orq(
+            api_key="key",
+            evaluation_name="eval",
+            evaluation_description=None,
+            dataset_id=None,
+            results=build_results(0.5),
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        )
+        assert response is not None
+        assert response.rows_created == 1
+        assert response.experiment_url == "https://my.orq.ai/e/abc"
+        assert response.experiment_name == "eval"
+        assert response.sheet_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_gap_between_uploaded_and_rows_created_warns_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=0))
+        lines, handler_id = self._capture_loguru()
+        try:
+            await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=build_results(0.5),  # 1 uploaded, 0 registered
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        gap_warnings = [ln for ln in lines if "registered 0 of 1 uploaded" in ln]
+        assert len(gap_warnings) == 1
+        assert "https://my.orq.ai/e/abc" in gap_warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_all_rows_created(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=1))
+        lines, handler_id = self._capture_loguru()
+        try:
+            await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=build_results(0.5),
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        assert not [ln for ln in lines if "registered" in ln]
+
+    @pytest.mark.asyncio
+    async def test_gap_warning_without_url_uses_placeholder(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=0, url=None))
+        lines, handler_id = self._capture_loguru()
+        try:
+            response = await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=build_results(0.5),
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        assert response is not None
+        assert response.experiment_url is None
+        gap_warnings = [ln for ln in lines if "registered 0 of 1 uploaded" in ln]
+        assert len(gap_warnings) == 1
+        assert "<no url returned>" in gap_warnings[0]

--- a/tests/test_send_results.py
+++ b/tests/test_send_results.py
@@ -668,6 +668,35 @@ class TestUploadDiagnostics:
         assert not [ln for ln in lines if "registered" in ln]
 
     @pytest.mark.asyncio
+    async def test_partial_gap_warning_carries_both_counts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        """A 3-of-5 partial registration warns with the exact numbers."""
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=3))
+        five_results = [r for _ in range(5) for r in build_results(0.5)]
+        lines, handler_id = self._capture_loguru()
+        try:
+            response = await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=five_results,
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        assert response is not None
+        assert response.rows_created == 3
+        gap_warnings = [ln for ln in lines if "registered 3 of 5 uploaded" in ln]
+        assert len(gap_warnings) == 1
+
+    @pytest.mark.asyncio
     async def test_gap_warning_without_url_uses_placeholder(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Migrated from orqkit PR [#193](https://github.com/orq-ai/orqkit/pull/193) (the evaluatorq package moved to this repo). Implements RES-823: the upload boundary no longer throws away the diagnostics that explain the recurring "34 local rows, 8 in Explorer" mismatch.

- **`send_results_to_orq` returns the full `OrqResponse`** (`experiment_url`, `rows_created`, `experiment_name`, `sheet_id`) instead of just the URL string. The **gap warning** lives at this boundary: `rows_created < uploaded rows` produces exactly one WARNING line with both numbers and the URL, so both the red-team runner and plain `evaluatorq()` uploads get mismatch visibility from one implementation.
- **`_send_cleaned_results`** logs at INFO: cleaned vs raw row counts before upload, registered/uploaded counts + URL after; and persists **`uploaded_count`**, **`rows_created`**, and `experiment_url` on `RedTeamReport`, so the local run JSON alone diagnoses an Explorer sample-count gap.
- **Strip-to-zero path surfaced**: when raw rows exist but every job output is `None`, the skip now warns loudly (was DEBUG-only) and persists `uploaded_count=0`; the attempt count is recorded before the upload call so even an exception path leaves it in the JSON.
- **`RedTeamReport`**: two new optional fields, backward compatible.

## Migration notes

- Since the orqkit branch, this repo gained the `_experiment_url_out` sink in `evaluatorq.py` (simulation persists the experiment URL) and the RES-912 `resolve_results_base_url` forwarding in `_send_cleaned_results`; both are reconciled with the new `OrqResponse` return.

## Testing

- Full non-integration suite: 3431 passed. `ruff check src` and `basedpyright` clean.

Ticket: RES-823
