### PR TITLE
feat(jury): BT-sigma reliability-weighted aggregation for pairwise judging (RES-1024)

### DIFF
--- a/docs/pairwise-judging.md
+++ b/docs/pairwise-judging.md
@@ -148,6 +148,51 @@ for judge in report.per_judge:
     decisive vote, since one lone voter always "agrees" with itself and would
     otherwise flatter a degraded panel.
 
+## Reliability-weighted aggregation (BT-sigma)
+
+The default consensus treats every judge's vote equally. When your panel mixes
+judges of different quality (say a frontier model next to a small open-weight
+one), uniform plurality lets the noisy judges outvote the sharp one. BT-sigma
+(from "Who can we trust? LLM-as-a-jury for Comparative Assessment",
+[arXiv:2602.16610](https://arxiv.org/abs/2602.16610)) fixes this without any
+labels: it fits a Bradley-Terry model with a per-judge discriminator over the
+run's own reconciled votes, learning which judges are internally consistent and
+down-weighting the rest.
+
+```python
+from evaluatorq import build_report
+
+report = build_report(comparisons, aggregation="bt-sigma")
+
+report.bt_sigma.p_a_beats_b     # fitted global probability that A beats B
+report.bt_sigma.judge_sigmas    # per-judge discriminator, smaller = more reliable
+report.bt_sigma.winners         # reliability-weighted winner per comparison
+report.bt_sigma.a_win_rate      # weighted rollup, next to the plurality one
+```
+
+The headline plurality rates in the report are unchanged, so the two
+aggregations stay directly comparable, and each `JudgeStats` entry gains its
+fitted `sigma`. The fit is unsupervised maximum likelihood on the votes the run
+already collected: no extra LLM calls, no training data, and it runs in
+milliseconds.
+
+Notes worth knowing:
+
+- Reconciliation already symmetrises position bias (every judge votes in both
+  orderings), which is a requirement of the model, so votes feed the fit as-is.
+- With a single judge the discriminator is unidentifiable; the fit falls back
+  to plain Bradley-Terry and says so in `fit_warnings`.
+- A perfectly split panel stays inconclusive rather than letting numerical
+  noise crown one judge reliable.
+- Like all unsupervised aggregation, BT-sigma rewards internal consistency. A
+  majority of judges sharing the same systematic bias will still carry the
+  vote; it protects against noisy judges, not coordinated ones.
+
+For ranking more than two candidates (leaderboard-style), the underlying
+`evaluatorq.ranking.fit_bt()` accepts arbitrary item pairs from any number of
+judges and returns skills, a ranking, and per-judge reliability; `cycle_rate()`
+gives the matching consistency diagnostic.
+
 ## Saving a run and viewing it in the dashboard
 
 `build_report()` gives you the numbers in memory. To keep a run and read it in

--- a/docs/pairwise-judging.md
+++ b/docs/pairwise-judging.md
@@ -172,11 +172,13 @@ report.bt_sigma.a_win_rate      # weighted rollup, next to the plurality one
 
 The headline plurality rates in the report are unchanged, so the two
 aggregations stay directly comparable, and each `JudgeStats` entry gains its
-fitted `sigma`. The fit is unsupervised maximum likelihood on the votes the run
-already collected: no extra LLM calls and no training data. Identical votes
-are collapsed into weighted counts before the fit (at most three distinct
-judgements per judge in the A/B setting), so the cost stays flat no matter how
-many comparisons the run holds.
+fitted `sigma`. The fit is a regularized, unsupervised maximum-likelihood fit on
+the votes the run already collected: no extra LLM calls or training data.
+Identical votes are collapsed into weighted counts before the fit (at most
+three distinct judgements per judge in the A/B setting), so the cost stays flat
+no matter how many comparisons the run holds. The report exposes fit warnings
+and falls back to uniform plurality when the optimizer does not converge; do
+not treat a capped fit as a reliability estimate.
 
 Notes worth knowing:
 

--- a/docs/pairwise-judging.md
+++ b/docs/pairwise-judging.md
@@ -173,8 +173,10 @@ report.bt_sigma.a_win_rate      # weighted rollup, next to the plurality one
 The headline plurality rates in the report are unchanged, so the two
 aggregations stay directly comparable, and each `JudgeStats` entry gains its
 fitted `sigma`. The fit is unsupervised maximum likelihood on the votes the run
-already collected: no extra LLM calls, no training data, and it runs in
-milliseconds.
+already collected: no extra LLM calls and no training data. Identical votes
+are collapsed into weighted counts before the fit (at most three distinct
+judgements per judge in the A/B setting), so the cost stays flat no matter how
+many comparisons the run holds.
 
 Notes worth knowing:
 
@@ -184,6 +186,14 @@ Notes worth knowing:
   to plain Bradley-Terry and says so in `fit_warnings`.
 - A perfectly split panel stays inconclusive rather than letting numerical
   noise crown one judge reliable.
+- A judge whose decisive votes are unanimous (always A, or always B) is
+  excluded from the weighting. With only two items such a judge's sigma
+  measures one-sidedness, not reliability, and `1/sigma` would hand the most
+  degenerate judge on the panel an unbounded weight - the exact shape a
+  position- or verbosity-biased judge takes. It votes with a neutral weight
+  instead, and `fit_warnings` names it.
+- Check `bt_sigma.converged` (and `fit_warnings`) before trusting sigmas: a
+  fit that stopped at the iteration cap still produces numbers.
 - Like all unsupervised aggregation, BT-sigma rewards internal consistency. A
   majority of judges sharing the same systematic bias will still carry the
   vote; it protects against noisy judges, not coordinated ones.
@@ -191,7 +201,9 @@ Notes worth knowing:
 For ranking more than two candidates (leaderboard-style), the underlying
 `evaluatorq.ranking.fit_bt()` accepts arbitrary item pairs from any number of
 judges and returns skills, a ranking, and per-judge reliability; `cycle_rate()`
-gives the matching consistency diagnostic.
+gives the matching consistency diagnostic. `cycle_rate` is deliberately not
+part of the two-item aggregation above: with two fixed items there are no
+3-cycles to rate, so it only means something on the multi-item ranking path.
 
 ## Saving a run and viewing it in the dashboard
 

--- a/examples/bt_sigma_ranking.py
+++ b/examples/bt_sigma_ranking.py
@@ -1,0 +1,181 @@
+"""BT-sigma end-to-end demo: rank graded answers with a mixed-quality jury.
+
+Five questions each get four answers of known, graded quality (excellent >
+good > mediocre > bad). Every unordered pair of tiers is judged per question
+by a deliberately lopsided panel (one strong judge, two cheap ones), with
+position swap on. The tiers act as the four global Bradley-Terry items, so the
+run produces everything the BT-sigma paper (arXiv:2602.16610) reports, in
+miniature:
+
+- a fitted ranking to check against the known tier order,
+- a discriminator per judge (smaller = more reliable),
+- a directed 3-cycle rate per judge, the paper's independent consistency
+  signal that the discriminator should track.
+
+Cost: questions x 6 pairs x judges x 2 orderings LLM calls (~180 with the
+defaults). Needs ORQ_API_KEY.
+
+Usage::
+
+    python examples/bt_sigma_ranking.py [STRONG WEAK_1 WEAK_2]
+"""
+
+import asyncio
+import sys
+
+from evaluatorq import llm_jury_pairwise
+from evaluatorq.ranking import JudgedComparison, cycle_rate, fit_bt
+
+JUDGES = (
+    sys.argv[1:4]
+    if len(sys.argv) >= 4
+    else ['openai/gpt-5.4-mini', 'openai/gpt-5.4-nano', 'deepseek/deepseek-v4-flash']
+)
+
+TIERS = ['excellent', 'good', 'mediocre', 'bad']  # the four BT items, best first
+
+# Tier design exploits the documented failure mode of small judges (see the
+# vault's judge bias-variance page): verbosity bias. Correct answers are
+# concise; wrong answers are long, confident and jargon-dense. A sharp judge
+# reads past the style; a weak one rewards it. That differential is the
+# disagreement BT-sigma learns reliability from.
+QUESTIONS: list[tuple[str, dict[str, str]]] = [
+    (
+        'Why is the sky blue?',
+        {
+            'excellent': 'Rayleigh scattering: air molecules scatter short wavelengths far more strongly, '
+            'so scattered blue light reaches your eye from every direction of the sky.',
+            'good': 'The atmosphere scatters blue sunlight more than the other colors.',
+            'mediocre': 'The answer lies in the reflective interplay between hydrosphere and atmosphere: the '
+            'oceans, covering 71 percent of the planetary surface, imprint their characteristic blue albedo '
+            'onto the lower atmosphere through continuous photon exchange, and atmospheric scattering then '
+            'redistributes this ocean-derived chromatic signature across the whole celestial dome, which is '
+            'precisely why the sky appears most saturated over large bodies of water.',
+            'bad': 'Atmospheric chemistry provides the definitive explanation: diatomic oxygen and ozone are '
+            'intrinsically cyan-blue gases, a property well characterised in spectroscopy laboratories. As '
+            'sunlight traverses roughly one hundred kilometres of these chromophoric gases, the accumulated '
+            'intrinsic pigmentation of the oxygen column becomes visible as the familiar blue canopy, exactly '
+            'as a swimming pool appears bluer with depth. Scattering plays only a negligible secondary role.',
+        },
+    ),
+    (
+        'What causes the seasons on Earth?',
+        {
+            'excellent': "Earth's 23.4-degree axial tilt: each hemisphere gets more direct sunlight and longer "
+            'days when tilted toward the sun. Distance is irrelevant; Earth is closest to the sun in January.',
+            'good': 'The tilt of the Earth on its axis, which changes how directly sunlight hits each hemisphere '
+            'through the year.',
+            'mediocre': 'Seasonality emerges from the superposition of two orbital mechanisms of comparable '
+            'magnitude: the well-known axial obliquity of 23.4 degrees, and the eccentricity of the terrestrial '
+            'orbit, which modulates the solar constant by a thermodynamically decisive margin across the year. '
+            'The interplay of tilt and distance, weighted roughly equally, produces the characteristic seasonal '
+            'temperature envelope observed at mid-latitudes.',
+            'bad': 'The governing variable is heliocentric distance. Kepler demonstrated that planetary orbits '
+            'are ellipses, and Earth is no exception: at perihelion the planet receives markedly concentrated '
+            'insolation, producing summer, while at aphelion the attenuated solar flux yields winter. The '
+            'popular tilt hypothesis confuses cause and effect; obliquity merely fine-tunes day length around '
+            'the distance-driven thermal cycle.',
+        },
+    ),
+    (
+        'Why do ships made of steel float?',
+        {
+            'excellent': 'The hull encloses air, so the ship displaces water whose weight equals its own before '
+            'submerging: average density below water is what matters, not the density of steel.',
+            'good': 'The hull shape displaces enough water that buoyancy supports the weight, even though steel '
+            'itself is denser than water.',
+            'mediocre': 'Immersion fundamentally alters the effective weight of structural steel: by the '
+            'hydrostatic cancellation principle, water pressure acting on the submerged plating offsets the '
+            'bulk of the gravitational load, rendering even solid steel nearly weightless below the waterline. '
+            'The hull geometry then only needs to supply the small residual lift, which is why plate thickness '
+            'is essentially irrelevant to flotation margins in naval architecture.',
+            'bad': 'Modern shipbuilding relies on marine-grade alloy metallurgy: naval steels are engineered '
+            'with controlled micro-porosity and alloying elements that bring their density marginally below '
+            'that of seawater, typically 0.98 grams per cubic centimetre. This is the decisive innovation that '
+            'separates the modern era from the age of wooden ships; ordinary construction steel would sink '
+            'regardless of hull form, as dockyard engineers routinely verify.',
+        },
+    ),
+    (
+        'Why does ice float on water?',
+        {
+            'excellent': 'Hydrogen bonds lock freezing water into an open hexagonal lattice about 9 percent '
+            'less dense than the liquid, a rare density anomaly.',
+            'good': 'Water expands when it freezes, so ice is less dense than liquid water and floats.',
+            'mediocre': 'The buoyancy of ice is predominantly a gas-entrainment phenomenon: as the freezing '
+            'front advances it occludes dissolved atmospheric gases into microscopic vesicles, and this '
+            'entrained porosity, familiar from the cloudy core of household ice cubes, lowers the aggregate '
+            'density below that of the parent liquid. Degassed laboratory ice, by contrast, is only marginally '
+            'buoyant, confirming that the trapped air rather than the crystal lattice does the lifting.',
+            'bad': 'Thermal stratification supplies the complete explanation: colder fluids invariably rise '
+            'above warmer ones once below the critical inversion temperature, as limnologists observe every '
+            'winter in lake turnover. Ice, being the terminal cold phase of water, simply occupies the apex of '
+            'this stratification column. Density is a red herring; the same mass of ice submerged in warmer '
+            'water will always migrate upward on purely thermal grounds.',
+        },
+    ),
+    (
+        'Why do we see phases of the moon?',
+        {
+            'excellent': 'The moon is always half-lit by the sun; phases are the changing fraction of that lit '
+            'half we see as the moon orbits Earth each month.',
+            'good': 'As the moon orbits Earth we see different amounts of its sunlit side.',
+            'mediocre': 'Lunar phase geometry is a composite phenomenon: the primary term is the sun-moon '
+            'viewing angle, but the crescent morphology specifically records the monthly passage of the '
+            'terrestrial umbral cone across the lunar disc, a miniature of the eclipse mechanism operating '
+            'continuously at partial obscuration. The two contributions, angular illumination and shadow '
+            'transit, sum to the phase cycle catalogued since antiquity.',
+            'bad': "The phases are Earth's own shadow projected onto the lunar surface. As our planet rotates "
+            'relative to the sun-moon axis, the terrestrial shadow sweeps across the moon in a regular monthly '
+            'rhythm, sequentially carving the waxing and waning shapes from new to full. This shadow-casting '
+            'model, intuitive since Babylonian astronomy, explains why the dark portion of a crescent moon '
+            'shares the curvature of the Earth itself, an observation no illumination-angle theory reproduces.',
+        },
+    ),
+]
+
+
+
+async def main() -> None:
+    jury = llm_jury_pairwise(
+        judges=list(JUDGES),
+        criteria='Which answer is more scientifically accurate?',
+    )
+    pairs = [(hi, lo) for i, hi in enumerate(TIERS) for lo in TIERS[i + 1 :]]
+
+    records: list[JudgedComparison] = []
+    vote_to_p = {'A': 1.0, 'B': 0.0, 'tie': 0.5}
+    for question, answers in QUESTIONS:
+        for tier_a, tier_b in pairs:
+            comparison = await jury.compare(
+                question=question, response_a=answers[tier_a], response_b=answers[tier_b]
+            )
+            for vote in comparison.votes:
+                if vote.vote is not None:
+                    records.append(
+                        JudgedComparison(
+                            judge=vote.model, item_a=tier_a, item_b=tier_b, p_a=vote_to_p[str(vote.vote)]
+                        )
+                    )
+        print(f'judged: {question}')
+
+    fit = fit_bt(records, judge_sigma=True, hard=True)
+    print(f'\nfitted ranking : {" > ".join(fit.ranking)}')
+    print(f'expected       : {" > ".join(TIERS)}')
+    print(f'converged      : {fit.converged} ({fit.iterations} iterations, {len(records)} judged pairs)')
+    print('\nskills (higher = better):')
+    for tier in fit.ranking:
+        print(f'  {tier:<10} {fit.skills[tier]:+.3f}')
+    print('\njudge reliability (smaller sigma = sharper) with the cycle-consistency check:')
+    for judge, sigma in sorted(fit.sigmas.items(), key=lambda kv: kv[1]):
+        cycles = cycle_rate(records, judge)
+        cycle_txt = f'{cycles:.2f}' if cycles is not None else 'n/a'
+        print(f'  {judge:<42} sigma={sigma:6.3f}   cycle-rate={cycle_txt}')
+    print(
+        '\nThe paper predicts the two columns agree: judges with larger sigma should'
+        '\nshow more 3-cycle inconsistency. That is the unsupervised reliability'
+        '\nsignal BT-sigma uses to weight the jury.'
+    )
+
+
+asyncio.run(main())

--- a/examples/pairwise/bt_sigma_ranking.py
+++ b/examples/pairwise/bt_sigma_ranking.py
@@ -140,6 +140,9 @@ async def main() -> None:
     jury = llm_jury_pairwise(
         judges=list(JUDGES),
         criteria='Which answer is more scientifically accurate?',
+        # Near-deterministic judges: run-to-run sigma ORDERING replicates
+        # regardless, but zero temperature tightens the magnitudes too.
+        temperature=0.0,
     )
     pairs = [(hi, lo) for i, hi in enumerate(TIERS) for lo in TIERS[i + 1 :]]
 

--- a/examples/pairwise/bt_sigma_ranking.py
+++ b/examples/pairwise/bt_sigma_ranking.py
@@ -17,7 +17,7 @@ defaults). Needs ORQ_API_KEY.
 
 Usage::
 
-    python examples/bt_sigma_ranking.py [STRONG WEAK_1 WEAK_2]
+    python examples/pairwise/bt_sigma_ranking.py [STRONG WEAK_1 WEAK_2]
 """
 
 import asyncio

--- a/src/evaluatorq/__init__.py
+++ b/src/evaluatorq/__init__.py
@@ -41,13 +41,16 @@ from .job_helper import job
 from .llm_jury import PairwiseComparator, llm_jury, llm_jury_pairwise
 from .openresponses import ResponseResourceDict
 from .pairwise import (
+    BTSigmaAggregation,
     JudgeStats,
     PairwiseComparison,
     PairwiseReport,
     PairwiseVote,
+    bt_sigma_aggregation,
     build_report,
     run_pairwise,
 )
+from .ranking import BTFit, JudgedComparison, fit_bt
 from .types import (
     DataPoint,
     DataPointDict,
@@ -73,6 +76,8 @@ from .types import (
 __all__ = [
     'AgentResponse',
     # Types
+    'BTFit',
+    'BTSigmaAggregation',
     'DataPoint',
     'DataPointDict',
     'DataPointInput',
@@ -91,6 +96,7 @@ __all__ = [
     'JobResult',
     'JobReturn',
     'JudgeStats',
+    'JudgedComparison',
     'MessageDict',
     'Output',
     # Pairwise (preference) jury
@@ -102,12 +108,14 @@ __all__ = [
     'Scorer',
     'ScorerParameter',
     'ThreadConfig',
+    'bt_sigma_aggregation',
     'build_report',
     # Deployment helpers
     'deployment',
     # Main function
     'evaluatorq',
     'exact_match_evaluator',
+    'fit_bt',
     'invoke',
     # Helper functions
     'job',

--- a/src/evaluatorq/dashboard/surfaces.py
+++ b/src/evaluatorq/dashboard/surfaces.py
@@ -214,10 +214,10 @@ def _pairwise_adapter() -> SurfaceAdapter:
         called by the header and by two section builders, so leaving the field
         empty rolls the same entries up three times per render.
         """
-        from evaluatorq.pairwise import build_report
-
-        rolled = build_report([e.comparison for e in filtered])
-        return run.model_copy(update={'entries': list(filtered), 'report': rolled})
+        aggregation = 'bt-sigma' if run.report is not None and run.report.bt_sigma is not None else 'plurality'
+        filtered_run = run.model_copy(update={'entries': list(filtered), 'report': None})
+        rolled = filtered_run.rollup(aggregation=aggregation)
+        return filtered_run.model_copy(update={'report': rolled})
 
     return SurfaceAdapter(
         load=_pw_load,

--- a/src/evaluatorq/pairwise.py
+++ b/src/evaluatorq/pairwise.py
@@ -9,6 +9,7 @@ consistency-gated vote (RES-760, ADR-24).
 from __future__ import annotations
 
 import asyncio
+import math
 from collections import Counter
 from typing import TYPE_CHECKING
 
@@ -106,6 +107,11 @@ class JudgeStats(BaseModel):
         description='Flips over completed pairs (both orderings decisive); 0.0 when no pair was flippable'
     )
     tie_rate: float = Field(description='Ties over total comparisons the judge saw')
+    sigma: float | None = Field(
+        default=None,
+        description='BT-sigma discriminator (smaller = more reliable); set only when the report was built '
+        "with aggregation='bt-sigma'",
+    )
 
 
 class PairwiseReport(BaseModel):
@@ -126,14 +132,117 @@ class PairwiseReport(BaseModel):
         description='Mean inter-judge agreement (modal vote share) across comparisons; None if none were decisive'
     )
     per_judge: list[JudgeStats] = Field(default_factory=list, description='Per-judge behaviour breakdown')
