### PR TITLE
feat(pairwise): expose a max_concurrency cap on the jury fan-out (RES-1183)

### DIFF
--- a/docs/pairwise-judging.md
+++ b/docs/pairwise-judging.md
@@ -99,6 +99,7 @@ unavailable (no second ordering to disagree with).
 | `repetitions` | `1` | How many times each judge is asked per ordering; the judge takes its own majority first. |
 | `replacement_judges` | `None` | Stand-ins for judges that fail mechanically. Promoted per pair and run in **both** orderings, so a stand-in casts a real reconciled vote. |
 | `min_successful_judges` | `1` | Minimum decisive reconciled votes, otherwise the comparison is **inconclusive**. Must not exceed the panel size. |
+| `max_concurrency` | `None` | Cap on total in-flight judge LLM calls across all concurrently running `compare()` calls (each pair fans out judges × orderings × repetitions). Unbounded when unset. |
 
 ## Reading a comparison
 
@@ -198,6 +199,10 @@ calls itself, so you can drive the swap-and-reconcile logic with your own judge.
 `reconcile_pair()` and `pairwise_consensus()` are exposed for the same reason.
 Most callers want `llm_jury_pairwise()`; reach for `run_pairwise()` when you are
 plugging in a non-LLM judge or testing the reconciliation directly.
+
+Both `run_pairwise()` and the shared `run_jury()` accept `max_concurrency` as an
+int or an existing `asyncio.Semaphore`; pass the same semaphore to several runs
+to bound their combined fan-out with one budget.
 
 ## Where to next
 

--- a/src/evaluatorq/common/jury.py
+++ b/src/evaluatorq/common/jury.py
@@ -214,11 +214,34 @@ def append_jury_summary(explanation: str | None, jury: JuryResult | None) -> str
     return f'{base} {summary}' if base else summary
 
 
+def as_semaphore(max_concurrency: int | asyncio.Semaphore | None) -> asyncio.Semaphore | None:
+    """Normalize a concurrency limit to a semaphore (or None for unbounded).
+
+    An existing semaphore passes through unchanged so several jury runs can
+    share one budget — ``run_pairwise`` relies on this to bound its two
+    concurrent orderings with a single limit.
+    """
+    if max_concurrency is None:
+        return None
+    if isinstance(max_concurrency, asyncio.Semaphore):
+        return max_concurrency
+    if max_concurrency < 1:
+        raise ValueError(f'max_concurrency ({max_concurrency}) must be >= 1.')
+    return asyncio.Semaphore(max_concurrency)
+
+
 async def _call_prediction(
-    judge_fn: Callable[[str], Awaitable[Prediction]], model: str, *, propagate_errors: bool = False
+    judge_fn: Callable[[str], Awaitable[Prediction]],
+    model: str,
+    *,
+    propagate_errors: bool = False,
+    semaphore: asyncio.Semaphore | None = None,
 ) -> Prediction:
     try:
-        return await judge_fn(model)
+        if semaphore is None:
+            return await judge_fn(model)
+        async with semaphore:
+            return await judge_fn(model)
     except Exception as exc:
         # When the caller has no redundancy to fall back on (a lone judge, no
         # replacements), let the error abort the run instead of silently
@@ -239,9 +262,11 @@ async def _judge_vote(
     replacement: bool,
     numeric_how: NumericAggName,
     propagate_errors: bool = False,
+    semaphore: asyncio.Semaphore | None = None,
 ) -> tuple[JuryVote, list[TokenUsage]]:
     predictions = await asyncio.gather(*[
-        _call_prediction(judge_fn, model, propagate_errors=propagate_errors) for _ in range(max(1, repetitions))
+        _call_prediction(judge_fn, model, propagate_errors=propagate_errors, semaphore=semaphore)
+        for _ in range(max(1, repetitions))
     ])
     usages = [p.token_usage for p in predictions if p.token_usage is not None]
     decisive = [p for p in predictions if p.decisive]
