### PR TITLE
fix(simulation): isolate each conversation on its own target clone (RES-1195)

### DIFF
--- a/docs/cli-reference/simulation.md
+++ b/docs/cli-reference/simulation.md
@@ -25,7 +25,7 @@ Targets — provide **exactly one**:
 | Flag | Description |
 |---|---|
 | `--target` | `agent:<key>` or `deployment:<key>`. Bare values default to `agent:<key>`. |
-| `--memory-entity` | Memory `entity_id` sent with every `agent:<key>` (or bare `<key>`) target call, for agents with a memory store attached. Omit to mint a fresh id per run; pass one to reuse a specific (e.g. seeded) entity, shared across the run. |
+| `--memory-entity` | Memory `entity_id` sent with every `agent:<key>` (or bare `<key>`) target call, for agents with a memory store attached. Omit to mint a fresh id per conversation (parallel conversations never share memory); pass one to reuse a specific (e.g. seeded) entity, shared across the run. |
 | `--vercel-url` | Vercel AI SDK HTTP endpoint URL. |
 | `--openai-model` | OpenAI-compatible model name. Provider resolved from env: `ORQ_API_KEY` → Orq AI Router; `OPENAI_API_KEY` → OpenAI-compatible. |
 
@@ -67,7 +67,7 @@ and `--dataset-id`; the latter fetches the datapoints from an Orq dataset.
 |---|---|---|
 | `--input` / `-i` | `Path \| None` | Path to datapoints JSONL file. Mutually exclusive with `--dataset-id`. |
 | `--dataset-id` | `str \| None` | Fetch datapoints from an Orq dataset instead of a local file. Requires `ORQ_API_KEY`. |
-| `--memory-entity` | `str \| None` / `None` | Memory `entity_id` sent with every `agent:<key>` (or bare `<key>`) target call, for agents with a memory store attached. Omit to mint a fresh id per run; pass one to reuse a specific (e.g. seeded) entity. |
+| `--memory-entity` | `str \| None` / `None` | Memory `entity_id` sent with every `agent:<key>` (or bare `<key>`) target call, for agents with a memory store attached. Omit to mint a fresh id per conversation; pass one to reuse a specific (e.g. seeded) entity, shared across the run. |
 | `--name` / `-n` | `str` / `sim` | Run name for the run-store entry. |
 | `--sim-model` | `str` / `openai/gpt-5.4-mini` | Model for user-simulator and judge. |
 | `--max-turns` | `int` / `10` | Maximum conversation turns. |

--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -54,8 +54,9 @@ and opening messages from a short description of your agent — no hand-written
 
     Agents with a memory store attached reject calls that carry no memory scope
     (a 400 with `memory_entity_id_required`). A fresh entity id is minted per