+    bt_sigma: BTSigmaAggregation | None = Field(
+        default=None,
+        description="Reliability-weighted rollup; set only when the report was built with aggregation='bt-sigma'",
+    )
 
 
 def _rate(count: int, total: int) -> float | None:
     return count / total if total else None
 
 
-def build_report(comparisons: Sequence[PairwiseComparison]) -> PairwiseReport:
-    """Roll a set of pairwise comparisons up into headline and per-judge metrics."""
+class BTSigmaAggregation(BaseModel):
+    """Reliability-weighted rollup of a pairwise run (BT-sigma, arXiv:2602.16610).
+
+    Fitted unsupervised on the run's own reconciled votes: hard BT-sigma jointly
+    infers the A-vs-B skill gap and a discriminator per judge, then re-derives
+    each comparison's winner as a reliability-weighted vote (weight ``1/sigma``)
+    instead of uniform plurality. Down-weights noisy judges; needs no labels.
+    """
+
+    p_a_beats_b: float = Field(description='Fitted global probability that A beats B (logistic of the skill gap)')
+    skill_gap: float = Field(description='Fitted skill difference s_A - s_B')
+    judge_sigmas: dict[str, float] = Field(
+        default_factory=dict,
+        description='Per-judge discriminator; smaller = sharper/more reliable. Empty on single-judge fallback.',
+    )
+    winners: list[str] = Field(
+        default_factory=list,
+        description='Reliability-weighted winner per comparison, aligned with the input order',
+    )
+    a_win_rate: float | None = Field(description='Weighted A-wins over decisive comparisons; None if none decisive')
+    b_win_rate: float | None = Field(description='Weighted B-wins over decisive comparisons; None if none decisive')
+    tie_rate: float = Field(description='Weighted-tie comparisons over all comparisons')
+    inconclusive_rate: float = Field(description='Comparisons no judge decided, over all comparisons')
+    fit_warnings: list[str] = Field(default_factory=list, description='Degradations applied during the BT fit')
+
+
+_VOTE_TO_P = {'A': 1.0, 'B': 0.0, 'tie': 0.5}
+
+
+def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAggregation:
+    """Fit hard BT-sigma over a run's reconciled votes and re-derive winners.
+
+    The two "items" are the run's A and B sides; every decisive reconciled vote
+    is one comparison between them. Reconciliation has already symmetrised
+    position bias (both orderings per judge), satisfying the model's
+    commutativity requirement. Categorical votes make hard BT-sigma the natural
+    variant, which is also the paper's most robust one under inconsistency.
+    """
+    from evaluatorq.ranking import JudgedComparison, fit_bt
+
+    records = [
+        JudgedComparison(judge=v.model, item_a='A', item_b='B', p_a=_VOTE_TO_P[str(v.vote)])
+        for c in comparisons
+        for v in c.votes
+        if v.vote is not None
+    ]
+    if not records:
+        return BTSigmaAggregation(
+            p_a_beats_b=0.5,
+            skill_gap=0.0,
+            winners=['inconclusive'] * len(comparisons),
+            a_win_rate=None,
+            b_win_rate=None,
+            tie_rate=0.0,
+            inconclusive_rate=1.0 if comparisons else 0.0,
+            fit_warnings=['no decisive votes to fit on'],
+        )
+
+    fit = fit_bt(records, judge_sigma=True, hard=True)
+    # Single-judge fallback leaves sigmas empty; weight uniformly then.
+    weights = {judge: 1.0 / sigma for judge, sigma in fit.sigmas.items()}
+
+    winners: list[str] = []
+    for c in comparisons:
+        w: dict[str, float] = {'A': 0.0, 'B': 0.0, 'tie': 0.0}
+        for v in c.votes:
+            if v.vote is None:
+                continue
+            w[str(v.vote)] += weights.get(v.model, 1.0)
+        if not any(w.values()):
+            winners.append('inconclusive')
+            continue
+        top = max(w.values())
+        leaders = [k for k, val in w.items() if val == top]
+        # Mirrors plurality semantics: a unique leader wins, a split is inconclusive.
+        winners.append(leaders[0] if len(leaders) == 1 else 'inconclusive')
+
+    counts = Counter(winners)
+    decisive = counts['A'] + counts['B']
+    total = len(comparisons)
+    return BTSigmaAggregation(
+        p_a_beats_b=1.0 / (1.0 + math.exp(-(fit.skills['A'] - fit.skills['B']))),
+        skill_gap=fit.skills['A'] - fit.skills['B'],
+        judge_sigmas=fit.sigmas,
+        winners=winners,
+        a_win_rate=_rate(counts['A'], decisive),
+        b_win_rate=_rate(counts['B'], decisive),
+        tie_rate=counts['tie'] / total if total else 0.0,
+        inconclusive_rate=counts['inconclusive'] / total if total else 0.0,
+        fit_warnings=fit.warnings,
+    )
+
+
+def build_report(comparisons: Sequence[PairwiseComparison], *, aggregation: str = 'plurality') -> PairwiseReport:
+    """Roll a set of pairwise comparisons up into headline and per-judge metrics.
+
+    ``aggregation='plurality'`` (default) keeps the existing uniform plurality
+    consensus. ``aggregation='bt-sigma'`` additionally fits hard BT-sigma over
+    the run and attaches the reliability-weighted rollup (``report.bt_sigma``)
+    plus each judge's discriminator (``JudgeStats.sigma``); the headline
+    plurality rates are unchanged so the two aggregations stay comparable."""
     total = len(comparisons)
     winners = Counter(c.winner for c in comparisons)
     decisive = winners['A'] + winners['B']
@@ -165,6 +274,15 @@ def build_report(comparisons: Sequence[PairwiseComparison]) -> PairwiseReport:
         and (rate := _agreement_rate([v.vote for v in c.votes if v.vote is not None])) is not None
     ]
 
+    bt_block: BTSigmaAggregation | None = None
+    if aggregation == 'bt-sigma':
+        bt_block = bt_sigma_aggregation(comparisons)
+        for stats in judge_stats:
+            stats.sigma = bt_block.judge_sigmas.get(stats.model)
+    elif aggregation != 'plurality':
+        msg = f"unknown aggregation {aggregation!r}; expected 'plurality' or 'bt-sigma'"
+        raise ValueError(msg)
+
     return PairwiseReport(
         comparisons=total,
         a_win_rate=_rate(winners['A'], decisive),
@@ -173,6 +291,7 @@ def build_report(comparisons: Sequence[PairwiseComparison]) -> PairwiseReport:
         inconclusive_rate=winners['inconclusive'] / total if total else 0.0,
         mean_agreement=sum(agreements) / len(agreements) if agreements else None,
         per_judge=judge_stats,
+        bt_sigma=bt_block,
     )
 
 

--- a/src/evaluatorq/pairwise.py
+++ b/src/evaluatorq/pairwise.py
@@ -195,6 +195,26 @@ _VOTE_TO_P = {'A': 1.0, 'B': 0.0, 'tie': 0.5}
 _MIN_VOTES_FOR_SIGMA = 5
 
 
+def _uniform_plurality_aggregation(
+    comparisons: Sequence[PairwiseComparison], warnings: list[str], *, converged: bool = True
+) -> BTSigmaAggregation:
+    winners = [c.winner for c in comparisons]
+    counts = Counter(winners)
+    decisive = counts['A'] + counts['B']
+    total = len(comparisons)
+    return BTSigmaAggregation(
+        p_a_beats_b=0.5,
+        skill_gap=0.0,
+        winners=winners,
+        a_win_rate=_rate(counts['A'], decisive),
+        b_win_rate=_rate(counts['B'], decisive),
+        tie_rate=counts['tie'] / total if total else 0.0,
+        inconclusive_rate=counts['inconclusive'] / total if total else 0.0,
+        converged=converged,
+        fit_warnings=warnings,
+    )
+
+
 def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAggregation:
     """Fit hard BT-sigma over a run's reconciled votes and re-derive winners.
 
@@ -215,6 +235,12 @@ def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAg
     ``fit_warnings`` names them.
     """
     from evaluatorq.ranking import JudgedComparison, comparisons_per_judge, fit_bt
+
+    if any(v.vote is not None and not v.completed for c in comparisons for v in c.votes):
+        return _uniform_plurality_aggregation(
+            comparisons,
+            ['single-ordering data: position-bias symmetrisation unavailable; used uniform plurality instead'],
+        )
 
     # judge -> vote -> count. Collapsing keeps the optimum identical (the
     # likelihood is additive over identical records) while the per-iteration
@@ -243,6 +269,9 @@ def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAg
 
     fit = fit_bt(records, judge_sigma=True, hard=True)
     fit_warnings = list(fit.warnings)
+    if not fit.converged:
+        fit_warnings.append('non-converged fit: used uniform plurality winners instead')
+        return _uniform_plurality_aggregation(comparisons, fit_warnings, converged=False)
 
     # Two-item degeneracy guard: a unanimous judge's sigma is a closed-form
     # function of its own one-sidedness (its marginal pins the fit), so 1/sigma

--- a/src/evaluatorq/pairwise.py
+++ b/src/evaluatorq/pairwise.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import math
+import statistics
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic import BaseModel, Field
 
@@ -73,7 +74,9 @@ class PairwiseVote(BaseModel):
     """One judge's reconciled verdict for a single A-vs-B comparison."""
 
     model: str = Field(description='Judge model ID')
