### PR TITLE
docs: make uv the default install and run path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,37 +57,45 @@ The library is deliberately lightweight: async-first, typed end-to-end, and usab
 ## 📥 Installation
 
 ```bash
-pip install evaluatorq
-# or
 uv add evaluatorq
-# or
-poetry add evaluatorq
 ```
+
+Then run your evaluation and the CLI through the same project environment:
+
+```bash
+uv run my_eval.py
+uv run eq --help          # `uv run evaluatorq` works too
+```
+
+`uv run` resolves the project's environment before executing, so the code you
+run and the packages you installed can't drift apart. With pip, name the
+interpreter explicitly to get the same guarantee:
+
+```bash
+python -m pip install evaluatorq
+python my_eval.py
+```
+
+Poetry (`poetry add evaluatorq`, `poetry run python my_eval.py`) works the same way.
 
 ### Optional Dependencies
 
 If you want to use the Orq platform integration:
 
 ```bash
-pip install orq-ai-sdk
-# or
-pip install evaluatorq[orq]
+uv add "evaluatorq[orq]"
 ```
 
 For OpenTelemetry tracing (optional):
 
 ```bash
-pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-semantic-conventions
-# or
-pip install evaluatorq[otel]
+uv add "evaluatorq[otel]"
 ```
 
 For LangChain/LangGraph integration:
 
 ```bash
-pip install langchain
-# or
-pip install evaluatorq[langchain]
+uv add "evaluatorq[langchain]"
 ```
 
 ## 🏁 Getting Started
@@ -671,7 +679,7 @@ Send traces to any OpenTelemetry-compatible backend:
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=https://your-collector:4318 \
 OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer token" \
-python my_eval.py
+uv run my_eval.py
 ```
 
 ### Disable Tracing
@@ -771,7 +779,7 @@ Complete examples are available in the examples folder:
 Run adversarial attacks against an LLM or agent and measure how well it resists. Attacks are generated dynamically by an attacker LLM and mapped to OWASP vulnerability categories (LLM Top 10 and Agentic Security Initiative).
 
 ```bash