-    run automatically; pass `memory_entity_id="..."` (CLI: `--memory-entity`)
-    to run against a specific, e.g. pre-seeded, entity instead.
+    conversation automatically, so parallel conversations never share memory;
+    pass `memory_entity_id="..."` (CLI: `--memory-entity`) to run every
+    conversation against one specific, e.g. pre-seeded, entity instead.
 
     ```python
     import asyncio

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -1047,6 +1047,21 @@ class AgentTarget(ABC):
 
     def __init__(self, memory_entity_id: str | None = None) -> None:
         self.memory_entity_id = memory_entity_id
+        # Seeded (constructor arg / plain assignment) vs auto-minted: subclasses
+        # whose ``new()`` distinguishes the two (ORQAgentTarget,
+        # OrqResponsesTarget) preserve seeded ids across clones and re-mint
+        # minted ones. ``mint_memory_entity_id`` is the non-seeding write path.
+        self._memory_entity_seeded = memory_entity_id is not None
+
+    def mint_memory_entity_id(self, value: str) -> None:
+        """Install an auto-minted memory entity id without marking it seeded.
+
+        Plain assignment to ``memory_entity_id`` counts as an explicit seed
+        (clone-preserving); backends minting a fallback scope use this instead
+        so every clone keeps re-minting its own isolated entity.
+        """
+        self.memory_entity_id = value
+        self._memory_entity_seeded = False
 
     @abstractmethod
     async def respond(self, messages: list[Message]) -> AgentResponse:

--- a/src/evaluatorq/openresponses/target.py
+++ b/src/evaluatorq/openresponses/target.py
@@ -64,6 +64,19 @@ class OrqResponsesTarget(AgentTarget):
         else:
             self._client, self._client_owned = build_simulation_client(config.client, require_orq=require_orq)
 
+    @property
+    def memory_entity_id(self) -> str | None:
+        return self._memory_entity_id
+
+    @memory_entity_id.setter
+    def memory_entity_id(self, value: str | None) -> None:
+        # Assignment is how callers seed an explicit entity id (the sim layer's
+        # --memory-entity path); mark it so ``new()`` preserves it across
+        # clones. ``new()``'s re-mint writes ``_memory_entity_id`` directly and
+        # stays unseeded. Mirrors ``ORQAgentTarget``'s seeded-vs-minted split.
+        self._memory_entity_id = value
+        self._memory_entity_seeded = value is not None
+
     async def respond(self, messages: list[Message]) -> AgentResponse:
         """Stateless: send the full message list, return the response."""
         return await self._call_responses_api(
@@ -78,20 +91,26 @@ class OrqResponsesTarget(AgentTarget):
         do so. Self-owned clients are not propagated — the new instance builds
         its own from env vars, keeping connection lifetimes independent.
 
-        Per the ``AgentTarget`` contract each ``new()`` produces an independent
-        memory scope; we mint a fresh ``memory_entity_id`` if one was set.
+        An explicitly seeded ``memory_entity_id`` (constructor arg or later
+        assignment) is preserved so clones keep pointing at the seeded entity;
+        an unseeded one is re-minted per clone, keeping parallel jobs in
+        independent memory scopes. Mirrors ``ORQAgentTarget.new()``.
         """
-        fresh_memory_id = str(uuid.uuid4()) if self.memory_entity_id is not None else None
-        return OrqResponsesTarget(
+        clone = OrqResponsesTarget(
             self.config,
             instructions=self.instructions,
             tools=self.tools,
-            memory_entity_id=fresh_memory_id,
+            memory_entity_id=self.memory_entity_id if self._memory_entity_seeded else None,
             client=self._client if not self._client_owned else None,
             retry_attempts=self.retry_attempts,
             retry_statuses=self.retry_statuses,
             require_orq=self.require_orq,
         )
+        if not self._memory_entity_seeded and self.memory_entity_id is not None:
+            # Re-mint bypassing the seeding setter so grandchild clones keep
+            # re-minting instead of inheriting this one as if it were seeded.
+            clone._memory_entity_id = str(uuid.uuid4())
+        return clone
 
     async def get_agent_context(self) -> AgentContext:
         """Describe this target — the configured model is the agent key."""

--- a/src/evaluatorq/redteam/backends/base.py
+++ b/src/evaluatorq/redteam/backends/base.py
@@ -151,7 +151,10 @@ class HybridAgentBackend(Backend):
         # Mint one per target, matching ORQAgentTarget, so parallel jobs stay
         # isolated and cleanup_memory has an id to delete.
         if getattr(target, 'memory_entity_id', 'unset') is None:
-            target.memory_entity_id = f'red-team-{uuid.uuid4().hex[:12]}'
+            # Auto-mint, not a user seed: plain assignment would mark the id
+            # seeded (clone-preserving), but a minted id must keep re-minting
+            # per clone or parallel jobs share one memory scope.
+            target.mint_memory_entity_id(f'red-team-{uuid.uuid4().hex[:12]}')
         return target
 
     async def resolve_context(self, agent_key: str) -> AgentContext:

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -201,9 +201,10 @@ async def simulate(
             ``agent:<key>`` (or bare ``<key>``) target. The Responses router
             requires a memory scope when the target agent has a memory store
             attached; pass this to run against a specific (e.g. seeded) entity.
-            When omitted, a fresh per-target id is minted so memory-backed
-            agents still work out of the box. One explicit id is shared across
-            the run's conversations. Only valid for string agent targets.
+            When omitted, a fresh id is minted per conversation so memory-backed
+            agents work out of the box and parallel conversations never share
+            memory. One explicit id is shared across the run's conversations.
+            Only valid for string agent targets.
         max_turns: Cap on conversation turns. Defaults to 10, or — when
             replaying via ``previous_run`` — to the cap the replayed run used.
             An explicit value always wins.

--- a/src/evaluatorq/simulation/runner/simulation.py
+++ b/src/evaluatorq/simulation/runner/simulation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
@@ -278,6 +279,10 @@ class SimulationRunner:
         self._effective_target: AgentTarget | None = target_agent or (
             CallableTarget(cast('AgentCallable', target)) if target is not None else None
         )
+        # Per-conversation clones minted by run() (see _new_conversation_target),
+        # retained so close() can release any resources they own (e.g. an
+        # OrqResponsesTarget clone builds its own HTTP client).
+        self._spawned_targets: list[AgentTarget] = []
         self._target_agent_timeout_ms = target_agent_timeout_ms
         self._max_target_retries = max_target_retries
         self._model = model
@@ -366,6 +371,13 @@ class SimulationRunner:
         response_traces: list[ResponseTrace] = []
 
         try:
+            # Each conversation runs against its own target clone: targets may
+            # hold per-conversation state (ORQAgentTarget threads server-side
+            # turns via _task_id; memory-backed targets own an entity id), and
+            # sharing one instance across parallel conversations races that
+            # state. new() preserves a seeded memory_entity_id and re-mints
+            # unseeded ones, so isolation never drops a --memory-entity seed.
+            conversation_target = self._new_conversation_target()
             # One Orq thread per simulation groups all its turns (target + user
             # simulator + judge) under one id in Orq observability. ContextVar
             # scoping keeps concurrent datapoints isolated. A run-scoped thread_id
@@ -394,6 +406,7 @@ class SimulationRunner:
                             run_span=run_span,
                             usage_holder=usage_holder,
                             response_traces=response_traces,
+                            conversation_target=conversation_target,
                         )
                         result.thread_id = thread_id
                         result.response_traces = response_traces
@@ -463,6 +476,7 @@ class SimulationRunner:
         run_span: Span | None,
         usage_holder: dict[str, Callable[[], TokenUsage]],
         response_traces: list[ResponseTrace],
+        conversation_target: AgentTarget | None = None,
     ) -> SimulationResult:
         """Inner simulation body (runs inside the orq.simulation.run span)."""
         system_prompt = build_datapoint_system_prompt(persona, scenario)  # pyright: ignore[reportArgumentType]
@@ -576,7 +590,7 @@ class SimulationRunner:
                         target_span,
                         [{'role': m.role, 'content': m.content or ''} for m in messages],
                     )
-                    call = await self._get_target_response(messages)
+                    call = await self._get_target_response(messages, target=conversation_target)
                     agent_response_text = call.response.text
                     # Only trust usage on success; a synthetic error response
                     # carries no real token accounting.
@@ -772,7 +786,21 @@ class SimulationRunner:
         return final_results
 
     async def close(self) -> None:
-        """Close and cleanup shared HTTP client."""
+        """Close the shared HTTP client and any per-conversation target clones."""
+        # Clones may own resources (an OrqResponsesTarget clone builds its own
+        # HTTP client when the parent's was self-owned); close them best-effort
+        # so one failing clone never masks the rest or the caller's exception.
+        spawned, self._spawned_targets = self._spawned_targets, []
+        for clone in spawned:
+            closer = getattr(clone, 'close', None)
+            if closer is None:
+                continue
+            try:
+                maybe_coro = closer()
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
+            except Exception as exc:
+                logger.warning('Failed to close per-conversation target clone: %s', exc)
         if self._shared_client is not None and self._client_owned:
             await self._shared_client.close()
             self._shared_client = None
@@ -841,21 +869,40 @@ class SimulationRunner:
             metadata=metadata,
         )
 
-    async def _get_target_response(self, messages: list[Message]) -> TargetCallResult:
+    def _new_conversation_target(self) -> AgentTarget | None:
+        """Mint a fresh target clone for one conversation.
+
+        Stateful targets (e.g. ``ORQAgentTarget`` threading server-side turns
+        via ``_task_id``) race when one instance serves parallel conversations,
+        so every ``run()`` gets its own ``new()`` clone. Clones are retained on
+        the runner so :meth:`close` can release resources they own.
+        """
+        if self._effective_target is None:
+            return None
+        clone = self._effective_target.new()
+        self._spawned_targets.append(clone)
+        return clone
+
+    async def _get_target_response(
+        self, messages: list[Message], *, target: AgentTarget | None = None
+    ) -> TargetCallResult:
         """Call the target through the shared bounded-retry + timeout helper.
 
-        Both target flavours (rich ``target_agent`` and a plain callback wrapped
-        in ``CallableTarget``) route through the same helper. The returned
+        ``target`` is the per-conversation clone minted by ``run()``; the shared
+        ``_effective_target`` is only a fallback for direct callers of this
+        helper. Both target flavours (rich ``target_agent`` and a plain callback
+        wrapped in ``CallableTarget``) route through the same helper. The returned
         :class:`TargetCallResult` carries ``.response`` (always populated — real
         or synthetic), ``.succeeded``, and ``.error``. ``response.model`` is the
         model the target reports (``None`` for plain callbacks, which may call any
         provider); NEVER substitute ``self._model`` — that is the user-simulator /
         judge model, not the evaluated target.
         """
-        if self._effective_target is None:
+        effective = target if target is not None else self._effective_target
+        if effective is None:
             raise RuntimeError('No target agent configured')
         return await call_target_with_retry(
-            self._effective_target,
+            effective,
             messages,
             target_agent_timeout_ms=self._target_agent_timeout_ms,
             max_target_retries=self._max_target_retries,

--- a/tests/redteam/test_orq_responses_target_as_agent_target.py
+++ b/tests/redteam/test_orq_responses_target_as_agent_target.py
@@ -120,3 +120,58 @@ class TestNew:
         client.responses.create = AsyncMock(return_value=_make_response())
         target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
         assert target.new()._client is client
+
+    def test_new_preserves_constructor_seeded_memory_entity(self):
+        """A seeded id must survive cloning (the sim --memory-entity path);
+        mirrors ORQAgentTarget.new() semantics."""
+        target = OrqResponsesTarget(
+            LLMCallConfig(model="gpt-4o"), client=_make_client(), memory_entity_id="seeded-entity"
+        )
+        assert target.new().memory_entity_id == "seeded-entity"
+
+    def test_new_preserves_assignment_seeded_memory_entity(self):
+        target = _make_target()
+        target.memory_entity_id = "seeded-entity"
+        assert target.new().memory_entity_id == "seeded-entity"
+
+    def test_seeded_id_survives_grandchild_clones(self):
+        target = OrqResponsesTarget(
+            LLMCallConfig(model="gpt-4o"), client=_make_client(), memory_entity_id="seeded-entity"
+        )
+        assert target.new().new().memory_entity_id == "seeded-entity"
+
+    def test_unseeding_via_assignment_reverts_to_none_clones(self):
+        target = OrqResponsesTarget(
+            LLMCallConfig(model="gpt-4o"), client=_make_client(), memory_entity_id="seeded-entity"
+        )
+        target.memory_entity_id = None
+        assert target.new().memory_entity_id is None
+
+
+class TestHybridBackendMintStaysUnseeded:
+    """The HybridAgentBackend auto-mint is not a user seed: clones must
+    re-mint it (parallel-job isolation), while a later explicit assignment
+    seeds and survives clones."""
+
+    def _hybrid_target(self, monkeypatch):
+        from evaluatorq.redteam.backends.registry import make_agent_backend
+        from evaluatorq.redteam.contracts import LLMConfig, TargetConfig
+
+        monkeypatch.setenv("ORQ_API_KEY", "test-key")
+        backend = make_agent_backend(
+            target_config=TargetConfig(system_prompt=None), pipeline_config=LLMConfig()
+        )
+        return backend.create_target("my-agent")
+
+    def test_auto_minted_id_re_mints_per_clone(self, monkeypatch):
+        target = self._hybrid_target(monkeypatch)
+        assert target.memory_entity_id is not None
+        assert target.memory_entity_id.startswith("red-team-")
+        clone = target.new()
+        assert clone.memory_entity_id is not None
+        assert clone.memory_entity_id != target.memory_entity_id
+
+    def test_explicit_seed_after_create_survives_clone(self, monkeypatch):
+        target = self._hybrid_target(monkeypatch)
+        target.memory_entity_id = "seeded-entity"
+        assert target.new().memory_entity_id == "seeded-entity"

--- a/tests/simulation/runner/test_target_isolation.py
+++ b/tests/simulation/runner/test_target_isolation.py
@@ -1,0 +1,222 @@
+"""Per-conversation target isolation: parallel conversations must never share
+mutable target state (the shared-instance ``_task_id`` race).
+
+The fake target below mimics ``ORQAgentTarget``'s statefulness: ``respond``
+reads its ``_task_id``, yields to the event loop (as a real HTTP call would),
+then writes a conversation-specific value back. On a shared instance,
+concurrent conversations interleave those read/write pairs and stitch turns
+onto the wrong chain — which is exactly what the runner's per-conversation
+``new()`` clone prevents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, AgentTarget, Message
+from evaluatorq.simulation.runner.simulation import SimulationRunner
+from evaluatorq.simulation.types import (
+    CommunicationStyle,
+    Persona,
+    Scenario,
+    SimulationDatapoint,
+)
+
+
+def _datapoint(idx: int) -> SimulationDatapoint:
+    persona = Persona(
+        name=f'P{idx}',
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background='A test user.',
+    )
+    scenario = Scenario(name=f'S{idx}', goal='Get help')
+    return SimulationDatapoint(
+        id=f'dp-{idx}',
+        persona=persona,
+        scenario=scenario,
+        user_system_prompt='',
+        first_message='hello',
+    )
+
+
+class StatefulFakeTarget(AgentTarget):
+    """Mimics ORQAgentTarget's per-conversation state and clone semantics."""
+
+    def __init__(
+        self, *, memory_entity_id: str | None = None, registry: list[StatefulFakeTarget] | None = None
+    ) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
+        self._seeded = memory_entity_id is not None
+        self._task_id: str | None = None
+        self.task_writes: list[tuple[str | None, str]] = []
+        self.closed = False
+        # Shared across clones so tests can inspect every instance that served.
+        self.registry: list[StatefulFakeTarget] = registry if registry is not None else []
+        self.registry.append(self)
+
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        conversation = next(m.content for m in messages if m.role == 'user')
+        observed = self._task_id
+        # Yield twice so concurrent conversations interleave here, exactly like
+        # a real HTTP round-trip between the _task_id read and write.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        self._task_id = f'task-{conversation}'
+        self.task_writes.append((observed, self._task_id))
+        return AgentResponse(text=f'reply to {conversation}')
+
+    def new(self) -> StatefulFakeTarget:
+        return StatefulFakeTarget(
+            memory_entity_id=self.memory_entity_id if self._seeded else None,
+            registry=self.registry,
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _runner(target: AgentTarget) -> SimulationRunner:
+    # The runner validates injected agents by duck typing, so the plain fakes
+    # below suffice; cast for the type checker only.
+    return SimulationRunner(
+        target_agent=target,
+        max_turns=1,
+        user_simulator=cast('Any', _FakeUserSimulator()),
+        judge=cast('Any', _FakeJudge()),
+    )
+
+
+class _FakeUserSimulator:
+    def update_context(self, *, persona_context=None, scenario_context=None) -> None:
+        return None
+
+    async def generate_first_message(self) -> str:
+        return 'hello'
+
+    async def respond_async(self, messages, *, llm_purpose=None) -> str:
+        return 'user follow-up'
+
+    def get_usage(self):
+        from evaluatorq.contracts import TokenUsage
+
+        return TokenUsage()
+
+    def reset_usage(self) -> None:
+        return None
+
+
+class _FakeJudge:
+    async def evaluate(self, messages):
+        from evaluatorq.simulation.types import Judgment
+
+        return Judgment(
+            should_terminate=True,
+            reason='ok',
+            goal_achieved=True,
+            rules_broken=[],
+            goal_completion_score=1.0,
+        )
+
+    def get_usage(self):
+        from evaluatorq.contracts import TokenUsage
+
+        return TokenUsage()
+
+    def reset_usage(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_parallel_conversations_never_share_a_target_instance() -> None:
+    """Each conversation runs on its own clone with a self-consistent task chain.
+
+    On a shared instance (main before this fix) the interleaved read/write
+    pairs cross conversations: some clone would observe a prior task id
+    belonging to a different conversation.
+    """
+    registry: list[StatefulFakeTarget] = []
+    root = StatefulFakeTarget(registry=registry)
+    runner = _runner(root)
+
+    datapoints = [_datapoint(i) for i in range(4)]
+    results = await runner.run_batch(datapoints, max_concurrency=4)
+
+    assert len(results) == 4
+    assert all(r.terminated_by.value != 'error' for r in results), [r.reason for r in results]
+    # The root never served a conversation; each conversation used a fresh clone.
+    assert root.task_writes == []
+    serving = [t for t in registry if t.task_writes]
+    assert len(serving) == 4
+    for clone in serving:
+        # A fresh clone starts with no task id, and every write on it belongs
+        # to one conversation only (no cross-conversation observations).
+        observed_ids = {obs for obs, _new in clone.task_writes}
+        written_ids = {new for _obs, new in clone.task_writes}
+        assert observed_ids <= {None} | written_ids
+        assert len(written_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_seeded_memory_entity_reaches_every_conversation() -> None:
+    registry: list[StatefulFakeTarget] = []
+    root = StatefulFakeTarget(memory_entity_id='seeded-entity', registry=registry)
+    runner = _runner(root)
+
+    await runner.run_batch([_datapoint(i) for i in range(3)], max_concurrency=3)
+
+    serving = [t for t in registry if t.task_writes]
+    assert len(serving) == 3
+    assert all(t.memory_entity_id == 'seeded-entity' for t in serving)
+
+
+@pytest.mark.asyncio
+async def test_unseeded_clones_get_isolated_memory_scopes() -> None:
+    registry: list[StatefulFakeTarget] = []
+    root = StatefulFakeTarget(registry=registry)
+    runner = _runner(root)
+
+    await runner.run_batch([_datapoint(i) for i in range(3)], max_concurrency=3)
+
+    serving = [t for t in registry if t.task_writes]
+    assert all(t.memory_entity_id is None for t in serving)
+
+
+@pytest.mark.asyncio
+async def test_close_releases_spawned_clones() -> None:
+    registry: list[StatefulFakeTarget] = []
+    root = StatefulFakeTarget(registry=registry)
+    runner = _runner(root)
+
+    await runner.run_batch([_datapoint(i) for i in range(2)], max_concurrency=2)
+    await runner.close()
+
+    clones = [t for t in registry if t is not root]
+    assert clones
+    assert all(t.closed for t in clones)
+    # The shared root target is owned by the caller, not the runner.
+    assert root.closed is False
+
+
+@pytest.mark.asyncio
+async def test_plain_callable_target_still_works() -> None:
+    async def target(messages: list[Message]) -> str:
+        return 'callable reply'
+
+    runner = SimulationRunner(
+        target=target,
+        max_turns=1,
+        user_simulator=cast('Any', _FakeUserSimulator()),
+        judge=cast('Any', _FakeJudge()),
+    )
+    results = await runner.run_batch([_datapoint(0)], max_concurrency=1)
+
+    assert len(results) == 1
+    assert results[0].terminated_by.value != 'error'
+    assert any(m.content == 'callable reply' for m in results[0].messages)

--- a/tests/simulation/runner/test_target_retry.py
+++ b/tests/simulation/runner/test_target_retry.py
@@ -90,20 +90,28 @@ def _make_mock_judge() -> MagicMock:
 
 
 class _FlakyTarget(AgentTarget):
-    """Returns an error-marker AgentResponse for the first ``fail_times`` calls."""
+    """Returns an error-marker AgentResponse for the first ``fail_times`` calls.
 
-    def __init__(self, fail_times: int) -> None:
+    The fail budget and call counter live in a shared dict so the
+    per-conversation clone the runner mints (``new()``) keeps counting against
+    the same state — these tests assert retry behavior, not clone isolation.
+    """
+
+    def __init__(self, fail_times: int, *, _state: dict[str, int] | None = None) -> None:
         super().__init__()
-        self._fail = fail_times
-        self.calls = 0
+        self._state = _state if _state is not None else {'fail': fail_times, 'calls': 0}
+
+    @property
+    def calls(self) -> int:
+        return self._state['calls']
 
     def new(self) -> _FlakyTarget:
-        return _FlakyTarget(self._fail)
+        return _FlakyTarget(0, _state=self._state)
 
     async def respond(self, messages: list[Message]) -> AgentResponse:
-        self.calls += 1
-        if self._fail > 0:
-            self._fail -= 1
+        self._state['calls'] += 1
+        if self._state['fail'] > 0:
+            self._state['fail'] -= 1
             return AgentResponse(
                 text='[ERROR]',
                 error=AgentResponseError(message='boom', error_type='target_error'),

--- a/tests/simulation/test_orq_responses_target.py
+++ b/tests/simulation/test_orq_responses_target.py
@@ -316,15 +316,24 @@ class TestOrqResponsesTargetNew:
         target = _make_target(client=client, instructions="Be concise.")
         assert target.new().instructions == "Be concise."
 
-    def test_new_mints_fresh_memory_entity_id_when_set(self):
-        import uuid
-
+    def test_new_preserves_constructor_seeded_memory_entity_id(self):
+        """A constructor-passed id is a seed and survives clones (the sim
+        --memory-entity path); only auto-minted ids re-mint per clone."""
         client = _make_client()
         target = OrqResponsesTarget(
             LLMCallConfig(model="gpt-4o"),
             memory_entity_id="original-uuid-abc",
             client=client,
         )
+
+        assert target.new().memory_entity_id == "original-uuid-abc"
+
+    def test_new_re_mints_auto_minted_memory_entity_id(self):
+        import uuid
+
+        client = _make_client()
+        target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
+        target.mint_memory_entity_id("minted-abc")
 
         fresh = target.new()
 

--- a/tests/simulation/test_tracing.py
+++ b/tests/simulation/test_tracing.py
@@ -1017,7 +1017,9 @@ async def test_target_agent_usage_aggregated_into_run_result(
             return AgentResponse(text=f'reply #{self.call_count}', usage=self._usage)
 
         def new(self) -> '_FakeAgentTarget':
-            return _FakeAgentTarget(self._usage)
+            # Shared on purpose: this test asserts usage aggregation on one
+            # instance, not clone isolation (covered in test_target_isolation).
+            return self
 
     target_usage = TokenUsage(
         input_tokens=9,


### PR DESCRIPTION
## Summary

Implements RES-1195 (split out of the RES-1164 review): the simulation runner reused one resolved target instance across all conversations in a run, so at the default `parallelism=5` concurrent conversations raced any per-conversation target state — `ORQAgentTarget` threads server-side turns via `self._task_id`, and memory-backed targets own an entity id, so turns could stitch onto the wrong server-side chain and conversations could share memory.

- **Per-conversation clone**: `SimulationRunner.run()` now mints `target.new()` per conversation and threads it through the turn loop instead of the shared `_effective_target`. One seam covers both execution paths (the evaluatorq job and direct `run_batch`). The runner tracks spawned clones and `close()` releases the resources they own (an `OrqResponsesTarget` clone builds its own HTTP client when the parent's was self-owned).
- **Seeded memory survives isolation**: `OrqResponsesTarget.new()` now preserves an explicitly seeded `memory_entity_id` (constructor arg or assignment) and re-mints unseeded ones — the same seeded-vs-minted split `ORQAgentTarget.new()` got in RES-1164. Without this, cloning would have silently dropped `--memory-entity`.
- **`AgentTarget.mint_memory_entity_id()`**: the non-seeding write path. `HybridAgentBackend`'s fallback mint uses it so auto-minted ids keep re-minting per clone (preserving red-team per-attack memory isolation) while user seeds survive.

## Behavior change worth knowing

An **unseeded** memory-store agent previously had all of a run's conversations share one auto-minted entity (a side effect of the shared instance); each conversation now gets its own entity, and `--memory-entity <id>` remains the way to share one deliberately. Docs updated in the guide, the CLI flag tables, and the `simulate()` docstring.

Usage accounting is unaffected: sim token totals accumulate from each turn's `AgentResponse.token_usage` inside the runner, never from target instance state.

## Testing

- New `tests/simulation/runner/test_target_isolation.py` (5 tests): a stateful fake target with a read-yield-write `_task_id` cycle proves each of 4 parallel conversations gets its own clone with a self-consistent task chain — **this test fails on main** (verified against the pre-fix runner); seeded entity reaches every conversation; unseeded clones stay isolated; `close()` releases spawned clones (and never the caller-owned root); plain-callable targets unaffected.
- 6 new clone-semantics tests for `OrqResponsesTarget` (constructor/assignment seeds survive, grandchild clones, hybrid-backend auto-mint re-mints per clone, explicit seed after `create_target` survives).
- Two existing tests updated for the new contract (retry fake shares its counter across clones; the old always-re-mint assertion now reflects seeded-survives).
- Full non-integration suite: 3462 passed. `ruff check src`, `ruff format --check src`, `basedpyright`, and `mkdocs build --strict` clean.

Ticket: RES-1195