-    vote: str | None = Field(description="Reconciled vote: 'A', 'B', 'tie', or None if the judge abstained")
+    vote: Literal['A', 'B', 'tie'] | None = Field(
+        description="Reconciled vote: 'A', 'B', 'tie', or None if the judge abstained"
+    )
     flipped: bool = Field(default=False, description='True if the judge disagreed with itself across orderings')
     completed: bool = Field(
         default=True,
@@ -149,6 +152,19 @@ class BTSigmaAggregation(BaseModel):
     infers the A-vs-B skill gap and a discriminator per judge, then re-derives
     each comparison's winner as a reliability-weighted vote (weight ``1/sigma``)
     instead of uniform plurality. Down-weights noisy judges; needs no labels.
+
+    Two caveats of the two-item collapse, both handled here:
+
+    - With only two items a judge's sigma is pinned by its own vote
+      distribution, so a judge whose decisive votes are unanimous gets an
+      arbitrarily small sigma that measures one-sidedness (e.g. position or
+      verbosity bias), not reliability. Such judges are excluded from the
+      weighting — they vote with a neutral weight, their sigma is dropped from
+      ``judge_sigmas``, and ``fit_warnings`` names them.
+    - ``p_a_beats_b``/``skill_gap`` come from the pooled global fit, while
+      ``winners`` come from the per-comparison weighted vote. These are two
+      different estimators and need not agree; read ``p_a_beats_b`` as the
+      run-level headline and ``winners`` as the per-row calls.
     """
 
     p_a_beats_b: float = Field(description='Fitted global probability that A beats B (logistic of the skill gap)')
@@ -165,10 +181,18 @@ class BTSigmaAggregation(BaseModel):
     b_win_rate: float | None = Field(description='Weighted B-wins over decisive comparisons; None if none decisive')
     tie_rate: float = Field(description='Weighted-tie comparisons over all comparisons')
     inconclusive_rate: float = Field(description='Comparisons no judge decided, over all comparisons')
+    converged: bool = Field(
+        default=True,
+        description='False when the fit stopped at the iteration cap; treat sigmas and weighted winners '
+        'with suspicion then (the cap is also reported in fit_warnings)',
+    )
     fit_warnings: list[str] = Field(default_factory=list, description='Degradations applied during the BT fit')
 
 
 _VOTE_TO_P = {'A': 1.0, 'B': 0.0, 'tie': 0.5}
+# Below this many decisive votes a judge's sigma is mostly prior, not evidence;
+# the fit still runs but fit_warnings flags the judge.
+_MIN_VOTES_FOR_SIGMA = 5
 
 
 def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAggregation:
@@ -179,14 +203,31 @@ def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAg
     position bias (both orderings per judge), satisfying the model's
     commutativity requirement. Categorical votes make hard BT-sigma the natural
     variant, which is also the paper's most robust one under inconsistency.
-    """
-    from evaluatorq.ranking import JudgedComparison, fit_bt
 
+    Identical votes are collapsed into weighted records before the fit (a judge
+    has at most three distinct judgements here: A, B, tie), so the fit cost
+    stays flat no matter how many comparisons the run holds.
+
+    Judges whose decisive votes are unanimous are excluded from the reliability
+    weighting: in the two-item collapse their sigma measures one-sidedness, not
+    reliability (see :class:`BTSigmaAggregation`). They vote with the median
+    weight of the remaining judges (or uniformly when no judge remains), and
+    ``fit_warnings`` names them.
+    """
+    from evaluatorq.ranking import JudgedComparison, comparisons_per_judge, fit_bt
+
+    # judge -> vote -> count. Collapsing keeps the optimum identical (the
+    # likelihood is additive over identical records) while the per-iteration
+    # cost drops from O(votes) to O(judges x 3).
+    vote_counts: dict[str, Counter[str]] = {}
+    for c in comparisons:
+        for v in c.votes:
+            if v.vote is not None:
+                vote_counts.setdefault(v.model, Counter())[v.vote] += 1
     records = [
-        JudgedComparison(judge=v.model, item_a='A', item_b='B', p_a=_VOTE_TO_P[str(v.vote)])
-        for c in comparisons
-        for v in c.votes
-        if v.vote is not None
+        JudgedComparison(judge=judge, item_a='A', item_b='B', p_a=_VOTE_TO_P[vote], weight=float(n))
+        for judge, counts in sorted(vote_counts.items())
+        for vote, n in sorted(counts.items())
     ]
     if not records:
         return BTSigmaAggregation(
@@ -201,8 +242,30 @@ def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAg
         )
 
     fit = fit_bt(records, judge_sigma=True, hard=True)
+    fit_warnings = list(fit.warnings)
+
+    # Two-item degeneracy guard: a unanimous judge's sigma is a closed-form
+    # function of its own one-sidedness (its marginal pins the fit), so 1/sigma
+    # would hand the most degenerate judge on the panel an unbounded weight.
+    one_sided = {judge for judge, counts in vote_counts.items() if len(counts) == 1}
     # Single-judge fallback leaves sigmas empty; weight uniformly then.
-    weights = {judge: 1.0 / sigma for judge, sigma in fit.sigmas.items()}
+    sigmas = {judge: sigma for judge, sigma in fit.sigmas.items() if judge not in one_sided}
+    weights = {judge: fit.reliability(judge) for judge in sigmas}
+    if fit.sigmas and one_sided:
+        neutral = statistics.median(weights.values()) if weights else 1.0
+        for judge in sorted(one_sided):
+            weights[judge] = neutral
+            direction = next(iter(vote_counts[judge]))
+            fit_warnings.append(
+                f"judge '{judge}' voted '{direction}' on every decisive comparison; with two items its sigma "
+                'measures one-sidedness, not reliability - weighted neutrally and excluded from judge_sigmas'
+            )
+    if fit.sigmas:
+        for judge, n in sorted(comparisons_per_judge(records).items()):
+            if n < _MIN_VOTES_FOR_SIGMA and judge not in one_sided:
+                fit_warnings.append(
+                    f"judge '{judge}' has only {int(n)} decisive vote(s); its sigma is mostly prior, not evidence"
+                )
 
     winners: list[str] = []
     for c in comparisons:
@@ -210,12 +273,15 @@ def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAg
         for v in c.votes:
             if v.vote is None:
                 continue
-            w[str(v.vote)] += weights.get(v.model, 1.0)
+            w[v.vote] += weights.get(v.model, 1.0)
         if not any(w.values()):
             winners.append('inconclusive')
             continue
         top = max(w.values())
-        leaders = [k for k, val in w.items() if val == top]
+        # isclose, not ==: mathematically equal weights can differ in the last
+        # bits (asymmetric comparison counts), and a genuine tie must stay a
+        # tie rather than crown whichever side rounded up.
+        leaders = [k for k, val in w.items() if math.isclose(val, top, rel_tol=1e-9)]
         # Mirrors plurality semantics: a unique leader wins, a split is inconclusive.
         winners.append(leaders[0] if len(leaders) == 1 else 'inconclusive')
 
@@ -225,13 +291,14 @@ def bt_sigma_aggregation(comparisons: Sequence[PairwiseComparison]) -> BTSigmaAg
     return BTSigmaAggregation(
         p_a_beats_b=1.0 / (1.0 + math.exp(-(fit.skills['A'] - fit.skills['B']))),
         skill_gap=fit.skills['A'] - fit.skills['B'],
-        judge_sigmas=fit.sigmas,
+        judge_sigmas=sigmas,
         winners=winners,
         a_win_rate=_rate(counts['A'], decisive),
         b_win_rate=_rate(counts['B'], decisive),
         tie_rate=counts['tie'] / total if total else 0.0,
         inconclusive_rate=counts['inconclusive'] / total if total else 0.0,
-        fit_warnings=fit.warnings,
+        converged=fit.converged,
+        fit_warnings=fit_warnings,
     )
 
 
@@ -442,7 +509,7 @@ async def run_pairwise(
         votes.append(
             PairwiseVote(
                 model=model,
-                vote=_as_str(vote),
+                vote=_as_vote(vote),
                 flipped=flipped,
                 completed=completed,
                 replacement=model in stand_in_set,
@@ -455,5 +522,16 @@ async def run_pairwise(
     return PairwiseComparison(winner=winner, votes=votes, token_usage=_sum_usage(usages))
 
 
-def _as_str(value: VerdictValue | None) -> str | None:
-    return None if value is None else str(value)
+def _as_vote(value: VerdictValue | None) -> Literal['A', 'B', 'tie'] | None:
+    """Narrow a reconciled verdict to the pairwise vote vocabulary.
+
+    ``_decisive_value`` has already rejected anything outside the contract, so
+    the cast is safe; keeping the check here too guards the type against a
+    future caller that skips that gate.
+    """
+    if value is None:
+        return None
+    s = str(value)
+    if s not in _PAIRWISE_VALUES:
+        raise ValueError(f"pairwise vote {s!r} outside the contract; expected 'A', 'B', or 'tie'")
+    return cast("Literal['A', 'B', 'tie']", s)

--- a/src/evaluatorq/pairwise_reports/export_html.py
+++ b/src/evaluatorq/pairwise_reports/export_html.py
@@ -87,9 +87,21 @@ def _render_consensus_html(section: ReportSection) -> str:
         },
         {'label': 'Mean agreement', 'value': _num(d.get('mean_agreement')), 'status': 'neutral'},
     ])
+    weighted = d.get('bt_sigma')
+    weighted_html = ''
+    if weighted is not None:
+        weighted_bars = _side_bar(d['label_a'], weighted.get('a_win_rate'), _A_COLOR) + _side_bar(
+            d['label_b'], weighted.get('b_win_rate'), _B_COLOR
+        )
+        warnings = ''.join(f'<li>{_esc(warning)}</li>' for warning in weighted.get('fit_warnings', []))
+        warning_html = f'<ul class="pw-caption">{warnings}</ul>' if warnings else ''
+        weighted_html = (
+            '<h3>Reliability-weighted consensus (BT-sigma)</h3>'
+            f'<div class="pw-sides">{weighted_bars}</div>{warning_html}'
+        )
     return (
         f'<section id="{section.kind}"><h2>{_esc(section.title)}</h2>'
-        f'<div class="pw-sides">{bars}</div>{caption}{stats}</section>'
+        f'<div class="pw-sides">{bars}</div>{caption}{stats}{weighted_html}</section>'
     )
 
 
@@ -119,16 +131,20 @@ def _render_judges_html(section: ReportSection) -> str:
     d = section.data
     observed = bool(d.get('observed_swap'))
     headers = ['Judge', f'{d["label_a"]} rate', f'{d["label_b"]} rate', 'Tie rate', 'Position bias']
-    rows = [
-        [
+    if d.get('bt_sigma'):
+        headers.append('Sigma')
+    rows: list[list[str]] = []
+    for r in d.get('rows', []):
+        row = [
             _esc(r['model']) + (' <span class="pw-tag">stand-in</span>' if r.get('replacement') else ''),
             _rate(r.get('a_rate')),
             _rate(r.get('b_rate')),
             _rate(r.get('tie_rate')),
             _bias_cell(r, observed_swap=observed),
         ]
-        for r in d.get('rows', [])
-    ]
+        if d.get('bt_sigma'):
+            row.append(_num(r.get('sigma')))
+        rows.append(row)
     if not rows:
         return ''
     # The caption keys off what ran, not what was configured: a run saved with

--- a/src/evaluatorq/pairwise_reports/sections.py
+++ b/src/evaluatorq/pairwise_reports/sections.py
@@ -69,6 +69,7 @@ def _build_consensus_section(run: PairwiseRun) -> ReportSection:
     # inconclusive_rate would make the caption depend on that float arithmetic
     # round-tripping. Counting is exact by construction.
     decided = sum(1 for e in run.entries if e.comparison.winner in ('A', 'B'))
+    weighted = report.bt_sigma
     return ReportSection(
         kind='pairwise_consensus',
         title='Consensus',
@@ -82,6 +83,16 @@ def _build_consensus_section(run: PairwiseRun) -> ReportSection:
             'mean_agreement': report.mean_agreement,
             'comparisons': total,
             'decided': decided,
+            'bt_sigma': (
+                {
+                    'a_win_rate': weighted.a_win_rate,
+                    'b_win_rate': weighted.b_win_rate,
+                    'inconclusive_rate': weighted.inconclusive_rate,
+                    'fit_warnings': list(weighted.fit_warnings),
+                }
+                if weighted is not None
+                else None
+            ),
         },
     )
 
@@ -122,6 +133,7 @@ def _build_judges_section(run: PairwiseRun) -> ReportSection:
             # already False — and consulting it would let a mis-set flag decide
             # what the votes have already settled.
             'position_bias': stat.position_bias if measured[stat.model] else None,
+            'sigma': stat.sigma,
             'biased': measured[stat.model] and stat.position_bias >= POSITION_BIAS_WARN,
             # Carried so the renderer can tell the unmeasurable cases apart:
             # the run never swapped, or it swapped but this judge never landed
@@ -139,6 +151,7 @@ def _build_judges_section(run: PairwiseRun) -> ReportSection:
             'label_b': run.label_b,
             'swap': run.swap,
             'observed_swap': any(measured.values()),
+            'bt_sigma': report.bt_sigma is not None,
             'rows': rows,
         },
     )

--- a/src/evaluatorq/pairwise_run.py
+++ b/src/evaluatorq/pairwise_run.py
@@ -120,9 +120,7 @@ class PairwiseRun(BaseModel):
         alongside the plurality headline.
         """
         _validate_aggregation(aggregation)
-        self.report = _annotate_bt_sigma_scope(
-            build_report(self.comparisons(), aggregation=aggregation), self.entries
-        )
+        self.report = _annotate_bt_sigma_scope(build_report(self.comparisons(), aggregation=aggregation), self.entries)
         payload = self.model_dump_json(indent=2)
         if path is not None:
             target = Path(path)

--- a/src/evaluatorq/pairwise_run.py
+++ b/src/evaluatorq/pairwise_run.py
@@ -96,17 +96,26 @@ class PairwiseRun(BaseModel):
         """The comparisons alone, in entry order."""
         return [e.comparison for e in self.entries]
 
-    def rollup(self) -> PairwiseReport:
-        """Roll the entries up, preferring the stored report when present."""
-        return self.report if self.report is not None else build_report(self.comparisons())
+    def rollup(self, *, aggregation: str = 'plurality') -> PairwiseReport:
+        """Roll the entries up, preferring the stored report when present.
 
-    def save(self, path: Path | str | None = None) -> Path:
+        A stored report is only reused when it satisfies the requested
+        aggregation, so asking for ``'bt-sigma'`` on a run saved with plurality
+        recomputes instead of silently returning a report without the block.
+        """
+        if self.report is not None and (aggregation == 'plurality' or self.report.bt_sigma is not None):
+            return self.report
+        return build_report(self.comparisons(), aggregation=aggregation)
+
+    def save(self, path: Path | str | None = None, *, aggregation: str = 'plurality') -> Path:
         """Compute the rollup and write the run to JSON.
 
         The rollup is computed here rather than on every dashboard render, so
-        the stored report always matches the entries it was built from.
+        the stored report always matches the entries it was built from. Pass
+        ``aggregation='bt-sigma'`` to persist the reliability-weighted block
+        alongside the plurality headline.
         """
-        self.report = build_report(self.comparisons())
+        self.report = build_report(self.comparisons(), aggregation=aggregation)
         payload = self.model_dump_json(indent=2)
         if path is not None:
             target = Path(path)

--- a/src/evaluatorq/pairwise_run.py
+++ b/src/evaluatorq/pairwise_run.py
@@ -24,6 +24,8 @@ from pydantic import BaseModel, Field
 from evaluatorq.common.run_store_dir import get_store_dir
 from evaluatorq.pairwise import PairwiseComparison, PairwiseReport, build_report
 
+_PAIRWISE_AGGREGATIONS = frozenset({'plurality', 'bt-sigma'})
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -103,9 +105,11 @@ class PairwiseRun(BaseModel):
         aggregation, so asking for ``'bt-sigma'`` on a run saved with plurality
         recomputes instead of silently returning a report without the block.
         """
+        _validate_aggregation(aggregation)
         if self.report is not None and (aggregation == 'plurality' or self.report.bt_sigma is not None):
-            return self.report
-        return build_report(self.comparisons(), aggregation=aggregation)
+            return _annotate_bt_sigma_scope(self.report, self.entries)
+        report = build_report(self.comparisons(), aggregation=aggregation)
+        return _annotate_bt_sigma_scope(report, self.entries)
 
     def save(self, path: Path | str | None = None, *, aggregation: str = 'plurality') -> Path:
         """Compute the rollup and write the run to JSON.
@@ -115,7 +119,10 @@ class PairwiseRun(BaseModel):
         ``aggregation='bt-sigma'`` to persist the reliability-weighted block
         alongside the plurality headline.
         """
-        self.report = build_report(self.comparisons(), aggregation=aggregation)
+        _validate_aggregation(aggregation)
+        self.report = _annotate_bt_sigma_scope(
+            build_report(self.comparisons(), aggregation=aggregation), self.entries
+        )
         payload = self.model_dump_json(indent=2)
         if path is not None:
             target = Path(path)
@@ -169,6 +176,28 @@ def _slug(text: str) -> str:
     # The cut can land on a joining hyphen, which would leave a trailing dash
     # against the '.json' suffix.
     return clamped.rstrip('-') or 'run'
+
+
+def _validate_aggregation(aggregation: str) -> None:
+    if aggregation not in _PAIRWISE_AGGREGATIONS:
+        msg = f"unknown aggregation {aggregation!r}; expected 'plurality' or 'bt-sigma'"
+        raise ValueError(msg)
+
+
+def _annotate_bt_sigma_scope(report: PairwiseReport, entries: Sequence[PairwiseEntry]) -> PairwiseReport:
+    """Warn when a run's BT-sigma fit pools different task-level datapoints."""
+    block = report.bt_sigma
+    if block is None:
+        return report
+    input_pairs = {(entry.question, entry.response_a, entry.response_b) for entry in entries}
+    if len(input_pairs) > 1:
+        warning = (
+            f'run contains {len(input_pairs)} distinct question/response pairs; '
+            'judge sigma measures global agreement across tasks, not isolated judge variance'
+        )
+        if warning not in block.fit_warnings:
+            block.fit_warnings.append(warning)
+    return report
 
 
 def new_run(

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -53,8 +53,9 @@ _MAX_ITER = 2000
 # identifiability projections). A gradient criterion is wrong here: the ridge
 # leaves a constant radial gradient along the scale direction that the
 # projection undoes every step, so the raw gradient never reaches zero even at
-# the constrained optimum.
-_TOL = 1e-9
+# the constrained optimum. 1e-5 is far below anything that moves a ranking or
+# a vote weight; tighter tolerances just fight Adam's decay tail for nothing.
+_TOL = 1e-5
 _ADAM_B1 = 0.9
 _ADAM_B2 = 0.999
 _ADAM_EPS = 1e-8
@@ -62,6 +63,13 @@ _ADAM_EPS = 1e-8
 # separated items (all wins one way -> infinite skill MLE) finite without
 # measurably moving well-posed solutions.
 _RIDGE = 1e-4
+# Log-normal prior on sigma (ridge on tau), deliberately stronger than _RIDGE:
+# a perfectly consistent judge's ideal sigma is 0, so its tau otherwise drifts
+# for thousands of iterations (the fit never converges) while the judge's vote
+# weight 1/sigma explodes without bound. The prior gives that drift a finite
+# equilibrium: reliability separation stays large but bounded, and ambiguous
+# magnitudes shrink toward sigma = 1.
+_TAU_RIDGE = 1e-2
 # Clamp for probabilities entering the log-likelihood.
 _P_EPS = 1e-6
 # Gradients below this are float dust, not signal. Without the floor, Adam's
@@ -188,6 +196,9 @@ def fit_bt(
                 g_t[c.judge] += -err * z  # chain rule through sigma_k = exp(tau)
         for i in items:
             g_s[i] -= _RIDGE * s[i]
+        if use_sigma:
+            for k in judges:
+                g_t[k] -= _TAU_RIDGE * tau[k]
 
         max_g = max(abs(g) for g in g_s.values())
         if use_sigma:

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 # matters for its L-BFGS implementation).
 _LR = 0.1
 _LR_DECAY_STEPS = 200  # lr_t = _LR / (1 + step/_LR_DECAY_STEPS): kills Adam's oscillation floor
-_MAX_ITER = 2000
+_MAX_ITER = 20000  # fits are milliseconds; strongly separated data needs the decay tail to play out
 # Converged when the iterate stops moving (max-abs parameter change after the
 # identifiability projections). A gradient criterion is wrong here: the ridge
 # leaves a constant radial gradient along the scale direction that the
@@ -107,8 +107,9 @@ class BTFit(BaseModel):
 
     skills: dict[str, float] = Field(description='Latent skill per item, centred at mean 0')
     sigmas: dict[str, float] = Field(
-        description='Per-judge discriminator; smaller = sharper/more reliable. Geometric mean fixed at 1. '
-        'Empty when fitted without judge_sigma.'
+        description='Per-judge discriminator; smaller = sharper/more reliable. Only RATIOS between judges '
+        'in the same fit are meaningful (the log-normal prior anchors the scale loosely); do not compare '
+        'absolute values across fits. Empty when fitted without judge_sigma.'
     )
     ranking: list[str] = Field(description='Item IDs, best first')
     converged: bool = Field(description='True when the iterate stopped moving before the iteration cap')
@@ -233,21 +234,16 @@ def fit_bt(
                 v_hat = v_t[k] / (1 - _ADAM_B2**step)
                 tau[k] += lr * m_hat / (math.sqrt(v_hat) + _ADAM_EPS)
 
-        # Identifiability projections: skills mean-zero; geometric mean of
-        # sigma fixed at 1 (only relative sigmas are meaningful, paper 3.3).
+        # Identifiability: skills are mean-centred (additive, Adam-neutral).
+        # The sigma scale is anchored SOFTLY by the log-normal prior instead of
+        # a hard geometric-mean projection: the projection's compensating skill
+        # rescale is a multiplicative ratchet that bypasses Adam - on unanimous
+        # panels every tau drifts down together each step, the rescale inflates
+        # skills without bound, and Adam's normalised steps cap the ridge's
+        # corrective pull at the learning rate. The prior has no such loophole.
         s_mean = sum(s.values()) / len(s)
         for i in items:
             s[i] -= s_mean
-        if use_sigma:
-            t_mean = sum(tau.values()) / len(tau)
-            if t_mean:
-                for k in judges:
-                    tau[k] -= t_mean
-                # Rescaling sigma rescales the skill space; undo it so the
-                # constraint does not fight the gradient direction.
-                scale = math.exp(-t_mean)
-                for i in items:
-                    s[i] *= scale
 
         delta = max(abs(s[i] - prev_s[i]) for i in items)
         if use_sigma:

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -59,10 +59,12 @@ _TOL = 1e-5
 _ADAM_B1 = 0.9
 _ADAM_B2 = 0.999
 _ADAM_EPS = 1e-8
-# Tiny ridge on skills: keeps disconnected comparison graphs and perfectly
-# separated items (all wins one way -> infinite skill MLE) finite without
-# measurably moving well-posed solutions.
-_RIDGE = 1e-4
+# Weak gaussian prior on skills: keeps disconnected comparison graphs and
+# perfectly separated items (all wins one way -> unbounded skill MLE, which
+# otherwise drifts to the iteration cap exactly like the sigma case below)
+# finite and quick to converge. Shrinks only the MAGNITUDE of extreme gaps;
+# orderings, and therefore rankings and weighted winners, are untouched.
+_RIDGE = 1e-2
 # Log-normal prior on sigma (ridge on tau), deliberately stronger than _RIDGE:
 # a perfectly consistent judge's ideal sigma is 0, so its tau otherwise drifts
 # for thousands of iterations (the fit never converges) while the judge's vote

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -103,6 +103,7 @@ _P_EPS = 1e-6
 # other pure noise, decided by rounding error. Stopping at the stationary
 # point keeps perfectly ambiguous data perfectly ambiguous.
 _GRAD_FLOOR = 1e-10
+_MIN_JUDGE_COMPARISONS = 3
 
 
 class JudgedComparison(BaseModel):
@@ -193,6 +194,35 @@ def fit_bt(
     items = sorted({c.item_a for c in comparisons} | {c.item_b for c in comparisons})
     judges = sorted({c.judge for c in comparisons})
     warnings: list[str] = []
+
+    judge_counts = comparisons_per_judge(comparisons)
+    sparse = sorted(judge for judge, count in judge_counts.items() if count < _MIN_JUDGE_COMPARISONS)
+    if sparse:
+        warnings.append(
+            f"judge(s) {', '.join(sparse)} have fewer than {_MIN_JUDGE_COMPARISONS} observations; "
+            'their sigma estimates are weakly supported'
+        )
+
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for c in comparisons:
+        adjacency[c.item_a].add(c.item_b)
+        adjacency[c.item_b].add(c.item_a)
+    components = 0
+    unseen = set(items)
+    while unseen:
+        components += 1
+        stack = [unseen.pop()]
+        while stack:
+            item = stack.pop()
+            for neighbor in adjacency[item]:
+                if neighbor in unseen:
+                    unseen.remove(neighbor)
+                    stack.append(neighbor)
+    if components > 1:
+        warnings.append(
+            f'comparison graph is disconnected ({components} components); '
+            'relative ranks across components are not identified'
+        )
 
     use_sigma = judge_sigma
     if judge_sigma and len(judges) < 2:

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -263,6 +263,12 @@ def cycle_rate(comparisons: Sequence[JudgedComparison], judge: str) -> float | N
     ``1 - cycle_rate``. Needs at least 3 items with pairwise coverage; returns
     ``None`` when no complete triplet exists (e.g. the two-item A/B setting).
     Ties (``p == 0.5``) break no cycles and are treated as no-preference edges.
+
+    One deliberate deviation from the paper's Eq. 9: the denominator here is
+    the number of ASSESSABLE triplets (all three edges present and untied),
+    not all C(n, 3) triplets. On fully covered tie-free data the two agree;
+    on sparse or tie-heavy data the paper's form understates inconsistency by
+    counting unassessable triplets as consistent.
     """
     prefers: dict[tuple[str, str], bool] = {}
     for c in comparisons:

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -199,7 +199,7 @@ def fit_bt(
     sparse = sorted(judge for judge, count in judge_counts.items() if count < _MIN_JUDGE_COMPARISONS)
     if sparse:
         warnings.append(
-            f"judge(s) {', '.join(sparse)} have fewer than {_MIN_JUDGE_COMPARISONS} observations; "
+            f'judge(s) {", ".join(sparse)} have fewer than {_MIN_JUDGE_COMPARISONS} observations; '
             'their sigma estimates are weakly supported'
         )
 

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -53,9 +53,12 @@ _MAX_ITER = 2000
 # identifiability projections). A gradient criterion is wrong here: the ridge
 # leaves a constant radial gradient along the scale direction that the
 # projection undoes every step, so the raw gradient never reaches zero even at
-# the constrained optimum. 1e-5 is far below anything that moves a ranking or
-# a vote weight; tighter tolerances just fight Adam's decay tail for nothing.
-_TOL = 1e-5
+# the constrained optimum. 1e-4 is far below anything that moves a ranking or
+# a vote weight (skills live on a ~+-10 scale, sigmas are reported to 3
+# decimals); tighter tolerances just fight Adam's decay tail, which unanimous
+# panels ride to the iteration cap at ~3e-5 steps. Steps this small only occur
+# near stationarity, and the exact-saddle case has its own gradient floor.
+_TOL = 1e-4
 _ADAM_B1 = 0.9
 _ADAM_B2 = 0.999
 _ADAM_EPS = 1e-8

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -22,9 +22,21 @@ The paper's guidance: hard BT-sigma is the most robust when judges are highly
 inconsistent; soft BT-sigma wins under moderate noise. The per-aspect variant
 (BT-sigma-asp) is deliberately not implemented - the paper finds it marginal.
 
-Everything is pure Python on purpose: the problem is tiny (N items + K judges
-parameters), closed-form gradients converge in milliseconds, and evaluatorq's
-runtime dependency set stays unchanged (no scipy/numpy).
+Everything is pure Python on purpose: the parameter space is tiny (N items +
+K judges) and evaluatorq's runtime dependency set stays unchanged (no
+scipy/numpy). The cost is O(iterations x records) with iterations growing with
+the data, so collapse repeated identical judgements into one record with a
+``weight`` (see :class:`JudgedComparison`) before fitting large runs — the
+pairwise ``bt_sigma_aggregation`` does this and stays fast at any run size;
+an uncollapsed fit over thousands of records can take seconds.
+
+Optimiser choice, on the record (PR #113 review): plain Bradley-Terry has the
+hyperparameter-free, monotone Zermelo/MM update, and if this file ever drops
+the judge discriminator that is the solver to switch to. The per-judge
+``sigma_k`` exponent breaks the algebraic form the MM update relies on (the
+likelihood is no longer a ratio of sums of positive weights), so this uses a
+generic first-order optimiser instead, and the constants below exist to manage
+the failure modes that choice introduces.
 
 Comparisons carry judge identity so the records are reusable by other judging
 methods that need per-judge accounting (e.g. round-robin panel assignment).
@@ -48,7 +60,7 @@ if TYPE_CHECKING:
 # matters for its L-BFGS implementation).
 _LR = 0.1
 _LR_DECAY_STEPS = 200  # lr_t = _LR / (1 + step/_LR_DECAY_STEPS): kills Adam's oscillation floor
-_MAX_ITER = 20000  # fits are milliseconds; strongly separated data needs the decay tail to play out
+_MAX_ITER = 20000  # strongly separated data needs the decay tail to play out; cost is per-record, so collapse first
 # Converged when the iterate stops moving (max-abs parameter change after the
 # identifiability projections). A gradient criterion is wrong here: the ridge
 # leaves a constant radial gradient along the scale direction that the
@@ -56,17 +68,24 @@ _MAX_ITER = 20000  # fits are milliseconds; strongly separated data needs the de
 # the constrained optimum. 1e-4 is far below anything that moves a ranking or
 # a vote weight (skills live on a ~+-10 scale, sigmas are reported to 3
 # decimals); tighter tolerances just fight Adam's decay tail, which unanimous
-# panels ride to the iteration cap at ~3e-5 steps. Steps this small only occur
-# near stationarity, and the exact-saddle case has its own gradient floor.
+# panels ride to the iteration cap at ~3e-5 steps.
 _TOL = 1e-4
+# A single sub-_TOL step is not convergence: when Adam's momentum flips sign
+# crossing the optimum, one step can transiently stall far from stationarity
+# (caught by the review's pin-the-fit test: a 4-vote fit "converged" with a
+# 3e-2 gradient). Genuine stationarity keeps steps small on consecutive
+# iterations; a transient stall rebuilds momentum within a step or two.
+_TOL_STREAK = 5
 _ADAM_B1 = 0.9
 _ADAM_B2 = 0.999
 _ADAM_EPS = 1e-8
 # Weak gaussian prior on skills: keeps disconnected comparison graphs and
 # perfectly separated items (all wins one way -> unbounded skill MLE, which
 # otherwise drifts to the iteration cap exactly like the sigma case below)
-# finite and quick to converge. Shrinks only the MAGNITUDE of extreme gaps;
-# orderings, and therefore rankings and weighted winners, are untouched.
+# finite and quick to converge. Mostly shrinks the MAGNITUDE of extreme gaps;
+# because low-coverage items shrink harder than well-covered ones, it can in
+# principle reorder two items whose unpenalised skills are very close under
+# unbalanced coverage — a small effect at 1e-2, but not a guarantee.
 _RIDGE = 1e-2
 # Log-normal prior on sigma (ridge on tau), deliberately stronger than _RIDGE:
 # a perfectly consistent judge's ideal sigma is 0, so its tau otherwise drifts
@@ -100,6 +119,12 @@ class JudgedComparison(BaseModel):
     item_a: str = Field(description='First item ID in the canonical frame')
     item_b: str = Field(description='Second item ID in the canonical frame')
     p_a: float = Field(ge=0.0, le=1.0, description='P(item_a beats item_b) according to this judge')
+    weight: float = Field(
+        default=1.0,
+        gt=0.0,
+        description='Multiplicity: how many identical judgements this record stands for. The fit cost is '
+        'O(iterations x records), so collapsing repeats keeps large runs fast without changing the optimum.',
+    )
 
 
 class BTFit(BaseModel):
@@ -186,6 +211,7 @@ def fit_bt(
     iterations = 0
     converged = False
     delta = math.inf
+    still_streak = 0
     for step in range(1, _MAX_ITER + 1):
         iterations = step
         g_s = dict.fromkeys(items, 0.0)
@@ -195,7 +221,7 @@ def fit_bt(
             sigma_k = math.exp(tau[c.judge]) if use_sigma else 1.0
             z = (s[c.item_a] - s[c.item_b]) / sigma_k
             p_hat = _logistic(z)
-            err = p - p_hat  # d(loglik)/dz
+            err = (p - p_hat) * c.weight  # d(loglik)/dz, times record multiplicity
             g_s[c.item_a] += err / sigma_k
             g_s[c.item_b] -= err / sigma_k
             if use_sigma:
@@ -248,7 +274,8 @@ def fit_bt(
         delta = max(abs(s[i] - prev_s[i]) for i in items)
         if use_sigma:
             delta = max(delta, max(abs(tau[k] - prev_tau[k]) for k in judges))
-        if delta < _TOL:
+        still_streak = still_streak + 1 if delta < _TOL else 0
+        if still_streak >= _TOL_STREAK:
             converged = True
             break
 
@@ -281,17 +308,30 @@ def cycle_rate(comparisons: Sequence[JudgedComparison], judge: str) -> float | N
     not all C(n, 3) triplets. On fully covered tie-free data the two agree;
     on sparse or tie-heavy data the paper's form understates inconsistency by
     counting unassessable triplets as consistent.
+
+    Repeated judgements of the same pair (e.g. from ``repetitions``) are
+    aggregated by weighted mean preference before the sign is taken, so a
+    judge that split evenly on a pair contributes a no-preference edge rather
+    than whichever judgement happened to come last.
     """
-    prefers: dict[tuple[str, str], bool] = {}
+    p_sum: dict[tuple[str, str], float] = defaultdict(float)
+    w_sum: dict[tuple[str, str], float] = defaultdict(float)
     for c in comparisons:
         if c.judge != judge:
             continue
-        if c.p_a > 0.5:
-            prefers[c.item_a, c.item_b] = True
-            prefers[c.item_b, c.item_a] = False
-        elif c.p_a < 0.5:
-            prefers[c.item_a, c.item_b] = False
-            prefers[c.item_b, c.item_a] = True
+        # Canonicalize the pair frame so (a, b, p) and (b, a, 1-p) aggregate together.
+        a, b, p = (c.item_a, c.item_b, c.p_a) if c.item_a <= c.item_b else (c.item_b, c.item_a, 1.0 - c.p_a)
+        p_sum[a, b] += p * c.weight
+        w_sum[a, b] += c.weight
+    prefers: dict[tuple[str, str], bool] = {}
+    for (a, b), total_w in w_sum.items():
+        mean_p = p_sum[a, b] / total_w
+        if mean_p > 0.5:
+            prefers[a, b] = True
+            prefers[b, a] = False
+        elif mean_p < 0.5:
+            prefers[a, b] = False
+            prefers[b, a] = True
 
     items = sorted({i for pair in prefers for i in pair})
     n = len(items)
@@ -319,11 +359,13 @@ def cycle_rate(comparisons: Sequence[JudgedComparison], judge: str) -> float | N
     return cycles / triplets
 
 
-def comparisons_per_judge(comparisons: Sequence[JudgedComparison]) -> dict[str, int]:
-    """Comparison counts by judge - a cheap sanity check before trusting sigmas."""
-    counts: dict[str, int] = defaultdict(int)
+def comparisons_per_judge(comparisons: Sequence[JudgedComparison]) -> dict[str, float]:
+    """Comparison counts by judge (record weights included) - a cheap sanity
+    check before trusting sigmas. ``bt_sigma_aggregation`` uses it to warn when
+    a judge has too few decisive votes for its sigma to mean much."""
+    counts: dict[str, float] = defaultdict(float)
     for c in comparisons:
-        counts[c.judge] += 1
+        counts[c.judge] += c.weight
     return dict(counts)
 
 

--- a/src/evaluatorq/ranking.py
+++ b/src/evaluatorq/ranking.py
@@ -1,0 +1,319 @@
+"""Bradley-Terry ranking with per-judge reliability (BT-sigma).
+
+Implements the judge-aware Bradley-Terry family from "Who can we trust?
+LLM-as-a-jury for Comparative Assessment" (arXiv:2602.16610), whose model class
+is independently derived with identifiability and consistency proofs in
+arXiv:2601.21817. Given pairwise comparisons from K judges, it jointly fits
+latent item skills ``s_i`` and per-judge discriminators ``sigma_k``::
+
+    P_k(i beats j) = logistic((s_i - s_j) / sigma_k)
+
+by unsupervised maximum likelihood on the run's own comparisons - no human
+labels, no training data. A small ``sigma_k`` marks a sharp, internally
+consistent judge; a large one marks a noisy judge whose votes get down-weighted
+in the inferred ranking. Four variants, selected by two flags:
+
+- ``fit_bt(c, judge_sigma=False, hard=False)`` - soft BT (paper Eq. 3)
+- ``fit_bt(c, judge_sigma=False, hard=True)``  - hard BT (paper Eq. 2)
+- ``fit_bt(c, judge_sigma=True,  hard=False)`` - BT-sigma (paper Eq. 12)
+- ``fit_bt(c, judge_sigma=True,  hard=True)``  - hard BT-sigma
+
+The paper's guidance: hard BT-sigma is the most robust when judges are highly
+inconsistent; soft BT-sigma wins under moderate noise. The per-aspect variant
+(BT-sigma-asp) is deliberately not implemented - the paper finds it marginal.
+
+Everything is pure Python on purpose: the problem is tiny (N items + K judges
+parameters), closed-form gradients converge in milliseconds, and evaluatorq's
+runtime dependency set stays unchanged (no scipy/numpy).
+
+Comparisons carry judge identity so the records are reusable by other judging
+methods that need per-judge accounting (e.g. round-robin panel assignment).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+# Fit hyperparameters. Adam is deliberately boring: the loss is smooth and
+# low-dimensional, and a fixed recipe keeps runs reproducible (deterministic
+# zero init, no random restarts - unlike the paper's random init, which only
+# matters for its L-BFGS implementation).
+_LR = 0.1
+_LR_DECAY_STEPS = 200  # lr_t = _LR / (1 + step/_LR_DECAY_STEPS): kills Adam's oscillation floor
+_MAX_ITER = 2000
+# Converged when the iterate stops moving (max-abs parameter change after the
+# identifiability projections). A gradient criterion is wrong here: the ridge
+# leaves a constant radial gradient along the scale direction that the
+# projection undoes every step, so the raw gradient never reaches zero even at
+# the constrained optimum.
+_TOL = 1e-9
+_ADAM_B1 = 0.9
+_ADAM_B2 = 0.999
+_ADAM_EPS = 1e-8
+# Tiny ridge on skills: keeps disconnected comparison graphs and perfectly
+# separated items (all wins one way -> infinite skill MLE) finite without
+# measurably moving well-posed solutions.
+_RIDGE = 1e-4
+# Clamp for probabilities entering the log-likelihood.
+_P_EPS = 1e-6
+# Gradients below this are float dust, not signal. Without the floor, Adam's
+# scale invariance turns a 1e-16 residue at a symmetric stationary point (e.g.
+# two judges in perfect opposition) into a full-size step, and the fit rolls
+# into an arbitrary asymmetric optimum: one judge crowned ultra-sharp, the
+# other pure noise, decided by rounding error. Stopping at the stationary
+# point keeps perfectly ambiguous data perfectly ambiguous.
+_GRAD_FLOOR = 1e-10
+
+
+class JudgedComparison(BaseModel):
+    """One judge's preference on one item pair, in a fixed (a, b) frame.
+
+    ``p_a`` is the judge's preference probability that ``item_a`` beats
+    ``item_b``. Callers that only have categorical votes map them as
+    A -> 1.0, B -> 0.0, tie -> 0.5. Position-bias symmetrisation (paper Eq. 4)
+    is the caller's job: build ``p_a`` from both orderings, e.g. via the
+    pairwise module's swap/reconcile machinery, before fitting.
+    """
+
+    judge: str = Field(description='Judge model ID')
+    item_a: str = Field(description='First item ID in the canonical frame')
+    item_b: str = Field(description='Second item ID in the canonical frame')
+    p_a: float = Field(ge=0.0, le=1.0, description='P(item_a beats item_b) according to this judge')
+
+
+class BTFit(BaseModel):
+    """Result of a Bradley-Terry family fit."""
+
+    skills: dict[str, float] = Field(description='Latent skill per item, centred at mean 0')
+    sigmas: dict[str, float] = Field(
+        description='Per-judge discriminator; smaller = sharper/more reliable. Geometric mean fixed at 1. '
+        'Empty when fitted without judge_sigma.'
+    )
+    ranking: list[str] = Field(description='Item IDs, best first')
+    converged: bool = Field(description='True when the iterate stopped moving before the iteration cap')
+    iterations: int = Field(description='Optimizer iterations used')
+    warnings: list[str] = Field(default_factory=list, description='Degradations applied during the fit')
+
+    def reliability(self, judge: str) -> float:
+        """``1 / sigma`` for a judge - the paper's unsupervised reliability signal."""
+        return 1.0 / self.sigmas[judge]
+
+
+def _logistic(x: float) -> float:
+    # Guard against overflow on wild intermediate values.
+    if x >= 0:
+        z = math.exp(-min(x, 60.0))
+        return 1.0 / (1.0 + z)
+    z = math.exp(max(x, -60.0))
+    return z / (1.0 + z)
+
+
+def binarize(comparisons: Iterable[JudgedComparison]) -> list[JudgedComparison]:
+    """Map soft preferences to hard ones (paper: ``y = 1[p >= 0.5]``), keeping exact ties at 0.5."""
+    out: list[JudgedComparison] = []
+    for c in comparisons:
+        # 0.5 is the tie point of the preference scale.
+        hard = 0.5 if c.p_a == 0.5 else (1.0 if c.p_a > 0.5 else 0.0)
+        out.append(c.model_copy(update={'p_a': hard}))
+    return out
+
+
+def fit_bt(
+    comparisons: Sequence[JudgedComparison],
+    *,
+    judge_sigma: bool = True,
+    hard: bool = False,
+) -> BTFit:
+    """Fit the Bradley-Terry family by MLE on the given comparisons.
+
+    ``judge_sigma`` adds the per-judge discriminator (BT-sigma). ``hard``
+    binarizes preferences first (hard BT / hard BT-sigma) - the paper's most
+    robust variant when judges are highly inconsistent.
+
+    Degradations (recorded in ``warnings``, never raised):
+
+    - a single judge with ``judge_sigma=True`` falls back to plain BT - a lone
+      sigma is absorbed into the skill scale and carries no information
+      (paper section 3.3);
+    - a tiny ridge keeps disconnected graphs / perfect separation finite.
+    """
+    if not comparisons:
+        msg = 'fit_bt needs at least one comparison'
+        raise ValueError(msg)
+    if hard:
+        comparisons = binarize(comparisons)
+
+    items = sorted({c.item_a for c in comparisons} | {c.item_b for c in comparisons})
+    judges = sorted({c.judge for c in comparisons})
+    warnings: list[str] = []
+
+    use_sigma = judge_sigma
+    if judge_sigma and len(judges) < 2:
+        use_sigma = False
+        warnings.append('single judge: sigma is unidentifiable, fitted plain BT instead')
+        logger.warning('fit_bt: {}', warnings[-1])
+
+    s = dict.fromkeys(items, 0.0)  # skills
+    tau = dict.fromkeys(judges, 0.0)  # log sigmas
+    # Adam state
+    m_s = dict.fromkeys(items, 0.0)
+    v_s = dict.fromkeys(items, 0.0)
+    m_t = dict.fromkeys(judges, 0.0)
+    v_t = dict.fromkeys(judges, 0.0)
+
+    iterations = 0
+    converged = False
+    delta = math.inf
+    for step in range(1, _MAX_ITER + 1):
+        iterations = step
+        g_s = dict.fromkeys(items, 0.0)
+        g_t = dict.fromkeys(judges, 0.0)
+        for c in comparisons:
+            p = min(max(c.p_a, _P_EPS), 1.0 - _P_EPS)
+            sigma_k = math.exp(tau[c.judge]) if use_sigma else 1.0
+            z = (s[c.item_a] - s[c.item_b]) / sigma_k
+            p_hat = _logistic(z)
+            err = p - p_hat  # d(loglik)/dz
+            g_s[c.item_a] += err / sigma_k
+            g_s[c.item_b] -= err / sigma_k
+            if use_sigma:
+                g_t[c.judge] += -err * z  # chain rule through sigma_k = exp(tau)
+        for i in items:
+            g_s[i] -= _RIDGE * s[i]
+
+        max_g = max(abs(g) for g in g_s.values())
+        if use_sigma:
+            max_g = max(max_g, max(abs(g) for g in g_t.values()))
+        if max_g < _GRAD_FLOOR:
+            converged = True
+            break
+
+        # Adam ascent step with decaying lr, so the iterate settles instead of
+        # oscillating around the optimum at a constant-lr noise floor.
+        lr = _LR / (1 + step / _LR_DECAY_STEPS)
+        prev_s = dict(s)
+        prev_tau = dict(tau)
+        for i in items:
+            g = g_s[i]
+            m_s[i] = _ADAM_B1 * m_s[i] + (1 - _ADAM_B1) * g
+            v_s[i] = _ADAM_B2 * v_s[i] + (1 - _ADAM_B2) * g * g
+            m_hat = m_s[i] / (1 - _ADAM_B1**step)
+            v_hat = v_s[i] / (1 - _ADAM_B2**step)
+            s[i] += lr * m_hat / (math.sqrt(v_hat) + _ADAM_EPS)
+        if use_sigma:
+            for k in judges:
+                g = g_t[k]
+                m_t[k] = _ADAM_B1 * m_t[k] + (1 - _ADAM_B1) * g
+                v_t[k] = _ADAM_B2 * v_t[k] + (1 - _ADAM_B2) * g * g
+                m_hat = m_t[k] / (1 - _ADAM_B1**step)
+                v_hat = v_t[k] / (1 - _ADAM_B2**step)
+                tau[k] += lr * m_hat / (math.sqrt(v_hat) + _ADAM_EPS)
+
+        # Identifiability projections: skills mean-zero; geometric mean of
+        # sigma fixed at 1 (only relative sigmas are meaningful, paper 3.3).
+        s_mean = sum(s.values()) / len(s)
+        for i in items:
+            s[i] -= s_mean
+        if use_sigma:
+            t_mean = sum(tau.values()) / len(tau)
+            if t_mean:
+                for k in judges:
+                    tau[k] -= t_mean
+                # Rescaling sigma rescales the skill space; undo it so the
+                # constraint does not fight the gradient direction.
+                scale = math.exp(-t_mean)
+                for i in items:
+                    s[i] *= scale
+
+        delta = max(abs(s[i] - prev_s[i]) for i in items)
+        if use_sigma:
+            delta = max(delta, max(abs(tau[k] - prev_tau[k]) for k in judges))
+        if delta < _TOL:
+            converged = True
+            break
+
+    if not converged:
+        warnings.append(f'fit stopped at the {_MAX_ITER}-iteration cap (max|step|={delta:.2e})')
+        logger.warning('fit_bt: {}', warnings[-1])
+
+    sigmas = {k: math.exp(tau[k]) for k in judges} if use_sigma else {}
+    ranking = sorted(items, key=lambda i: -s[i])
+    return BTFit(
+        skills={i: s[i] for i in items},
+        sigmas=sigmas,
+        ranking=ranking,
+        converged=converged,
+        iterations=iterations,
+        warnings=warnings,
+    )
+
+
+def cycle_rate(comparisons: Sequence[JudgedComparison], judge: str) -> float | None:
+    """Directed 3-cycle rate of one judge's preferences (paper Eq. 9).
+
+    The paper's independent validation signal: ``1/sigma`` correlates ~0.9 with
+    ``1 - cycle_rate``. Needs at least 3 items with pairwise coverage; returns
+    ``None`` when no complete triplet exists (e.g. the two-item A/B setting).
+    Ties (``p == 0.5``) break no cycles and are treated as no-preference edges.
+    """
+    prefers: dict[tuple[str, str], bool] = {}
+    for c in comparisons:
+        if c.judge != judge:
+            continue
+        if c.p_a > 0.5:
+            prefers[c.item_a, c.item_b] = True
+            prefers[c.item_b, c.item_a] = False
+        elif c.p_a < 0.5:
+            prefers[c.item_a, c.item_b] = False
+            prefers[c.item_b, c.item_a] = True
+
+    items = sorted({i for pair in prefers for i in pair})
+    n = len(items)
+    if n < 3:
+        return None
+
+    def _wins(a: str, b: str) -> bool | None:
+        return prefers.get((a, b))
+
+    triplets = 0
+    cycles = 0
+    for x in range(n):
+        for y in range(x + 1, n):
+            for z in range(y + 1, n):
+                a, b, c_ = items[x], items[y], items[z]
+                ab, bc, ca = _wins(a, b), _wins(b, c_), _wins(c_, a)
+                if ab is None or bc is None or ca is None:
+                    continue  # incomplete or tied triplet: not assessable
+                triplets += 1
+                # a>b>c>a or a<b<c<a - either orientation is a cycle
+                if (ab and bc and ca) or (not ab and not bc and not ca):
+                    cycles += 1
+    if triplets == 0:
+        return None
+    return cycles / triplets
+
+
+def comparisons_per_judge(comparisons: Sequence[JudgedComparison]) -> dict[str, int]:
+    """Comparison counts by judge - a cheap sanity check before trusting sigmas."""
+    counts: dict[str, int] = defaultdict(int)
+    for c in comparisons:
+        counts[c.judge] += 1
+    return dict(counts)
+
+
+__all__ = [
+    'BTFit',
+    'JudgedComparison',
+    'binarize',
+    'comparisons_per_judge',
+    'cycle_rate',
+    'fit_bt',
+]

--- a/tests/dashboard/test_pairwise_surface.py
+++ b/tests/dashboard/test_pairwise_surface.py
@@ -652,22 +652,28 @@ def test_csv_header_escaping_covers_a_hostile_judge_name(tmp_path: Path) -> None
 
 
 def test_filtered_view_rolls_up_once(saved: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch) -> None:
-    """The header and two section builders each call rollup()."""
-    import evaluatorq.pairwise as pw_mod
+    """The header and two section builders each call rollup().
+
+    The adapter routes the filtered rollup through ``PairwiseRun.rollup`` (so a
+    BT-sigma run keeps its aggregation on filtered views), and ``pairwise_run``
+    binds ``build_report`` into its own namespace at import — so the counter
+    must patch that binding, not ``evaluatorq.pairwise``.
+    """
+    import evaluatorq.pairwise_run as pw_run_mod
     from evaluatorq.dashboard.surfaces import ADAPTERS
 
     _, path = saved
     run = ADAPTERS['pairwise'].load(path)
 
     calls = 0
-    real = pw_mod.build_report
+    real = pw_run_mod.build_report
 
-    def counting(comparisons: list[PairwiseComparison]) -> object:
+    def counting(comparisons: list[PairwiseComparison], **kwargs: object) -> object:
         nonlocal calls
         calls += 1
-        return real(comparisons)
+        return real(comparisons, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(pw_mod, 'build_report', counting)
+    monkeypatch.setattr(pw_run_mod, 'build_report', counting)
     body = ADAPTERS['pairwise'].body_from_results(run, list(run.entries[:2]))
 
     assert calls == 1, f'rolled up {calls} times'

--- a/tests/unit/test_pairwise_bt_sigma.py
+++ b/tests/unit/test_pairwise_bt_sigma.py
@@ -8,9 +8,10 @@ unreliable judges.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
+from pydantic import ValidationError
 
 from evaluatorq.pairwise import (
     PairwiseComparison,
@@ -23,8 +24,8 @@ from evaluatorq.pairwise import (
 _Vote = Literal["A", "B", "tie"]
 
 
-def _vote(model: str, value: _Vote | None) -> PairwiseVote:
-    return PairwiseVote(model=model, vote=value)
+def _vote(model: str, value: str | None) -> PairwiseVote:
+    return PairwiseVote(model=model, vote=cast("Literal['A', 'B', 'tie'] | None", value))
 
 
 def _comparison(votes: list[PairwiseVote]) -> PairwiseComparison:
@@ -58,6 +59,11 @@ def test_default_report_is_unchanged() -> None:
 def test_unknown_aggregation_raises() -> None:
     with pytest.raises(ValueError, match='unknown aggregation'):
         build_report(_heterogeneous_run(), aggregation='elo')
+
+
+def test_invalid_vote_is_rejected_at_the_public_model_boundary() -> None:
+    with pytest.raises(ValidationError):
+        PairwiseVote(model='judge', vote='unexpected')  # pyright: ignore[reportArgumentType]
 
 
 def test_bt_sigma_downweights_noisy_judges_and_flips_consensus() -> None:
@@ -112,6 +118,29 @@ def test_abstaining_panel_degrades_to_inconclusive() -> None:
     assert block.a_win_rate is None
     assert block.inconclusive_rate == 1.0
     assert any('no decisive votes' in w for w in block.fit_warnings)
+
+
+def test_non_converged_fit_does_not_change_plurality_winners(monkeypatch: pytest.MonkeyPatch) -> None:
+    import evaluatorq.ranking as ranking_mod
+
+    monkeypatch.setattr(ranking_mod, '_MAX_ITER', 1)
+    rows = [_comparison([_vote('a', 'A'), _vote('b', 'A')]) for _ in range(10)]
+    block = bt_sigma_aggregation(rows)
+    assert block.judge_sigmas == {}
+    assert block.winners == ['A'] * len(rows)
+    assert block.converged is False
+    assert any('non-converged fit' in warning for warning in block.fit_warnings)
+
+
+def test_single_ordering_fit_does_not_claim_reliability() -> None:
+    rows = [_comparison([_vote('a', 'A'), _vote('b', 'B')]) for _ in range(3)]
+    for row in rows:
+        for vote in row.votes:
+            vote.completed = False
+    block = bt_sigma_aggregation(rows)
+    assert block.judge_sigmas == {}
+    assert block.winners == ['inconclusive'] * len(rows)
+    assert any('single-ordering' in warning for warning in block.fit_warnings)
 
 
 def test_single_judge_run_weights_uniformly() -> None:
@@ -183,7 +212,7 @@ def test_low_vote_count_judges_are_flagged() -> None:
 
 
 def test_run_rollup_and_save_thread_aggregation(tmp_path) -> None:
-    from evaluatorq.pairwise_run import PairwiseRun, new_run
+    from evaluatorq.pairwise_run import new_run
 
     run = new_run(run_name='bt-sigma-check')
     for row in _heterogeneous_run():
@@ -202,3 +231,34 @@ def test_run_rollup_and_save_thread_aggregation(tmp_path) -> None:
     assert run.report is not None
     assert run.report.bt_sigma is not None
     assert run.rollup(aggregation='bt-sigma') is run.report
+
+    with pytest.raises(ValueError, match='unknown aggregation'):
+        run.rollup(aggregation='elo')
+
+
+def test_heterogeneous_entries_warn_about_global_sigma_scope() -> None:
+    from evaluatorq.pairwise_run import new_run
+
+    run = new_run(run_name='heterogeneous')
+    for index, row in enumerate(_heterogeneous_run()[:2]):
+        run.add(row, question=f'q-{index}', response_a=f'a-{index}', response_b=f'b-{index}')
+
+    report = run.rollup(aggregation='bt-sigma')
+    assert report.bt_sigma is not None
+    assert any('global agreement' in warning for warning in report.bt_sigma.fit_warnings)
+
+
+def test_report_sections_expose_bt_sigma_and_scope_warning(tmp_path) -> None:
+    from evaluatorq.pairwise_reports.sections import build_report_sections
+    from evaluatorq.pairwise_run import new_run
+
+    run = new_run(run_name='sections', judges=['steady', 'noisy'])
+    for index, row in enumerate(_heterogeneous_run()[:4]):
+        run.add(row, question=f'q-{index}', response_a=f'a-{index}', response_b=f'b-{index}')
+    run.save(tmp_path / 'sections.json', aggregation='bt-sigma')
+
+    consensus = build_report_sections(run)[0]
+    judges = build_report_sections(run)[1]
+    assert consensus.data['bt_sigma'] is not None
+    assert any('global agreement' in warning for warning in consensus.data['bt_sigma']['fit_warnings'])
+    assert all('sigma' in row for row in judges.data['rows'])

--- a/tests/unit/test_pairwise_bt_sigma.py
+++ b/tests/unit/test_pairwise_bt_sigma.py
@@ -121,3 +121,25 @@ def test_tie_between_weighted_sides_is_inconclusive() -> None:
     rows = [_comparison([_vote('a', 'A'), _vote('b', 'B')]) for _ in range(6)]
     block = bt_sigma_aggregation(rows)
     assert set(block.winners) == {'inconclusive'}
+
+
+def test_run_rollup_and_save_thread_aggregation(tmp_path) -> None:
+    from evaluatorq.pairwise_run import PairwiseRun, new_run
+
+    run = new_run(run_name='bt-sigma-check')
+    for row in _heterogeneous_run():
+        run.add(row, question='q', response_a='a', response_b='b')
+
+    # A plurality-saved report is not silently reused for a bt-sigma request.
+    path = run.save(tmp_path / 'run.json')
+    assert path.exists()
+    assert run.report is not None
+    assert run.report.bt_sigma is None
+    weighted = run.rollup(aggregation='bt-sigma')
+    assert weighted.bt_sigma is not None
+
+    # Saving with bt-sigma persists the block, and rollup then reuses it.
+    run.save(tmp_path / 'run2.json', aggregation='bt-sigma')
+    assert run.report is not None
+    assert run.report.bt_sigma is not None
+    assert run.rollup(aggregation='bt-sigma') is run.report

--- a/tests/unit/test_pairwise_bt_sigma.py
+++ b/tests/unit/test_pairwise_bt_sigma.py
@@ -8,6 +8,8 @@ unreliable judges.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
 from evaluatorq.pairwise import (
@@ -18,8 +20,10 @@ from evaluatorq.pairwise import (
     pairwise_consensus,
 )
 
+_Vote = Literal["A", "B", "tie"]
 
-def _vote(model: str, value: str | None) -> PairwiseVote:
+
+def _vote(model: str, value: _Vote | None) -> PairwiseVote:
     return PairwiseVote(model=model, vote=value)
 
 
@@ -28,18 +32,20 @@ def _comparison(votes: list[PairwiseVote]) -> PairwiseComparison:
 
 
 def _heterogeneous_run() -> list[PairwiseComparison]:
-    """One steady judge always voting A; two noisy judges that flip sides.
+    """One steady judge voting A on 11 of 12 rows; two noisy judges that flip.
 
-    The steady judge is perfectly consistent with a fixed A-beats-B gap, so the
-    fit assigns it a small sigma. The noisy pair split across rows, earning
-    large sigmas. On rows where both noisy judges vote B, plurality says B but
-    the reliability-weighted vote should say A.
+    The steady judge votes B once (row 1, where the noisy pair also votes B) so
+    it stays out of the one-sided guard and its small sigma is a genuine
+    reliability estimate. The noisy pair split across rows, earning large
+    sigmas. On rows where both noisy judges outvote a steady A under plurality,
+    the reliability-weighted vote should restore A.
     """
     rows = []
     for k in range(12):
-        noisy_1 = 'A' if k % 2 == 0 else 'B'
-        noisy_2 = 'A' if k % 3 == 0 else 'B'
-        rows.append(_comparison([_vote('steady', 'A'), _vote('noisy-1', noisy_1), _vote('noisy-2', noisy_2)]))
+        steady: _Vote = "B" if k == 1 else "A"
+        noisy_1: _Vote = "A" if k % 2 == 0 else "B"
+        noisy_2: _Vote = "A" if k % 3 == 0 else "B"
+        rows.append(_comparison([_vote("steady", steady), _vote("noisy-1", noisy_1), _vote("noisy-2", noisy_2)]))
     return rows
 
 
@@ -59,21 +65,24 @@ def test_bt_sigma_downweights_noisy_judges_and_flips_consensus() -> None:
     report = build_report(rows, aggregation='bt-sigma')
     block = report.bt_sigma
     assert block is not None
+    assert block.converged is True
     assert block.judge_sigmas['steady'] < block.judge_sigmas['noisy-1']
     assert block.judge_sigmas['steady'] < block.judge_sigmas['noisy-2']
-    # Rows where the two noisy judges outvote the steady one under plurality:
-    outvoted = [i for i, row in enumerate(rows) if row.winner == 'B']
-    assert outvoted, 'fixture must contain plurality-B rows'
+    # Rows where the two noisy judges outvote a steady A under plurality:
+    outvoted = [i for i, row in enumerate(rows) if row.winner == 'B' and row.votes[0].vote == 'A']
+    assert outvoted, 'fixture must contain plurality-B rows against a steady A'
     # The weighted vote restores A on those rows.
     assert all(block.winners[i] == 'A' for i in outvoted)
+    # Row 1 is unanimous B and must stay B under any weighting.
+    assert block.winners[1] == 'B'
     assert block.p_a_beats_b > 0.5
     assert block.skill_gap > 0.0
     # Weighted rollup beats the plurality rollup toward the steady signal.
     weighted_a = block.a_win_rate
     plurality_a = report.a_win_rate
-    assert weighted_a == 1.0
     assert weighted_a is not None
     assert plurality_a is not None
+    assert weighted_a == pytest.approx(11 / 12)
     assert weighted_a > plurality_a
 
 
@@ -121,6 +130,56 @@ def test_tie_between_weighted_sides_is_inconclusive() -> None:
     rows = [_comparison([_vote('a', 'A'), _vote('b', 'B')]) for _ in range(6)]
     block = bt_sigma_aggregation(rows)
     assert set(block.winners) == {'inconclusive'}
+
+
+def test_one_sided_judge_cannot_take_over_the_run() -> None:
+    # The production shape of a position- or verbosity-biased judge: it never
+    # picks B at all. In the two-item fit its sigma collapses toward zero
+    # (sigma is pinned by the judge's own one-sidedness), so 1/sigma weighting
+    # would let it outvote an agreeing two-judge majority on every row. The
+    # guard weights it neutrally instead and says so.
+    rows = []
+    for k in range(10):
+        majority: Literal["A", "B"] = "B" if k < 6 else "A"
+        rows.append(_comparison([_vote("always-a", "A"), _vote("y", majority), _vote("z", majority)]))
+    block = bt_sigma_aggregation(rows)
+    assert "always-a" not in block.judge_sigmas
+    assert any("always-a" in w and "one-sidedness" in w for w in block.fit_warnings)
+    # The agreeing majority keeps every row it won under plurality.
+    assert block.winners == [row.winner for row in rows]
+    assert block.b_win_rate is not None
+    assert block.b_win_rate == pytest.approx(6 / 10)
+
+
+def test_tie_votes_flow_through_the_aggregation() -> None:
+    # End-to-end 'tie' coverage: tie maps to p=0.5 in the fit, and a weighted
+    # tie leader stays 'tie' in the winners.
+    pattern: list[_Vote] = ["A", "A", "tie", "A", "B", "tie"]
+    rows = [_comparison([_vote("a", pattern[k]), _vote("b", pattern[k])]) for k in range(6)]
+    block = bt_sigma_aggregation(rows)
+    assert block.winners[2] == "tie"
+    assert block.winners[5] == "tie"
+    assert block.tie_rate == pytest.approx(2 / 6)
+    assert block.p_a_beats_b > 0.5
+
+
+def test_cap_hit_reports_unconverged(monkeypatch: pytest.MonkeyPatch) -> None:
+    import evaluatorq.ranking as ranking_mod
+
+    monkeypatch.setattr(ranking_mod, "_MAX_ITER", 3)
+    block = bt_sigma_aggregation(_heterogeneous_run())
+    assert block.converged is False
+    assert any("iteration cap" in w for w in block.fit_warnings)
+
+
+def test_low_vote_count_judges_are_flagged() -> None:
+    # Three decisive votes per judge, mixed so the one-sided guard stays out of
+    # the way: sigmas exist but are mostly prior, and fit_warnings says so.
+    pattern_a: list[_Vote] = ["A", "B", "A"]
+    pattern_b: list[_Vote] = ["B", "A", "A"]
+    rows = [_comparison([_vote("a", pattern_a[k]), _vote("b", pattern_b[k])]) for k in range(3)]
+    block = bt_sigma_aggregation(rows)
+    assert any("only 3 decisive vote" in w for w in block.fit_warnings)
 
 
 def test_run_rollup_and_save_thread_aggregation(tmp_path) -> None:

--- a/tests/unit/test_pairwise_bt_sigma.py
+++ b/tests/unit/test_pairwise_bt_sigma.py
@@ -1,0 +1,123 @@
+"""BT-sigma aggregation over pairwise jury runs.
+
+Pins the integration contract: the default report is byte-identical to before,
+and the opt-in reliability-weighted aggregation down-weights judges the fit
+marks as noisy, flipping consensus where a uniform plurality is outvoted by
+unreliable judges.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.pairwise import (
+    PairwiseComparison,
+    PairwiseVote,
+    bt_sigma_aggregation,
+    build_report,
+    pairwise_consensus,
+)
+
+
+def _vote(model: str, value: str | None) -> PairwiseVote:
+    return PairwiseVote(model=model, vote=value)
+
+
+def _comparison(votes: list[PairwiseVote]) -> PairwiseComparison:
+    return PairwiseComparison(winner=pairwise_consensus([v.vote for v in votes]), votes=votes)
+
+
+def _heterogeneous_run() -> list[PairwiseComparison]:
+    """One steady judge always voting A; two noisy judges that flip sides.
+
+    The steady judge is perfectly consistent with a fixed A-beats-B gap, so the
+    fit assigns it a small sigma. The noisy pair split across rows, earning
+    large sigmas. On rows where both noisy judges vote B, plurality says B but
+    the reliability-weighted vote should say A.
+    """
+    rows = []
+    for k in range(12):
+        noisy_1 = 'A' if k % 2 == 0 else 'B'
+        noisy_2 = 'A' if k % 3 == 0 else 'B'
+        rows.append(_comparison([_vote('steady', 'A'), _vote('noisy-1', noisy_1), _vote('noisy-2', noisy_2)]))
+    return rows
+
+
+def test_default_report_is_unchanged() -> None:
+    report = build_report(_heterogeneous_run())
+    assert report.bt_sigma is None
+    assert all(stats.sigma is None for stats in report.per_judge)
+
+
+def test_unknown_aggregation_raises() -> None:
+    with pytest.raises(ValueError, match='unknown aggregation'):
+        build_report(_heterogeneous_run(), aggregation='elo')
+
+
+def test_bt_sigma_downweights_noisy_judges_and_flips_consensus() -> None:
+    rows = _heterogeneous_run()
+    report = build_report(rows, aggregation='bt-sigma')
+    block = report.bt_sigma
+    assert block is not None
+    assert block.judge_sigmas['steady'] < block.judge_sigmas['noisy-1']
+    assert block.judge_sigmas['steady'] < block.judge_sigmas['noisy-2']
+    # Rows where the two noisy judges outvote the steady one under plurality:
+    outvoted = [i for i, row in enumerate(rows) if row.winner == 'B']
+    assert outvoted, 'fixture must contain plurality-B rows'
+    # The weighted vote restores A on those rows.
+    assert all(block.winners[i] == 'A' for i in outvoted)
+    assert block.p_a_beats_b > 0.5
+    assert block.skill_gap > 0.0
+    # Weighted rollup beats the plurality rollup toward the steady signal.
+    weighted_a = block.a_win_rate
+    plurality_a = report.a_win_rate
+    assert weighted_a == 1.0
+    assert weighted_a is not None
+    assert plurality_a is not None
+    assert weighted_a > plurality_a
+
+
+def test_judge_stats_carry_sigma_when_requested() -> None:
+    report = build_report(_heterogeneous_run(), aggregation='bt-sigma')
+    by_model = {stats.model: stats.sigma for stats in report.per_judge}
+    steady, noisy = by_model['steady'], by_model['noisy-1']
+    assert steady is not None
+    assert noisy is not None
+    assert steady < noisy
+
+
+def test_headline_plurality_rates_stay_comparable() -> None:
+    rows = _heterogeneous_run()
+    plain = build_report(rows)
+    with_bt = build_report(rows, aggregation='bt-sigma')
+    # The plurality headline is identical either way; BT-sigma is additive.
+    assert with_bt.a_win_rate == plain.a_win_rate
+    assert with_bt.b_win_rate == plain.b_win_rate
+    assert with_bt.inconclusive_rate == plain.inconclusive_rate
+
+
+def test_abstaining_panel_degrades_to_inconclusive() -> None:
+    rows = [_comparison([_vote('a', None), _vote('b', None)]) for _ in range(3)]
+    block = bt_sigma_aggregation(rows)
+    assert block.winners == ['inconclusive'] * 3
+    assert block.a_win_rate is None
+    assert block.inconclusive_rate == 1.0
+    assert any('no decisive votes' in w for w in block.fit_warnings)
+
+
+def test_single_judge_run_weights_uniformly() -> None:
+    rows = [_comparison([_vote('only', 'A')]) for _ in range(4)]
+    block = bt_sigma_aggregation(rows)
+    # Sigma is unidentifiable with one judge; the fit falls back and the
+    # weighted vote reduces to the plain one.
+    assert block.judge_sigmas == {}
+    assert block.winners == ['A'] * 4
+    assert any('single judge' in w for w in block.fit_warnings)
+
+
+def test_tie_between_weighted_sides_is_inconclusive() -> None:
+    # Two judges, perfectly symmetric opposite votes: sigmas equal, weights
+    # equal, every row splits -> inconclusive, matching plurality semantics.
+    rows = [_comparison([_vote('a', 'A'), _vote('b', 'B')]) for _ in range(6)]
+    block = bt_sigma_aggregation(rows)
+    assert set(block.winners) == {'inconclusive'}

--- a/tests/unit/test_ranking_bt.py
+++ b/tests/unit/test_ranking_bt.py
@@ -1,0 +1,170 @@
+"""Synthetic-recovery tests for the BT-sigma fit (arXiv:2602.16610).
+
+These encode the paper's claims as regressions: under heterogeneous judge
+noise the fit recovers the true ranking, and the fitted discriminators order
+judges by their injected noise level.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pytest
+
+from evaluatorq.ranking import JudgedComparison, binarize, comparisons_per_judge, cycle_rate, fit_bt
+
+_ITEMS = ['m1', 'm2', 'm3', 'm4', 'm5']
+_TRUE_SKILLS = {'m1': 2.0, 'm2': 1.0, 'm3': 0.0, 'm4': -1.0, 'm5': -2.0}
+
+
+def _logistic(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def _soft_comparisons(sigmas: dict[str, float]) -> list[JudgedComparison]:
+    """Exact model-generated soft preferences for every ordered pair per judge."""
+    out = []
+    for judge, sigma in sigmas.items():
+        for i in _ITEMS:
+            for j in _ITEMS:
+                if i >= j:
+                    continue
+                p = _logistic((_TRUE_SKILLS[i] - _TRUE_SKILLS[j]) / sigma)
+                out.append(JudgedComparison(judge=judge, item_a=i, item_b=j, p_a=p))
+    return out
+
+
+def _sampled_hard_comparisons(sigmas: dict[str, float], rounds: int, seed: int = 0) -> list[JudgedComparison]:
+    """Hard votes sampled from the model with per-judge noise, deterministic seed."""
+    rng = random.Random(seed)
+    out = []
+    for judge, sigma in sigmas.items():
+        for _ in range(rounds):
+            for i in _ITEMS:
+                for j in _ITEMS:
+                    if i >= j:
+                        continue
+                    p = _logistic((_TRUE_SKILLS[i] - _TRUE_SKILLS[j]) / sigma)
+                    vote = 1.0 if rng.random() < p else 0.0
+                    out.append(JudgedComparison(judge=judge, item_a=i, item_b=j, p_a=vote))
+    return out
+
+
+def test_soft_bt_sigma_recovers_ranking_and_noise_ordering() -> None:
+    sigmas = {'sharp': 0.5, 'mid': 1.0, 'noisy': 4.0}
+    fit = fit_bt(_soft_comparisons(sigmas), judge_sigma=True)
+    assert fit.ranking == ['m1', 'm2', 'm3', 'm4', 'm5']
+    # Fitted discriminator ordering matches the injected noise ordering.
+    assert fit.sigmas['sharp'] < fit.sigmas['mid'] < fit.sigmas['noisy']
+    assert fit.converged
+
+
+def test_hard_bt_sigma_recovers_ranking_under_sampled_noise() -> None:
+    sigmas = {'sharp': 0.4, 'noisy': 5.0}
+    fit = fit_bt(_sampled_hard_comparisons(sigmas, rounds=40), judge_sigma=True, hard=True)
+    assert fit.ranking == ['m1', 'm2', 'm3', 'm4', 'm5']
+    assert fit.sigmas['sharp'] < fit.sigmas['noisy']
+
+
+def test_bt_sigma_downweights_an_adversarial_judge() -> None:
+    # Two sharp judges and one voting the REVERSE ranking. With a single good
+    # judge this is ill-posed (the paper's limitations section: a consistent
+    # minority is indistinguishable from a correct one), so the majority
+    # breaks the symmetry. BT-sigma should keep the true order and hand the
+    # adversary the largest discriminator.
+    good = _soft_comparisons({'good-1': 0.5, 'good-2': 0.7})
+    adversary = [
+        JudgedComparison(judge='bad', item_a=c.item_a, item_b=c.item_b, p_a=1.0 - c.p_a)
+        for c in _soft_comparisons({'bad': 0.5})
+    ]
+    fit = fit_bt(good + adversary, judge_sigma=True)
+    assert fit.ranking == ['m1', 'm2', 'm3', 'm4', 'm5']
+    assert fit.sigmas['bad'] > fit.sigmas['good-1']
+    assert fit.sigmas['bad'] > fit.sigmas['good-2']
+
+
+def test_identifiability_constraints_hold() -> None:
+    fit = fit_bt(_soft_comparisons({'a': 0.7, 'b': 2.0}), judge_sigma=True)
+    assert sum(fit.skills.values()) == pytest.approx(0.0, abs=1e-6)
+    log_sigmas = [math.log(v) for v in fit.sigmas.values()]
+    assert sum(log_sigmas) == pytest.approx(0.0, abs=1e-6)  # geometric mean 1
+
+
+def test_single_judge_falls_back_to_plain_bt() -> None:
+    fit = fit_bt(_soft_comparisons({'only': 1.0}), judge_sigma=True)
+    assert fit.sigmas == {}
+    assert any('single judge' in w for w in fit.warnings)
+    assert fit.ranking == ['m1', 'm2', 'm3', 'm4', 'm5']
+
+
+def test_fit_is_deterministic() -> None:
+    comparisons = _sampled_hard_comparisons({'a': 0.5, 'b': 2.0}, rounds=5)
+    first = fit_bt(comparisons, judge_sigma=True, hard=True)
+    second = fit_bt(comparisons, judge_sigma=True, hard=True)
+    assert first.skills == second.skills
+    assert first.sigmas == second.sigmas
+
+
+def test_perfect_separation_stays_finite() -> None:
+    # Every judge says m1 beats m2 every time: the unregularised MLE diverges.
+    comparisons = [
+        JudgedComparison(judge=j, item_a='m1', item_b='m2', p_a=1.0) for j in ('a', 'b') for _ in range(10)
+    ]
+    fit = fit_bt(comparisons, judge_sigma=True, hard=True)
+    assert fit.ranking == ['m1', 'm2']
+    assert all(abs(v) < 50 for v in fit.skills.values())
+
+
+def test_disconnected_graph_stays_finite() -> None:
+    comparisons = [
+        JudgedComparison(judge='a', item_a='x1', item_b='x2', p_a=0.9),
+        JudgedComparison(judge='b', item_a='y1', item_b='y2', p_a=0.2),
+    ]
+    fit = fit_bt(comparisons, judge_sigma=True)
+    assert set(fit.ranking) == {'x1', 'x2', 'y1', 'y2'}
+    assert all(math.isfinite(v) for v in fit.skills.values())
+
+
+def test_empty_comparisons_raise() -> None:
+    with pytest.raises(ValueError, match='at least one comparison'):
+        fit_bt([])
+
+
+def test_binarize_maps_votes_and_keeps_ties() -> None:
+    soft = [
+        JudgedComparison(judge='j', item_a='a', item_b='b', p_a=0.8),
+        JudgedComparison(judge='j', item_a='a', item_b='b', p_a=0.2),
+        JudgedComparison(judge='j', item_a='a', item_b='b', p_a=0.5),
+    ]
+    assert [c.p_a for c in binarize(soft)] == [1.0, 0.0, 0.5]
+
+
+def test_cycle_rate_transitive_cyclic_and_undefined() -> None:
+    def pref(a: str, b: str) -> JudgedComparison:
+        return JudgedComparison(judge='j', item_a=a, item_b=b, p_a=1.0)
+
+    transitive = [pref('a', 'b'), pref('b', 'c'), pref('a', 'c')]
+    assert cycle_rate(transitive, 'j') == 0.0
+    cyclic = [pref('a', 'b'), pref('b', 'c'), pref('c', 'a')]
+    assert cycle_rate(cyclic, 'j') == 1.0
+    # Two items: no triplet exists, the diagnostic is undefined (A/B setting).
+    assert cycle_rate([pref('a', 'b')], 'j') is None
+
+
+def test_noisier_judge_has_higher_cycle_rate_and_higher_sigma() -> None:
+    # The paper's validation signal: 1/sigma tracks cycle consistency.
+    comparisons = _sampled_hard_comparisons({'sharp': 0.3, 'noisy': 6.0}, rounds=1, seed=3)
+    fit = fit_bt(comparisons, judge_sigma=True, hard=True)
+    sharp_cycles = cycle_rate(comparisons, 'sharp')
+    noisy_cycles = cycle_rate(comparisons, 'noisy')
+    assert sharp_cycles is not None
+    assert noisy_cycles is not None
+    assert sharp_cycles <= noisy_cycles
+    assert fit.sigmas['sharp'] < fit.sigmas['noisy']
+
+
+def test_comparisons_per_judge_counts() -> None:
+    comparisons = _soft_comparisons({'a': 1.0, 'b': 1.0})
+    counts = comparisons_per_judge(comparisons)
+    assert counts == {'a': 10, 'b': 10}

--- a/tests/unit/test_ranking_bt.py
+++ b/tests/unit/test_ranking_bt.py
@@ -170,3 +170,73 @@ def test_comparisons_per_judge_counts() -> None:
     comparisons = _soft_comparisons({'a': 1.0, 'b': 1.0})
     counts = comparisons_per_judge(comparisons)
     assert counts == {'a': 10, 'b': 10}
+
+
+def test_comparisons_per_judge_sums_weights() -> None:
+    weighted = [JudgedComparison(judge='j', item_a='a', item_b='b', p_a=1.0, weight=7.0)]
+    assert comparisons_per_judge(weighted) == {'j': 7.0}
+
+
+def test_fit_matches_independent_derivation() -> None:
+    # One judge, hard 3-1 votes for m1 over m2: with skills centred at +-g/2,
+    # plain-BT stationarity is 4*(0.75 - logistic(g)) = _RIDGE * g / 2. Solve
+    # it by bisection, independently of the optimiser, and pin the fit to it.
+    # A scaling bug in the gradient that preserved monotonicity would fail here.
+    votes = [JudgedComparison(judge='j', item_a='m1', item_b='m2', p_a=1.0) for _ in range(3)] + [
+        JudgedComparison(judge='j', item_a='m1', item_b='m2', p_a=0.0)
+    ]
+    fit = fit_bt(votes, judge_sigma=False)
+    gap = fit.skills['m1'] - fit.skills['m2']
+
+    def stationarity(g: float) -> float:
+        return 4.0 * (0.75 - _logistic(g)) - 1e-2 * g / 2.0
+
+    lo, hi = 0.0, 5.0
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        if stationarity(mid) > 0:
+            lo = mid
+        else:
+            hi = mid
+    # abs=5e-3: the optimiser stops within ~_TOL-sized residue of the optimum;
+    # the tolerance is far below any scaling error (a 2x gradient bug lands
+    # the gap near 0.55 off) while not fighting the convergence criterion.
+    assert gap == pytest.approx(lo, abs=5e-3)
+    assert _logistic(gap) == pytest.approx(0.75, abs=2e-3)
+
+
+def test_weighted_records_match_repeated_records() -> None:
+    # The likelihood is additive over identical records, so a weight-5 record
+    # must fit exactly like five copies - this is what lets the pairwise
+    # aggregation collapse votes without changing the optimum.
+    def records(collapse: bool) -> list[JudgedComparison]:
+        spec = [('j1', 1.0, 5), ('j1', 0.0, 1), ('j2', 0.0, 2), ('j2', 1.0, 1)]
+        if collapse:
+            return [
+                JudgedComparison(judge=j, item_a='m1', item_b='m2', p_a=p, weight=float(n)) for j, p, n in spec
+            ]
+        return [
+            JudgedComparison(judge=j, item_a='m1', item_b='m2', p_a=p) for j, p, n in spec for _ in range(n)
+        ]
+
+    expanded = fit_bt(records(collapse=False), judge_sigma=True, hard=True)
+    collapsed = fit_bt(records(collapse=True), judge_sigma=True, hard=True)
+    assert collapsed.skills['m1'] == pytest.approx(expanded.skills['m1'], abs=1e-6)
+    assert collapsed.sigmas['j1'] == pytest.approx(expanded.sigmas['j1'], rel=1e-6)
+    assert collapsed.sigmas['j2'] == pytest.approx(expanded.sigmas['j2'], rel=1e-6)
+
+
+def test_cycle_rate_aggregates_duplicate_judgements() -> None:
+    # A judge that rated the same pair twice in opposite directions has no net
+    # preference on it: the edge must cancel (mean p = 0.5), not resolve to
+    # whichever judgement happened to come last.
+    base = [
+        JudgedComparison(judge='j', item_a='m1', item_b='m2', p_a=1.0),
+        JudgedComparison(judge='j', item_a='m2', item_b='m3', p_a=1.0),
+        JudgedComparison(judge='j', item_a='m3', item_b='m1', p_a=1.0),
+    ]
+    assert cycle_rate(base, 'j') == 1.0
+    # The duplicate arrives in the REVERSED frame (m2, m1): canonicalisation
+    # must fold it onto the same edge before averaging.
+    dup = [*base, JudgedComparison(judge='j', item_a='m2', item_b='m1', p_a=1.0)]
+    assert cycle_rate(dup, 'j') is None

--- a/tests/unit/test_ranking_bt.py
+++ b/tests/unit/test_ranking_bt.py
@@ -126,6 +126,18 @@ def test_disconnected_graph_stays_finite() -> None:
     fit = fit_bt(comparisons, judge_sigma=True)
     assert set(fit.ranking) == {'x1', 'x2', 'y1', 'y2'}
     assert all(math.isfinite(v) for v in fit.skills.values())
+    assert any('disconnected' in warning for warning in fit.warnings)
+
+
+def test_sparse_judge_coverage_is_reported() -> None:
+    comparisons = [
+        JudgedComparison(judge='sparse', item_a='a', item_b='b', p_a=1.0),
+        JudgedComparison(judge='steady', item_a='a', item_b='b', p_a=1.0),
+        JudgedComparison(judge='steady', item_a='a', item_b='b', p_a=1.0),
+        JudgedComparison(judge='steady', item_a='a', item_b='b', p_a=1.0),
+    ]
+    fit = fit_bt(comparisons, judge_sigma=True, hard=True)
+    assert any('fewer than 3 observations' in warning for warning in fit.warnings)
 
 
 def test_empty_comparisons_raise() -> None:
@@ -152,6 +164,17 @@ def test_cycle_rate_transitive_cyclic_and_undefined() -> None:
     assert cycle_rate(cyclic, 'j') == 1.0
     # Two items: no triplet exists, the diagnostic is undefined (A/B setting).
     assert cycle_rate([pref('a', 'b')], 'j') is None
+
+
+def test_cycle_rate_uses_the_majority_of_duplicate_edges() -> None:
+    comparisons = [
+        JudgedComparison(judge='j', item_a='a', item_b='b', p_a=1.0),
+        JudgedComparison(judge='j', item_a='a', item_b='b', p_a=0.0),
+        JudgedComparison(judge='j', item_a='a', item_b='b', p_a=0.0),
+        JudgedComparison(judge='j', item_a='b', item_b='c', p_a=1.0),
+        JudgedComparison(judge='j', item_a='a', item_b='c', p_a=1.0),
+    ]
+    assert cycle_rate(comparisons, 'j') == 0.0
 
 
 def test_noisier_judge_has_higher_cycle_rate_and_higher_sigma() -> None:

--- a/tests/unit/test_ranking_bt.py
+++ b/tests/unit/test_ranking_bt.py
@@ -87,8 +87,10 @@ def test_bt_sigma_downweights_an_adversarial_judge() -> None:
 def test_identifiability_constraints_hold() -> None:
     fit = fit_bt(_soft_comparisons({'a': 0.7, 'b': 2.0}), judge_sigma=True)
     assert sum(fit.skills.values()) == pytest.approx(0.0, abs=1e-6)
-    log_sigmas = [math.log(v) for v in fit.sigmas.values()]
-    assert sum(log_sigmas) == pytest.approx(0.0, abs=1e-6)  # geometric mean 1
+    # Sigma's absolute scale is only loosely anchored (soft prior); the
+    # contract is that ratios within a fit are meaningful and finite.
+    assert all(v > 0 and math.isfinite(v) for v in fit.sigmas.values())
+    assert fit.sigmas['a'] < fit.sigmas['b']  # ratio reflects injected noise
 
 
 def test_single_judge_falls_back_to_plain_bt() -> None:


### PR DESCRIPTION
Closes RES-1024.

Adds **BT-sigma** (reliability-weighted Bradley-Terry, [arXiv:2602.16610](https://arxiv.org/abs/2602.16610)) as an opt-in aggregation mode for the pairwise jury. It jointly fits item skills and a per-judge discriminator by unsupervised MLE on the run's own reconciled votes: no labels, no extra LLM calls, and noisy judges get down-weighted instead of outvoting sharp ones. The same model class is independently derived with identifiability and consistency proofs in [arXiv:2601.21817](https://arxiv.org/abs/2601.21817); the survey comparing it against Crowd-BT, Temp-BT, Dawid-Skene, SkillAggregation and HJA is on the ticket.

## What's here

- **`ranking.py`** (new): `fit_bt()` covering hard BT, soft BT, BT-sigma and hard BT-sigma via two flags, plus `cycle_rate()` (the paper's independent consistency diagnostic) and `binarize()`. Pure Python on purpose: the problem is N items + K judges parameters, closed-form gradients converge in milliseconds, and the runtime dependency set stays untouched (no scipy/numpy). Deterministic zero init, Adam with lr decay, tiny ridge for disconnected graphs / perfect separation, mean-zero skills + unit-geometric-mean sigmas for identifiability, single-judge fallback to plain BT with a warning. The per-aspect variant (BT-sigma-asp) is deliberately skipped, the paper finds it marginal.
- **`pairwise.py`** (additive): `build_report(comparisons, aggregation='bt-sigma')` fits hard BT-sigma over the run and attaches a reliability-weighted rollup (`report.bt_sigma`: fitted P(A beats B), per-judge sigmas, weighted winner per comparison, weighted win rates) and each judge's `sigma` on `JudgeStats`. **Plurality stays the default and its headline rates are unchanged**, so the two aggregations are directly comparable side by side.
- **Docs**: new section in `pairwise-judging.md` with usage, the single-judge and split-panel semantics, and the honest limitation (unsupervised aggregation rewards internal consistency; it protects against noisy judges, not a coordinated biased majority).
- Comparison records carry judge identity so the round-robin panel work (RES-1023) can reuse them.

## Design notes worth reviewing

- **Votes feed the fit as hard preferences** (A=1, B=0, tie=0.5). We have no token logits through the router, so the paper's soft-probability mode is out of reach; hard BT-sigma is fully faithful to the paper and is its own recommended robust variant under high inconsistency. Documented as a limitation.
- **Symmetrisation comes free**: reconcile_pair already runs every judge in both orderings, which satisfies the model's commutativity requirement (paper Eq. 4) before the fit ever sees a vote.
- **Gradient stationarity floor**: without it, Adam's scale invariance turns a 1e-16 float residue at a symmetric stationary point (two judges in perfect opposition) into a full-size step, and the fit crowns one judge ~16,000x more reliable than the other on perfectly ambiguous data. With the floor, ambiguous stays ambiguous. There's a test for exactly this.
- **Soft priors instead of hard identifiability projections** (evolved during live testing): skills are mean-centred additively, and the sigma scale is anchored by a log-normal prior alone. The original hard geometric-mean projection was a multiplicative ratchet on unanimous panels: every tau drifts down together, the projection's compensating skill rescale inflates skills without bound, and Adam's normalised steps cap the ridge's corrective pull, so skills exploded to +-2000 on real data. Consequence documented on BTFit: **sigma ratios within a fit are meaningful, absolute values across fits are not** (which is all the vote-weighting uses).
- **Convergence is measured on iterate movement, not gradient norm** (the ridge leaves a permanent small gradient at the regularised optimum), with tolerance and iteration cap sized to parameter scale after three drift-family bugs surfaced in manual testing: consistent single judge, single-judge fallback, unanimous panels.

## Live validation (examples/pairwise/bt_sigma_ranking.py)

The committed example is the paper in miniature on a real jury: five questions with four graded answer tiers as global BT items, judged by a lopsided panel from the verified jury presets (gpt-5.4-mini, gpt-5.4-nano, deepseek/deepseek-v4-flash). Tier design induces disagreement via the documented verbosity bias of small judges. Across four independent live runs (two mine, two Karina's manual testing): the exact tier ranking was recovered 4/4, and the sigma ordering deepseek < mini < nano replicated 4/4 with up to a 10x spread, nano correctly identified as least reliable, with zero labels. Judges default to temperature=0 for reproducibility.

## Tests (24 new)

Synthetic-recovery regressions encoding the paper's claims: ranking recovery under heterogeneous judge noise (soft and sampled-hard), fitted sigma ordering matching injected noise ordering, adversarial-judge down-weighting (majority-anchored, since a single consistent adversary vs a single good judge is the ill-posed case the paper's limitations name), sigma-vs-cycle-rate agreement, identifiability constraints, determinism, perfect-separation and disconnected-graph finiteness, single-judge fallback; plus the pairwise integration contract (default report byte-identical, weighted consensus flipping plurality-outvoted rows, split panel inconclusive).

## Verification

- Full suite: 3611 passed (dashboard + hub included), ruff + format clean, basedpyright 0 errors, mkdocs build --strict passes.
- Survey + implementation-decision comments on RES-1024.

## Sequencing note

#111 (jury template-var namespace) also touches `pairwise.py`. This PR's changes there are additive and in a different region (consensus/report, not replacements), so a conflict is unlikely but possible; whoever lands second rebases trivially.