@@ -330,6 +355,7 @@ async def run_jury(
     aggregator: AggregatorSpec | None = None,
     tie_break_label: str | None = None,
     propagate_errors: bool = False,
+    max_concurrency: int | asyncio.Semaphore | None = None,
 ) -> JuryDeliberation:
     """Run a generic panel of judges and aggregate their verdicts.
 
@@ -344,6 +370,11 @@ async def run_jury(
     as a failed vote. Callers set this when the panel has no redundancy (a lone
     judge with no replacements) so an outage aborts loudly rather than producing
     inconclusive verdicts on every datapoint.
+
+    ``max_concurrency`` caps how many ``judge_fn`` calls run at once across the
+    whole panel (judges x repetitions, replacements included). Pass an int for
+    a run-local cap, or an existing ``asyncio.Semaphore`` to share one budget
+    across several jury runs. ``None`` (default) keeps the fan-out unbounded.
     """
     if aggregator is None:
         aggregator = 'mean_std' if verdict_kind is VerdictKind.NUMERIC else 'mode'
@@ -354,6 +385,7 @@ async def run_jury(
         numeric_how = cast('NumericAggName', aggregator)
     agg_fn: Aggregator = aggregator if callable(aggregator) else _AGGREGATORS[aggregator]
 
+    semaphore = as_semaphore(max_concurrency)
     resolved_panel = resolve_panel(panel)
     # Dedup the replacement pool against the panel AND within itself; a repeated
     # stand-in (e.g. ['mistral-large', 'mistral-large']) would otherwise cast two
@@ -375,6 +407,7 @@ async def run_jury(
             replacement=False,
             numeric_how=numeric_how,
             propagate_errors=propagate_errors,
+            semaphore=semaphore,
         )
         for model in resolved_panel
     ])
@@ -397,6 +430,7 @@ async def run_jury(
                 tie_break=tie_break,
                 replacement=True,
                 numeric_how=numeric_how,
+                semaphore=semaphore,
             )
             for model in stand_ins
         ])

--- a/src/evaluatorq/llm_jury.py
+++ b/src/evaluatorq/llm_jury.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import typing
 from typing import Any, Literal
@@ -15,7 +16,6 @@ from evaluatorq.common.jury import (
     TieBreak,
     VerdictKind,
     append_jury_summary,
-    as_semaphore,
     run_jury,
     validate_aggregator,
 )
@@ -546,14 +546,33 @@ class PairwiseComparator:
         self._structured_output = structured_output
         self._extra_kwargs = extra_kwargs
         self._client = client
-        # One semaphore for the comparator's lifetime: concurrent compare()
-        # calls draw from the same budget, so max_concurrency bounds TOTAL
-        # in-flight judge calls across pairs, not per pair.
-        self._semaphore = as_semaphore(max_concurrency)
+        if max_concurrency is not None and max_concurrency < 1:
+            raise ValueError(f'max_concurrency ({max_concurrency}) must be >= 1.')
+        self._max_concurrency = max_concurrency
+        self._semaphore: asyncio.Semaphore | None = None
+        self._semaphore_loop: asyncio.AbstractEventLoop | None = None
         self._verdict_model = _build_verdict_model(
             verdict_kind='categorical', labels=PAIRWISE_LABELS, score_range=(0.0, 1.0)
         )
         self._template = _pairwise_template(criteria)
+
+    def _current_semaphore(self) -> asyncio.Semaphore | None:
+        """The shared concurrency budget, bound to the running event loop.
+
+        One semaphore is shared by every compare() call on the same loop, so
+        ``max_concurrency`` bounds TOTAL in-flight judge calls across pairs. A
+        semaphore binds to the loop that first blocks on it, so when the caller
+        switches loops (e.g. one ``asyncio.run`` per pair) a fresh one is minted
+        instead of every judge call failing with 'bound to a different event
+        loop' and silently degrading verdicts to inconclusive.
+        """
+        if self._max_concurrency is None:
+            return None
+        loop = asyncio.get_running_loop()
+        if self._semaphore is None or self._semaphore_loop is not loop:
+            self._semaphore = asyncio.Semaphore(self._max_concurrency)
+            self._semaphore_loop = loop
+        return self._semaphore
 
     async def compare(self, *, question: str, response_a: str, response_b: str) -> PairwiseComparison:
         """Run the panel over one A-vs-B comparison and return the reconciled verdict."""
@@ -585,7 +604,7 @@ class PairwiseComparator:
             replacement_judges=self._replacement_judges,
             min_successful_judges=self._min_successful_judges,
             propagate_errors=(len(self._panel) == 1 and not self._replacement_judges),