-pip install evaluatorq[redteam]
+uv add "evaluatorq[redteam]"
 ```
 
 Point `red_team()` at an orq.ai agent — `"agent:<key>"` auto-selects the ORQ backend and discovers the agent's tools, memory, and system prompt:
@@ -806,7 +814,7 @@ No deployment? Red-team a raw model with `OpenAIModelTarget("openai/gpt-5.4-mini
 Stress-test an agent against *real users* before they do. A **user-simulator LLM** plays a persona pursuing a goal across a multi-turn conversation, and a **judge LLM** scores each run against your criteria. The non-adversarial counterpart to red teaming.
 
 ```bash
-pip install evaluatorq[simulation]
+uv add "evaluatorq[simulation]"
 ```
 
 Define who the user is (`Persona`) and what they want (`Scenario`), then simulate — against a hosted orq.ai agent (`target="agent:<key>"`) or a local callable:

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -4,8 +4,8 @@ This guide explains how to add custom evaluators, vulnerabilities, attack strate
 
 !!! note "Requires editing the package source"
     The extension points below modify evaluatorq's internal registries directly —
-    they are not a stable runtime API. Clone the repo and install in editable mode
-    (`pip install -e ".[redteam]"`), then make your changes there. A runtime
+    they are not a stable runtime API. Clone the repo and sync the dev
+    environment (`uv sync --all-extras --all-groups`), then make your changes there. A runtime
     registration API is planned; see the [Roadmap](roadmap.md).
 
 ## Architecture overview

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -22,15 +22,9 @@ The dashboard is an optional extra (it pulls in `python-fasthtml` and
 `uvicorn`):
 
 ```bash
-pip install "evaluatorq[dashboard]"
-# or — if you already have the redteam / simulation extras:
-pip install "evaluatorq[redteam,dashboard]"
-```
-
-With `uv`:
-
-```bash
 uv add "evaluatorq[dashboard]"
+# or — if you already have the redteam / simulation extras:
+uv add "evaluatorq[redteam,dashboard]"
 ```
 
 ## Launch

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,10 +24,13 @@ The Orq platform is optional — it stores results and routes LLMs when
 Pick the extra for what you're doing:
 
 ```bash
-pip install "evaluatorq"               # core evaluations
-pip install "evaluatorq[simulation]"   # agent simulation
-pip install "evaluatorq[redteam]"      # red teaming
+uv add "evaluatorq"               # core evaluations
+uv add "evaluatorq[simulation]"   # agent simulation
+uv add "evaluatorq[redteam]"      # red teaming
 ```
+
+Run your scripts with `uv run my_eval.py` and the CLI with `uv run eq`, so the
+environment you installed into is the one that executes.
 
 ### Do I need an Orq account or an OpenAI key?
 

--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -12,7 +12,7 @@ transcripts by hand. Three LLMs are in play:
     Requires the simulation extra and an `ORQ_API_KEY`:
 
     ```bash
-    pip install "evaluatorq[simulation]"
+    uv add "evaluatorq[simulation]"
     export ORQ_API_KEY=...
     ```
 
@@ -21,7 +21,7 @@ transcripts by hand. Three LLMs are in play:
     Requires the simulation extra, the `openai` package, and an `OPENAI_API_KEY`:
 
     ```bash
-    pip install "evaluatorq[simulation]" openai
+    uv add "evaluatorq[simulation]" openai
     export OPENAI_API_KEY=sk-...
     ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -6,8 +6,12 @@ data and a local scorer.
 ## Install
 
 ```bash
-pip install evaluatorq
+uv add evaluatorq
 ```
+
+Prefer pip? Use `python -m pip install evaluatorq`, which installs into the
+interpreter you just named rather than whichever `pip` happens to be first on
+your `PATH`.
 
 ## The mental model
 
@@ -69,7 +73,7 @@ if __name__ == "__main__":
 Run it:
 
 ```bash
-python simple_local_eval.py
+uv run simple_local_eval.py
 ```
 
 `print_results=True` renders a pass/fail table in the terminal. In this

--- a/docs/guides/red-teaming.md
+++ b/docs/guides/red-teaming.md
@@ -43,7 +43,7 @@ report = await red_team(target, mode="static", dataset="hf:my-org/my-attacks")
     platform — no model wiring on your side.
 
     ```bash
-    pip install "evaluatorq[redteam]"
+    uv add "evaluatorq[redteam]"
     export ORQ_API_KEY=...   # targets your Orq agent + routes the attacker LLM
     ```
 
@@ -78,7 +78,7 @@ report = await red_team(target, mode="static", dataset="hf:my-org/my-attacks")
     OpenAI using `OPENAI_API_KEY`.
 
     ```bash
-    pip install "evaluatorq[redteam]"
+    uv add "evaluatorq[redteam]"
     export OPENAI_API_KEY=sk-...   # the target model + the attacker LLM
     ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,19 @@ in Python — against any agent, with the Orq AI platform as optional infrastruc
 <!-- termynal -->
 
 ```console
-$ pip install evaluatorq
+$ uv add evaluatorq
 ---> 100%
 Successfully installed evaluatorq
 ```
 
+Run your code with `uv run my_eval.py` and the CLI with `uv run eq`, so the
+environment you installed into is the one that executes. Using pip instead,
+call it as `python -m pip install evaluatorq` to pin it to the same interpreter
+you run with.
+
 !!! tip "Optional extras"
-    `pip install "evaluatorq[redteam]"` adds adversarial red teaming ·
-    `pip install "evaluatorq[simulation]"` adds multi-turn agent simulation.
+    `uv add "evaluatorq[redteam]"` adds adversarial red teaming ·
+    `uv add "evaluatorq[simulation]"` adds multi-turn agent simulation.
 
 ## What it does
 

--- a/docs/orq-deployment.md
+++ b/docs/orq-deployment.md
@@ -21,7 +21,7 @@ the lifetime of the process.
 
 | Requirement | Detail |
 |---|---|
-| Package | `orq-ai-sdk>=4.4.7` — install directly with `pip install orq-ai-sdk` or via `pip install evaluatorq[orq]` |
+| Package | `orq-ai-sdk>=4.4.7` — install directly with `uv add orq-ai-sdk` or via `uv add "evaluatorq[orq]"` |
 | `ORQ_API_KEY` | Required. Set in the environment (the library does not auto-load `.env`; call `load_dotenv()` yourself first — see configuration.md). |
 | `ORQ_BASE_URL` | Optional. Defaults to `https://my.orq.ai`. Override for self-hosted or staging. |
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -25,11 +25,11 @@ even when the above variables are present.
 Tracing depends on optional packages that are not installed by default:
 
 ```bash
-pip install opentelemetry-api opentelemetry-sdk \
+uv add opentelemetry-api opentelemetry-sdk \
     opentelemetry-exporter-otlp-proto-http \
     opentelemetry-semantic-conventions
 # or via the extras bundle:
-pip install "evaluatorq[otel]"
+uv add "evaluatorq[otel]"
 ```
 
 If these packages are absent the SDK silently skips initialisation — no error is

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -156,7 +156,7 @@ Or pass a custom client: `red_team(..., llm_client=AsyncOpenAI(api_key="sk-...")
 
 ## External agent frameworks
 
-Agents built with external frameworks are wrapped into a target the pipeline can attack. Install the matching extra (`pip install evaluatorq[langgraph]`, `evaluatorq[openai-agents]`, or `evaluatorq[all]`).
+Agents built with external frameworks are wrapped into a target the pipeline can attack. Install the matching extra (`uv add "evaluatorq[langgraph]"`, `"evaluatorq[openai-agents]"`, or `"evaluatorq[all]"`).
 
 ### LangGraph
 
@@ -215,10 +215,14 @@ Sync functions are run in a thread automatically. If the callable holds state, p
 `eq redteam` exposes the same capability. It accepts `agent:` / `deployment:` targets only — for an OpenAI model use `OpenAIModelTarget` in the Python API.
 
 ```bash
-uv tool install "evaluatorq[redteam]"
-eq redteam run -t "agent:my-agent-key" -c LLM01 -c LLM07 --max-turns 2 -y
-eq redteam run --help   # all options
+uv add "evaluatorq[redteam]"
+uv run eq redteam run -t "agent:my-agent-key" -c LLM01 -c LLM07 --max-turns 2 -y
+uv run eq redteam run --help   # all options
 ```
+
+`uv run evaluatorq` is the same entry point under its long name. Avoid
+`uv tool install` here: it builds an isolated environment that exposes the CLI
+but leaves `evaluatorq` unimportable from your own scripts.
 
 For the full flag reference (multi-target, report export, `eq redteam runs`, etc.), see [`examples/redteam/README.md`](../../../examples/redteam/README.md#cli-reference).
 

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -207,10 +207,14 @@ The same capability is exposed as `eq sim run` / `eq sim generate`. Install and
 usage:
 
 ```bash
-uv tool install "evaluatorq[simulation]"
-eq sim run --help
-eq sim generate --help
+uv add "evaluatorq[simulation]"
+uv run eq sim run --help
+uv run eq sim generate --help
 ```
+
+`uv run evaluatorq` is the same entry point under its long name. Avoid
+`uv tool install` here: it builds an isolated environment that exposes the CLI
+but leaves `evaluatorq` unimportable from your own scripts.
 
 Examples:
 


### PR DESCRIPTION
## Why

A client spent an evening on this error:

```
ImportError: Red teaming requires optional dependencies: openai, typer.
Install with: pip install 'evaluatorq[redteam]'
```

They installed `openai` and `typer` repeatedly and it never helped. Their pip resolved to `/usr/local/lib/python3.13/site-packages` while `python3` loaded evaluatorq from `/workspace/.../.venv/`. Every install succeeded, just not into the interpreter running the script. #117 fixed the error message to name `sys.executable`; this PR fixes the instructions that led them there.

Two gaps in the docs made it easy to land in that state:

1. Every install line was a bare `pip install evaluatorq` — the form most likely to target the wrong environment, especially as root in a container.
2. **No page said how to run your code afterwards.** Every guide stopped at install and went straight to a Python snippet. The interpreter question was never addressed, so nothing here would have caught their setup.

## Change

`uv add` for installs, `uv run` for execution:

```bash
uv add evaluatorq
uv run my_eval.py
uv run eq --help          # `uv run evaluatorq` works too
```

`uv run` resolves the project environment before executing, so what you installed and what you run cannot drift apart. Where pip is kept as the alternative it is now `python -m pip install`, which installs into the interpreter you just named rather than whichever `pip` wins the `PATH` race.

Applied across README, index, faq, getting-started, red-teaming, agent-simulation, dashboard, tracing, orq-deployment, and custom-evaluators (the last switched to `uv sync --all-extras --all-groups`, matching CLAUDE.md).

## The `uv tool install` trap

`src/evaluatorq/redteam/README.md` and `simulation/README.md` both said:

```bash
uv tool install "evaluatorq[redteam]"
```

`uv tool` builds an isolated environment exposing only the entry points. You get the `eq` CLI, but `evaluatorq` is **not importable** from your own code. Anyone following that line and then writing `from evaluatorq.redteam import red_team` — which is the very next section — hits the client's exact ImportError, from an instruction we wrote. Both now use `uv add` + `uv run eq`, with a note explaining why not to reach for `uv tool` here.

## Not changed

The ~40 bare `eq ...` example invocations in the guides. Those sit in sections where the reader has already installed and activated; prefixing each with `uv run` would be noise. The install and CLI-entry sections are where the interpreter question actually gets decided, and those now answer it.

## Verification

- `uv run --group docs mkdocs build --strict` → clean
- `uv run python scripts/validate_mermaid.py` → 27 files OK
- No bare `pip install` left in any user-facing doc (remaining hits are the deliberate `python -m pip` fallbacks and the `uv tool install` warning text)

Docs-only, so no release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)