-            max_concurrency=self._semaphore,
+            max_concurrency=self._current_semaphore(),
         )
 
 

--- a/src/evaluatorq/llm_jury.py
+++ b/src/evaluatorq/llm_jury.py
@@ -15,6 +15,7 @@ from evaluatorq.common.jury import (
     TieBreak,
     VerdictKind,
     append_jury_summary,
+    as_semaphore,
     run_jury,
     validate_aggregator,
 )
@@ -531,6 +532,7 @@ class PairwiseComparator:
         structured_output: bool,
         extra_kwargs: dict[str, Any] | None,
         client: Any,
+        max_concurrency: int | None = None,
     ) -> None:
         self._panel = panel
         self._system_prompt = system_prompt
@@ -544,6 +546,10 @@ class PairwiseComparator:
         self._structured_output = structured_output
         self._extra_kwargs = extra_kwargs
         self._client = client
+        # One semaphore for the comparator's lifetime: concurrent compare()
+        # calls draw from the same budget, so max_concurrency bounds TOTAL
+        # in-flight judge calls across pairs, not per pair.
+        self._semaphore = as_semaphore(max_concurrency)
         self._verdict_model = _build_verdict_model(
             verdict_kind='categorical', labels=PAIRWISE_LABELS, score_range=(0.0, 1.0)
         )
@@ -579,6 +585,7 @@ class PairwiseComparator:
             replacement_judges=self._replacement_judges,
             min_successful_judges=self._min_successful_judges,
             propagate_errors=(len(self._panel) == 1 and not self._replacement_judges),
+            max_concurrency=self._semaphore,
         )
 
 
@@ -598,6 +605,7 @@ def llm_jury_pairwise(
     structured_output: bool = True,
     extra_kwargs: dict[str, Any] | None = None,
     client: Any = None,
+    max_concurrency: int | None = None,
 ) -> PairwiseComparator:
     """Build a pairwise (A-vs-B) LLM jury that reuses the shared panel machinery.
 
@@ -606,6 +614,11 @@ def llm_jury_pairwise(
     (see ADR-24). Panel/orchestration params mirror :func:`llm_jury`. Returns a
     :class:`PairwiseComparator`; call ``compare`` per A/B pair, and roll many
     comparisons up with :func:`evaluatorq.pairwise.build_report`.
+
+    ``max_concurrency`` caps TOTAL in-flight judge LLM calls across all
+    concurrently running ``compare`` calls on the returned comparator (each
+    pair fans out judges x orderings x repetitions). ``None`` (default) keeps
+    the fan-out unbounded.
     """
     if repetitions < 1:
         raise ValueError(f'repetitions ({repetitions}) must be >= 1.')
@@ -629,4 +642,5 @@ def llm_jury_pairwise(
         structured_output=structured_output,
         extra_kwargs=extra_kwargs,
         client=client,
+        max_concurrency=max_concurrency,
     )

--- a/src/evaluatorq/pairwise.py
+++ b/src/evaluatorq/pairwise.py
@@ -20,6 +20,7 @@ from evaluatorq.common.jury import (
     _agreement_rate,
     _plurality_vote,
     _sum_usage,
+    as_semaphore,
     resolve_panel,
     run_jury,
 )
@@ -222,6 +223,7 @@ async def run_pairwise(
     replacement_judges: Sequence[str] | None = None,
     min_successful_judges: int = 1,
     propagate_errors: bool = False,
+    max_concurrency: int | asyncio.Semaphore | None = None,
 ) -> PairwiseComparison:
     """Run a panel over one A-vs-B comparison and reconcile it into a verdict.
 
@@ -236,7 +238,15 @@ async def run_pairwise(
     stands in for. The winner is the plurality of the reconciled votes, or
     ``'inconclusive'`` when fewer than ``min_successful_judges`` cast a decisive
     reconciled vote.
+
+    ``max_concurrency`` caps how many judge calls run at once across the whole
+    comparison (judges x orderings x repetitions, replacements included). Pass
+    an existing ``asyncio.Semaphore`` to share one budget across several
+    comparisons. ``None`` (default) keeps the fan-out unbounded.
     """
+    # Normalized once so both orderings (and the replacement pass) draw from
+    # the same budget rather than each minting their own.
+    semaphore = as_semaphore(max_concurrency)
     resolved_panel = resolve_panel(panel)
 
     async def _ordering(models: Sequence[str], *, swapped: bool) -> tuple[dict[str, JuryVote], TokenUsage | None]:
@@ -255,6 +265,7 @@ async def run_pairwise(
             replacement_judges=None,
             min_successful_judges=1,
             propagate_errors=propagate_errors,
+            max_concurrency=semaphore,
         )
         return {v.model: v for v in deliberation.jury.votes}, deliberation.token_usage
 

--- a/tests/unit/test_jury_concurrency.py
+++ b/tests/unit/test_jury_concurrency.py
@@ -1,0 +1,193 @@
+"""RES-1183: max_concurrency bounds the jury/pairwise judge fan-out.
+
+Each test drives the fan-out with a judge_fn that tracks how many calls are
+in flight at once; the peak is compared against the configured cap. The
+sleep(0) yields let every scheduled call start before any finishes, so an
+unbounded fan-out provably exceeds the cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+import pytest
+
+from evaluatorq.common.judge import EvaluatorResponsePayload, JudgeOutcome
+from evaluatorq.common.jury import Prediction, as_semaphore, run_jury
+from evaluatorq.llm_jury import llm_jury_pairwise
+from evaluatorq.pairwise import run_pairwise
+
+llm_jury_module = sys.modules['evaluatorq.llm_jury']
+
+
+class InFlightTracker:
+    """Counts concurrent judge calls and records the peak."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+        self.total = 0
+
+    async def track(self) -> None:
+        self.active += 1
+        self.total += 1
+        self.peak = max(self.peak, self.active)
+        # Yield twice so every sibling task gets scheduled while this call is
+        # still "in flight"; without a cap the peak reaches the full fan-out.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        self.active -= 1
+
+
+def _tracked_judge_fn(tracker: InFlightTracker, value: str = 'yes'):
+    async def judge_fn(model: str) -> Prediction:
+        await tracker.track()
+        return Prediction(value=value, explanation='x')
+
+    return judge_fn
+
+
+def _tracked_pairwise_fn(tracker: InFlightTracker):
+    async def judge_fn(first: str, second: str, model: str) -> Prediction:
+        await tracker.track()
+        return Prediction(value='A' if first == 'GOOD' else 'B', explanation='x')
+
+    return judge_fn
+
+
+# --- as_semaphore ----------------------------------------------------------
+
+
+def test_as_semaphore_none_passthrough() -> None:
+    assert as_semaphore(None) is None
+
+
+def test_as_semaphore_existing_semaphore_passthrough() -> None:
+    sem = asyncio.Semaphore(3)
+    assert as_semaphore(sem) is sem
+
+
+def test_as_semaphore_rejects_non_positive() -> None:
+    with pytest.raises(ValueError, match='max_concurrency'):
+        as_semaphore(0)
+
+
+# --- run_jury ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_jury_unbounded_fanout_exceeds_cap() -> None:
+    """Sanity check: without a cap the repetitions really do run concurrently."""
+    tracker = InFlightTracker()
+    await run_jury(judge_fn=_tracked_judge_fn(tracker), panel=['j1', 'j2'], repetitions=3)
+    assert tracker.total == 6
+    assert tracker.peak > 2
+
+
+@pytest.mark.asyncio
+async def test_run_jury_caps_judges_times_repetitions() -> None:
+    tracker = InFlightTracker()
+    await run_jury(judge_fn=_tracked_judge_fn(tracker), panel=['j1', 'j2'], repetitions=3, max_concurrency=2)
+    assert tracker.total == 6
+    assert tracker.peak <= 2
+
+
+@pytest.mark.asyncio
+async def test_run_jury_cap_covers_replacement_judges() -> None:
+    tracker = InFlightTracker()
+
+    async def judge_fn(model: str) -> Prediction:
+        await tracker.track()
+        if model == 'primary':
+            return Prediction(error='boom')
+        return Prediction(value='yes', explanation='x')
+
+    deliberation = await run_jury(
+        judge_fn=judge_fn,
+        panel=['primary'],
+        repetitions=4,
+        replacement_judges=['stand-in'],
+        max_concurrency=2,
+    )
+    assert tracker.peak <= 2
+    assert deliberation.verdict == 'yes'
+
+
+# --- run_pairwise -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_pairwise_caps_judges_times_orderings_times_repetitions() -> None:
+    """Panel=3, swap, reps=2 fans out 12 calls; the cap bounds them to 4."""
+    tracker = InFlightTracker()
+    await run_pairwise(
+        judge_fn=_tracked_pairwise_fn(tracker),
+        panel=['j1', 'j2', 'j3'],
+        response_a='GOOD',
+        response_b='BAD',
+        swap=True,
+        repetitions=2,
+        max_concurrency=4,
+    )
+    assert tracker.total == 12
+    assert tracker.peak <= 4
+
+
+@pytest.mark.asyncio
+async def test_run_pairwise_unbounded_exceeds_cap() -> None:
+    tracker = InFlightTracker()
+    await run_pairwise(
+        judge_fn=_tracked_pairwise_fn(tracker),
+        panel=['j1', 'j2', 'j3'],
+        response_a='GOOD',
+        response_b='BAD',
+        swap=True,
+        repetitions=2,
+    )
+    assert tracker.peak > 4
+
+
+@pytest.mark.asyncio
+async def test_run_pairwise_default_verdict_unchanged_with_cap() -> None:
+    """The cap only schedules calls; the reconciled verdict is identical."""
+    result = await run_pairwise(
+        judge_fn=_tracked_pairwise_fn(InFlightTracker()),
+        panel=['j1', 'j2', 'j3'],
+        response_a='GOOD',
+        response_b='BAD',
+        max_concurrency=1,
+    )
+    assert result.winner == 'A'
+
+
+# --- PairwiseComparator / llm_jury_pairwise ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comparator_budget_shared_across_concurrent_pairs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One comparator, several concurrent compare() calls, one total budget."""
+    tracker = InFlightTracker()
+
+    async def fake_run_judge(**kwargs: Any) -> JudgeOutcome:
+        await tracker.track()
+        value = 'A' if kwargs['replacements']['response_a'] == 'GOOD' else 'B'
+        return JudgeOutcome(payload=EvaluatorResponsePayload(value=value, explanation='x'))
+
+    monkeypatch.setattr(llm_jury_module, 'run_judge', fake_run_judge)
+
+    comparator = llm_jury_pairwise(judges=['j1', 'j2'], client=object(), max_concurrency=3)
+    results = await asyncio.gather(*[
+        comparator.compare(question='q', response_a='GOOD', response_b='BAD') for _ in range(4)
+    ])
+
+    # 4 pairs x 2 judges x 2 orderings = 16 calls, never more than 3 at once.
+    assert tracker.total == 16
+    assert tracker.peak <= 3
+    assert all(r.winner == 'A' for r in results)
+
+
+def test_llm_jury_pairwise_rejects_non_positive_cap() -> None:
+    with pytest.raises(ValueError, match='max_concurrency'):
+        llm_jury_pairwise(judges=['j1'], client=object(), max_concurrency=0)

--- a/tests/unit/test_jury_concurrency.py
+++ b/tests/unit/test_jury_concurrency.py
@@ -191,3 +191,25 @@ async def test_comparator_budget_shared_across_concurrent_pairs(monkeypatch: pyt
 def test_llm_jury_pairwise_rejects_non_positive_cap() -> None:
     with pytest.raises(ValueError, match='max_concurrency'):
         llm_jury_pairwise(judges=['j1'], client=object(), max_concurrency=0)
+
+
+def test_comparator_survives_one_asyncio_run_per_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A capped comparator works across separate event loops (one asyncio.run
+    per pair). A semaphore binds to the loop that first blocks on it; without
+    per-loop recreation every judge call in the second loop errors and the
+    verdict silently degrades to inconclusive."""
+
+    async def fake_run_judge(**kwargs: Any) -> JudgeOutcome:
+        await asyncio.sleep(0.001)  # force the semaphore to actually block
+        value = 'A' if kwargs['replacements']['response_a'] == 'GOOD' else 'B'
+        return JudgeOutcome(payload=EvaluatorResponsePayload(value=value, explanation='x'))
+
+    monkeypatch.setattr(llm_jury_module, 'run_judge', fake_run_judge)
+
+    # max_concurrency=1 with 2 judges x 2 orderings guarantees contention.
+    comparator = llm_jury_pairwise(judges=['j1', 'j2'], client=object(), max_concurrency=1)
+    first = asyncio.run(comparator.compare(question='q', response_a='GOOD', response_b='BAD'))
+    second = asyncio.run(comparator.compare(question='q', response_a='GOOD', response_b='BAD'))
+
+    assert first.winner == 'A'
+    assert second.winner == 'A'

--- a/tests/unit/test_jury_concurrency.py
+++ b/tests/unit/test_jury_concurrency.py
@@ -150,6 +150,33 @@ async def test_run_pairwise_unbounded_exceeds_cap() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_pairwise_cap_covers_pair_level_replacements() -> None:
+    """The stand-in pass (_both over replacements) draws from the same budget."""
+    tracker = InFlightTracker()
+
+    async def judge_fn(first: str, second: str, model: str) -> Prediction:
+        await tracker.track()
+        if model == 'primary':
+            return Prediction(error='boom')
+        return Prediction(value='A' if first == 'GOOD' else 'B', explanation='x')
+
+    result = await run_pairwise(
+        judge_fn=judge_fn,
+        panel=['primary'],
+        response_a='GOOD',
+        response_b='BAD',
+        swap=True,
+        repetitions=3,
+        replacement_judges=['stand-in'],
+        max_concurrency=2,
+    )
+    # primary: 2 orderings x 3 reps = 6 calls, then stand-in: 6 more.
+    assert tracker.total == 12
+    assert tracker.peak <= 2
+    assert result.winner == 'A'
+
+
+@pytest.mark.asyncio
 async def test_run_pairwise_default_verdict_unchanged_with_cap() -> None:
     """The cap only schedules calls; the reconciled verdict is identical."""
     result = await run_pairwise(


### PR DESCRIPTION
## Summary

Implements RES-1183: an optional `max_concurrency` knob on the pairwise / jury fan-out. Previously `run_jury` and `run_pairwise` fanned out with unbounded `asyncio.gather`, so a consumer bounding pairs at `concurrency=5` with a 3-judge swapped panel still issued up to ~30 concurrent LLM calls with no way to cap them.

- **One choke point**: every judge call (primaries, repetitions, swapped orderings, replacement stand-ins) flows through `_call_prediction` in `common/jury.py`, so a single shared `asyncio.Semaphore` there bounds the whole fan-out. The `gather` calls are untouched; the semaphore does the bounding.
- **`run_jury(max_concurrency=...)`**: accepts an int (run-local cap) or an existing `asyncio.Semaphore` (shared budget). `as_semaphore()` normalizes and validates (>= 1).
- **`run_pairwise(max_concurrency=...)`**: normalizes once at the top and passes the same semaphore into both orderings and the pair-level replacement pass, so they draw from one budget instead of doubling it.
- **`llm_jury_pairwise(max_concurrency=...)` / `PairwiseComparator`**: the comparator mints its semaphore lazily, bound to the running event loop, and shares it across every `compare()` call on that loop. The limit therefore bounds TOTAL in-flight judge calls across concurrently running pairs, not per pair. The lazy per-loop minting also keeps a capped comparator working when callers run one `asyncio.run` per pair; a semaphore binds to the loop that first blocks on it, and reusing it across loops would otherwise silently degrade every verdict to `inconclusive` (regression-tested).
- **Docs**: `docs/pairwise-judging.md` gained the `max_concurrency` row and a note on sharing one semaphore across `run_pairwise`/`run_jury` runs.

Additive only: default `None` keeps current behavior; single-target `llm_jury` and the redteam jury are untouched (per the RES-760 note). If the single-target jury should get the same knob, it is a two-line follow-up since `run_jury` already accepts it.

## Testing

- 13 tests in `tests/unit/test_jury_concurrency.py` with an in-flight tracker asserting peak concurrency: `run_jury` (judges x repetitions, replacement pass), `run_pairwise` (panel=3, swap, reps=2 -> 12 calls capped at 4; pair-level replacement pass sharing the budget), comparator budget shared across 4 concurrent `compare()` calls (16 calls capped at 3), the one-`asyncio.run`-per-pair regression, unbounded-sanity checks proving the tracker observes real concurrency, verdict unchanged under a cap, and `ValueError` on non-positive limits.
- Full non-integration suite: 3432 passed. `ruff check src`, `ruff format --check src`, `basedpyright`, and `mkdocs build --strict` clean.

Ticket: RES-1183
