### PR TITLE
docs: finish the uv sweep across runtime messages, examples, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The library is deliberately lightweight: async-first, typed end-to-end, and usab
 uv add evaluatorq
 ```
 
+`uv add` installs into the current project. If you don't have one yet, `uv init`
+creates it (or `uv venv` for a bare virtualenv) — otherwise uv will tell you no
+`pyproject.toml` was found.
+
 Then run your evaluation and the CLI through the same project environment:
 
 ```bash
@@ -83,7 +87,7 @@ Poetry (`poetry add evaluatorq`, `poetry run python my_eval.py`) works the same 
 If you want to use the Orq platform integration:
 
 ```bash
-uv add "evaluatorq[orq]"
+uv add "evaluatorq[orq]"          # or the SDK on its own: uv add orq-ai-sdk
 ```
 
 For OpenTelemetry tracing (optional):
@@ -95,8 +99,10 @@ uv add "evaluatorq[otel]"
 For LangChain/LangGraph integration:
 
 ```bash
-uv add "evaluatorq[langchain]"
+uv add "evaluatorq[langchain]"    # or bring your own: uv add langchain langgraph
 ```
+
+Each extra works with pip too — `python -m pip install "evaluatorq[orq]"`.
 
 ## 🏁 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ The library is deliberately lightweight: async-first, typed end-to-end, and usab
 uv add evaluatorq
 ```
 
-`uv add` installs into the current project. If you don't have one yet, `uv init`
-creates it (or `uv venv` for a bare virtualenv) — otherwise uv will tell you no
-`pyproject.toml` was found.
+`uv add` installs into the current project. If you don't have a project, use
+`uv pip install evaluatorq` in an existing virtual environment instead.
 
 Then run your evaluation and the CLI through the same project environment:
 

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -5,8 +5,8 @@ This guide explains how to add custom evaluators, vulnerabilities, attack strate
 !!! note "Requires editing the package source"
     The extension points below modify evaluatorq's internal registries directly —
     they are not a stable runtime API. Clone the repo and sync the dev
-    environment (`uv sync --all-extras --all-groups`), then make your changes there. A runtime
-    registration API is planned; see the [Roadmap](roadmap.md).
+    environment (`uv sync --all-extras --all-groups`), then make your changes
+    there. A runtime registration API is planned; see the [Roadmap](roadmap.md).
 
 ## Architecture overview
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -27,6 +27,10 @@ uv add "evaluatorq[dashboard]"
 uv add "evaluatorq[redteam,dashboard]"
 ```
 
+Prefer pip? Use `python -m pip install "evaluatorq[dashboard]"`, which installs
+into the interpreter you just named rather than whichever `pip` happens to be
+first on your `PATH`.
+
 ## Launch
 
 Launch it with `eq dashboard` (the `evaluatorq` and `eq` entry points are

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,8 +29,38 @@ uv add "evaluatorq[simulation]"   # agent simulation
 uv add "evaluatorq[redteam]"      # red teaming
 ```
 
-Run your scripts with `uv run my_eval.py` and the CLI with `uv run eq`, so the
-environment you installed into is the one that executes.
+`uv add` installs into the current project — run `uv init` first if you don't
+have one. Run your scripts with `uv run my_eval.py` and the CLI with
+`uv run eq`, so the environment you installed into is the one that executes.
+
+Prefer pip? Use `python -m pip install "evaluatorq[redteam]"`, which installs
+into the interpreter you just named rather than whichever `pip` happens to be
+first on your `PATH`.
+
+### I installed evaluatorq but `import evaluatorq` fails
+
+The install went to a different interpreter than the one running your script.
+This is the single most common setup failure, and it has nothing to do with
+evaluatorq — bare `pip` and bare `python` can resolve to different environments
+(a system Python, a virtualenv you forgot to activate, a container's global
+site-packages).
+
+Confirm it by asking both sides where they live:
+
+```bash
+python -c "import sys; print(sys.executable)"   # which interpreter runs
+python -m pip show -f evaluatorq | head -3      # where the package landed
+```
+
+If the paths don't share a prefix, that's the bug. Two fixes:
+
+- **uv** — `uv add evaluatorq` then `uv run my_eval.py`. `uv run` resolves the
+  project environment before executing, so the two can't drift.
+- **pip** — always name the interpreter: `python -m pip install evaluatorq`,
+  and run with the same `python`.
+
+Avoid `uv tool install evaluatorq`: it builds an isolated environment that
+exposes the `eq` CLI but leaves `evaluatorq` unimportable from your own scripts.
 
 ### Do I need an Orq account or an OpenAI key?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,6 @@
 # FAQ
 
-Common questions, grouped by area — **General** (install, keys, privacy,
-running evaluations), **Red Teaming**, and **Agent Simulation**.
+Common questions, grouped by area — **General** (install, keys, privacy, running evaluations), **Red Teaming**, and **Agent Simulation**.
 
 ## General
 
@@ -9,15 +8,11 @@ running evaluations), **Red Teaming**, and **Agent Simulation**.
 
 A Python library for testing LLM apps and agents, with three modes:
 
-- **Evaluations** — run jobs over your data in parallel and score them with
-  built-in or custom evaluators; gate CI on pass/fail.
-- **Agent simulation** — a user-simulator LLM drives your agent through
-  multi-turn conversations while a judge scores whether it met its goals.
-- **Red teaming** — adaptive adversarial attacks mapped to the OWASP LLM Top 10
-  and Agentic Security Initiative.
+- **Evaluations** — run jobs over your data in parallel and score them with built-in or custom evaluators; gate CI on pass/fail.
+- **Agent simulation** — a user-simulator LLM drives your agent through multi-turn conversations while a judge scores whether it met its goals.
+- **Red teaming** — adaptive adversarial attacks mapped to the OWASP LLM Top 10 and Agentic Security Initiative.
 
-The Orq platform is optional — it stores results and routes LLMs when
-`ORQ_API_KEY` is set, but you can run entirely on OpenAI.
+The Orq platform is optional — it stores results and routes LLMs when `ORQ_API_KEY` is set, but you can run entirely on OpenAI.
 
 ### What do I install?
 
@@ -53,18 +48,11 @@ Avoid `uv tool install evaluatorq`: it builds an isolated environment that expos
 
 ### Do I need an Orq account or an OpenAI key?
 
-You need an LLM key wherever a simulator, attacker, or judge LLM runs —
-`OPENAI_API_KEY` for direct OpenAI, or `ORQ_API_KEY` to route through the Orq
-router. Plain evaluations with only deterministic evaluators need no key; any
-LLM-judged flow (jury, simulation, red teaming) does — including red teaming's
-**static mode**, where the target replays fixed attacks but the judge still
-scores each outcome with an LLM.
+You need an LLM key wherever a simulator, attacker, or judge LLM runs — `OPENAI_API_KEY` for direct OpenAI, or `ORQ_API_KEY` to route through the Orq router. Plain evaluations with only deterministic evaluators need no key; any LLM-judged flow (jury, simulation, red teaming) does — including red teaming's **static mode**, where the target replays fixed attacks but the judge still scores each outcome with an LLM.
 
 ### Which models run the simulator / attacker / judge — can I change them?
 
-They default to an LLM routed via `OPENAI_API_KEY` or `ORQ_API_KEY`. Override
-per surface: red teaming takes `llm_config=LLMConfig(attacker=..., evaluator=...)`,
-and simulation takes `sim_model=` for the simulator and judge.
+They default to an LLM routed via `OPENAI_API_KEY` or `ORQ_API_KEY`. Override per surface: red teaming takes `llm_config=LLMConfig(attacker=..., evaluator=...)`, and simulation takes `sim_model=` for the simulator and judge.
 
 ```python
 from evaluatorq.redteam import LLMConfig, LLMCallConfig
@@ -80,34 +68,19 @@ report = await red_team(
 
 ### What leaves my machine?
 
-Simulator/attacker/judge LLM calls go to OpenAI or the Orq router. Results upload
-to the Orq platform **only if `ORQ_API_KEY` is set.** With no key, everything
-stays local. Setting `ORQ_API_KEY` also enables OpenTelemetry tracing to
-`my.orq.ai`; suppress it with `ORQ_DISABLE_TRACING=1`, or keep tracing but strip
-prompt/response text from spans with `EVALUATORQ_CAPTURE_MESSAGE_CONTENT=false`.
-See [Configuration](configuration.md).
+Simulator/attacker/judge LLM calls go to OpenAI or the Orq router. Results upload to the Orq platform **only if `ORQ_API_KEY` is set.** With no key, everything stays local. Setting `ORQ_API_KEY` also enables OpenTelemetry tracing to `my.orq.ai`; suppress it with `ORQ_DISABLE_TRACING=1`, or keep tracing but strip prompt/response text from spans with `EVALUATORQ_CAPTURE_MESSAGE_CONTENT=false`. See [Configuration](configuration.md).
 
 ### How much does a run cost, and how do I keep it cheap?
 
-Cost and wall-clock scale with cases × turns × LLM calls. The levers are how many
-cases you run (`max_dynamic_datapoints` / `max_static_datapoints` for red
-teaming, `num_personas` × `num_scenarios` for simulation), `max_turns`, and
-`parallelism` (default 10 — lower it if your provider rate-limits). Red teaming's
-report tracks spend in `report.summary.token_usage_total`.
+Cost and wall-clock scale with cases × turns × LLM calls. The levers are how many cases you run (`max_dynamic_datapoints` / `max_static_datapoints` for red teaming, `num_personas` × `num_scenarios` for simulation), `max_turns`, and `parallelism` (default 10 — lower it if your provider rate-limits). Red teaming's report tracks spend in `report.summary.token_usage_total`.
 
 ### Where do results go, and how do I view a past run?
 
-Runs auto-save locally (red-team runs to `.evaluatorq/runs/`; simulation runs to
-`.evaluatorq/sim-runs/`). Browse them in the multi-run FastHTML dashboard with
-`eq dashboard` (no path browses both stores; `eq dashboard .evaluatorq/sim-runs`
-scopes to simulation), or list runs with `eq redteam runs` / `eq sim runs`. The
-legacy `eq redteam ui` / `eq sim ui` Streamlit views remain callable but are
-deprecated. See [Dashboard](dashboard.md).
+Runs auto-save locally (red-team runs to `.evaluatorq/runs/`; simulation runs to `.evaluatorq/sim-runs/`). Browse them in the multi-run FastHTML dashboard with `eq dashboard` (no path browses both stores; `eq dashboard .evaluatorq/sim-runs` scopes to simulation), or list runs with `eq redteam runs` / `eq sim runs`. The legacy `eq redteam ui` / `eq sim ui` Streamlit views remain callable but are deprecated. See [Dashboard](dashboard.md).
 
 ### How do I run a plain evaluation?
 
-Decorate a function with `@job`, hand `evaluatorq()` your data and evaluators,
-and it runs the jobs in parallel and scores each row:
+Decorate a function with `@job`, hand `evaluatorq()` your data and evaluators, and it runs the jobs in parallel and scores each row:
 
 ```python
 from evaluatorq import DataPoint, evaluatorq, job, string_contains_evaluator
@@ -131,100 +104,62 @@ See [Getting Started](guides/getting-started.md).
 
 ### What evaluators are built in, and can I write my own?
 
-There are deterministic ones (string match, JSON, regex) and LLM-judge ones. For
-custom logic, write a function that scores a row — see
-[Custom Evaluators & Frameworks](custom-evaluators-and-frameworks.md). For higher
-confidence, score one response with a **panel** of judges
-([LLM as a Jury](llm-as-a-jury.md)) or compare two responses head-to-head
-([Pairwise Judging](pairwise-judging.md)).
+There are deterministic ones (string match, JSON, regex) and LLM-judge ones. For custom logic, write a function that scores a row — see [Custom Evaluators & Frameworks](custom-evaluators-and-frameworks.md). For higher confidence, score one response with a **panel** of judges ([LLM as a Jury](llm-as-a-jury.md)) or compare two responses head-to-head ([Pairwise Judging](pairwise-judging.md)).
 
 ## Red Teaming
 
 ### How do I know my agent is safe?
 
-You don't, until you attack it. Shipping after a refused *"say something
-harmful"* is a vibe check, not a test. It only proves the agent refuses the
-one obvious prompt you thought to try. Red teaming runs a mapped set of
-adversarial attacks and reports a **resistance rate** (the fraction the agent
-withstood), so "safe" becomes a number you can gate on. See
-[Red Teaming](guides/red-teaming.md).
+You don't, until you attack it. Shipping after a refused *"say something harmful"* is a vibe check, not a test. It only proves the agent refuses the one obvious prompt you thought to try. Red teaming runs a mapped set of adversarial attacks and reports a **resistance rate** (the fraction the agent withstood), so "safe" becomes a number you can gate on. See [Red Teaming](guides/red-teaming.md).
 
 ### Isn't a single-turn "refused → safe" check enough?
 
 No. The attacks that land are the ones a single prompt can't express:
 
-- **Multi-turn escalation** — each message looks benign; the attack assembles
-  across turns. Invisible to single-turn evals.
-- **Indirect injection** — the attacker controls what the agent *reads* (emails,
-  docs, tool results), not what you type. You never see the payload.
+- **Multi-turn escalation** — each message looks benign; the attack assembles across turns. Invisible to single-turn evals.
+- **Indirect injection** — the attacker controls what the agent *reads* (emails, docs, tool results), not what you type. You never see the payload.
 - **Memory poisoning** — a planted instruction fires on a later, unrelated run.
 - **Many-shot jailbreaking** — 100+ in-context examples steer behaviour.
 
-Red teaming generates multi-turn attacks by default (`max_turns=`) precisely so
-these surface.
+Red teaming generates multi-turn attacks by default (`max_turns=`) precisely so these surface.
 
 ### What does red teaming actually test?
 
 Attacks and LLM-judge evaluators mapped to three frameworks:
 
 - **OWASP LLM Top 10** — prompt injection, system-prompt leakage, and the rest.
-- **OWASP Agentic Security Initiative (ASI)** — agent-specific risks: tool
-  abuse, excessive agency, trust exploitation.
-- **Responsible AI** — fairness/bias, liability (legal, medical), content
-  policy, harmful content.
+- **OWASP Agentic Security Initiative (ASI)** — agent-specific risks: tool abuse, excessive agency, trust exploitation.
+- **Responsible AI** — fairness/bias, liability (legal, medical), content policy, harmful content.
 
-Pass the ones you care about via `categories=["LLM01", "ASI01", ...]`. The full
-list of codes is in the [redteam API reference](reference/evaluatorq/redteam.md).
+Pass the ones you care about via `categories=["LLM01", "ASI01", ...]`. The full list of codes is in the [redteam API reference](reference/evaluatorq/redteam.md).
 
 ### Static, dynamic, or hybrid — which mode?
 
-- **static** — replays a fixed dataset of known attacks. Deterministic and
-  cheap; run it in CI. Defaults to Orq's public
-  [`orq/redteam-vulnerabilities`](https://huggingface.co/datasets/orq/redteam-vulnerabilities)
-  set, or pass your own with `dataset=`.
-- **dynamic** — an LLM generates attacks tailored to *your* agent's tools and
-  prompt.
+- **static** — replays a fixed dataset of known attacks. Deterministic and cheap; run it in CI. Defaults to Orq's public [`orq/redteam-vulnerabilities`](https://huggingface.co/datasets/orq/redteam-vulnerabilities) set, or pass your own with `dataset=`.
+- **dynamic** — an LLM generates attacks tailored to *your* agent's tools and prompt.
 - **hybrid** — static seeds plus dynamic expansion, in one pass.
 
 Details in [Red Teaming › Modes](guides/red-teaming.md#modes).
 
 ### How does it decide what to attack?
 
-Probe → attack → judge. It first inspects the target (tools, permissions, system
-prompt) to build a capability profile, generates attacks against the exposed
-surface, then scores each outcome against per-vulnerability LLM-judge rubrics.
-Filtering out attacks that can't apply keeps a run focused on real exposure.
+Probe → attack → judge. It first inspects the target (tools, permissions, system prompt) to build a capability profile, generates attacks against the exposed surface, then scores each outcome against per-vulnerability LLM-judge rubrics. Filtering out attacks that can't apply keeps a run focused on real exposure.
 
 ### Why an LLM judge instead of keyword matching?
 
-Because the surface text lies. *"I see malicious instructions in this email but I
-won't follow them"* and *"I'll forward that email right away"* both mention
-instructions, yet one is resistant, one is vulnerable. A regex can't tell them
-apart; a judge rubric can. Write your own in
-[Custom Evaluators & Frameworks](custom-evaluators-and-frameworks.md).
+Because the surface text lies. *"I see malicious instructions in this email but I won't follow them"* and *"I'll forward that email right away"* both mention instructions, yet one is resistant, one is vulnerable. A regex can't tell them apart; a judge rubric can. Write your own in [Custom Evaluators & Frameworks](custom-evaluators-and-frameworks.md).
 
 ### How do I trust the judge itself?
 
-Calibrate it against known baselines: run the same attack set through an agent
-that *should* pass and one that *should* fail. If the safe agent gets flagged
-vulnerable you have false positives; if the weak agent is marked resistant you
-have blind spots. Either way, patch the rubric and rerun. Matched pairs (same
-attacks, both agents) make the miscalibration visible.
+Calibrate it against known baselines: run the same attack set through an agent that *should* pass and one that *should* fail. If the safe agent gets flagged vulnerable you have false positives; if the weak agent is marked resistant you have blind spots. Either way, patch the rubric and rerun. Matched pairs (same attacks, both agents) make the miscalibration visible.
 
 ### Isn't "vulnerable" context-dependent?
 
-Yes, and the evaluators account for it. Fetching a shell script from GitHub is
-helpful in a coding assistant and an RCE vector in a support bot; chaining three
-API calls unprompted is doing the job or excessive agency depending on the
-agent. Judges see the agent's declared context, so the same action can score
-differently across agents.
+Yes, and the evaluators account for it. Fetching a shell script from GitHub is helpful in a coding assistant and an RCE vector in a support bot; chaining three API calls unprompted is doing the job or excessive agency depending on the agent. Judges see the agent's declared context, so the same action can score differently across agents.
 
 ### How do I run it against my own agent?
 
-Subclass `AgentTarget` and implement two methods: `respond(messages)` (return an
-`AgentResponse`) and `new()` (return a fresh instance for each attack). Any
-framework works behind those two methods (LangChain, LangGraph, the OpenAI
-Agents SDK, or a plain loop), so there's no framework buy-in:
+Subclass `AgentTarget` and implement two methods: `respond(messages)` (return an `AgentResponse`) and `new()` (return a fresh instance for each attack). Any framework works behind those two methods (LangChain, LangGraph, the OpenAI Agents SDK, or a plain loop), so there's no framework buy-in:
 
 ```python
 from evaluatorq.contracts import AgentTarget, AgentResponse, Message
@@ -244,49 +179,29 @@ report = await red_team(target=MyAgent(), mode="dynamic", max_turns=4)
 print(f"resistance: {report.summary.resistance_rate:.0%}")
 ```
 
-Or point it at an Orq agent by key (`"agent:<key>"`), or drive it from the CLI
-with `eq redteam run --target agent:<key>`. See
-[Red Teaming › Red-team your target](guides/red-teaming.md#red-team-your-target)
-and [`examples/redteam/15_tool_chaining.py`](examples/redteam/15_tool_chaining.md)
-for a full custom target.
+Or point it at an Orq agent by key (`"agent:<key>"`), or drive it from the CLI with `eq redteam run --target agent:<key>`. See [Red Teaming › Red-team your target](guides/red-teaming.md#red-team-your-target) and [`examples/redteam/15_tool_chaining.py`](examples/redteam/15_tool_chaining.md) for a full custom target.
 
 ### If I red-team my real agent, will the attacks actually fire its tools?
 
-Yes. The target runs its own tools, so a successful attack triggers real side
-effects (sends the email, moves the money, runs the shell command). Point red
-teaming at a **sandboxed or test instance** with fake/stubbed tools — like the
-demo's fake wallets — not at production credentials wired to irreversible
-actions.
+Yes. The target runs its own tools, so a successful attack triggers real side effects (sends the email, moves the money, runs the shell command). Point red teaming at a **sandboxed or test instance** with fake/stubbed tools — like the demo's fake wallets — not at production credentials wired to irreversible actions.
 
 ### The report says my agent is vulnerable — what do I change?
 
-Usually the system prompt. The load-bearing fixes are an explicit instruction
-hierarchy (data the agent *reads* is never a command), a confirmation gate
-before risky tools, and refusing authority claims — then rerun and watch the
-resistance rate climb. Pass `generate_recommendations=True` to have the run
-attach LLM-generated focus-area recommendations to the report.
+Usually the system prompt. The load-bearing fixes are an explicit instruction hierarchy (data the agent *reads* is never a command), a confirmation gate before risky tools, and refusing authority claims — then rerun and watch the resistance rate climb. Pass `generate_recommendations=True` to have the run attach LLM-generated focus-area recommendations to the report.
 
 ### What does `passed=True` mean?
 
-The agent **resisted** the attack (the attack failed). `passed=False` means the
-attack succeeded: the agent is **vulnerable**. `resistance_rate` is the fraction
-of attacks that came back `passed=True`.
+The agent **resisted** the attack (the attack failed). `passed=False` means the attack succeeded: the agent is **vulnerable**. `resistance_rate` is the fraction of attacks that came back `passed=True`.
 
 ## Agent Simulation
 
 ### What is agent simulation, and how is it different from red teaming?
 
-Both drive your agent across multi-turn conversations, but with opposite intent.
-Simulation plays a **cooperative** user (a persona pursuing a realistic goal) and
-asks *"did the agent do its job?"*; red teaming plays an **adversary** and asks
-*"can the agent be broken?"* Three LLMs are in play for simulation: your agent, a
-user-simulator, and a judge that scores `goal_achieved` / `criteria_met`.
+Both drive your agent across multi-turn conversations, but with opposite intent. Simulation plays a **cooperative** user (a persona pursuing a realistic goal) and asks *"did the agent do its job?"*; red teaming plays an **adversary** and asks *"can the agent be broken?"* Three LLMs are in play for simulation: your agent, a user-simulator, and a judge that scores `goal_achieved` / `criteria_met`.
 
 ### How do I simulate multi-turn conversations?
 
-`generate_and_simulate()` is the fastest start: it synthesizes personas,
-scenarios, and opening messages from a one-line description of your agent, no
-hand-written transcripts:
+`generate_and_simulate()` is the fastest start: it synthesizes personas, scenarios, and opening messages from a one-line description of your agent, no hand-written transcripts:
 
 ```python
 from evaluatorq.simulation import generate_and_simulate
@@ -307,15 +222,8 @@ See [Agent Simulation](guides/agent-simulation.md).
 
 ### Where do the personas and scenarios come from?
 
-Your choice of control: generate them from a one-line description, seed by
-archetype, hand-build `Persona(...)` / `Scenario(...)` for full control, or
-ground new cases in your **real production traces** so they mirror how users
-actually behave. You can also replay stored datapoints to re-run the exact same
-cases against any target. See
-[Agent Simulation](guides/agent-simulation.md#from-existing-traces-and-data).
+Your choice of control: generate them from a one-line description, seed by archetype, hand-build `Persona(...)` / `Scenario(...)` for full control, or ground new cases in your **real production traces** so they mirror how users actually behave. You can also replay stored datapoints to re-run the exact same cases against any target. See [Agent Simulation](guides/agent-simulation.md#from-existing-traces-and-data).
 
 ### Which agent frameworks does simulation work with?
 
-LangGraph, the OpenAI Agents SDK, Pydantic AI, CrewAI, a plain async callback
-(passed as `target=`), or a hosted Orq agent (`target="agent:<key>"`) — see the
-[framework demos](guides/agent-simulation.md#external-framework-demos).
+LangGraph, the OpenAI Agents SDK, Pydantic AI, CrewAI, a plain async callback (passed as `target=`), or a hosted Orq agent (`target="agent:<key>"`) — see the [framework demos](guides/agent-simulation.md#external-framework-demos).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,21 +29,13 @@ uv add "evaluatorq[simulation]"   # agent simulation
 uv add "evaluatorq[redteam]"      # red teaming
 ```
 
-`uv add` installs into the current project — run `uv init` first if you don't
-have one. Run your scripts with `uv run my_eval.py` and the CLI with
-`uv run eq`, so the environment you installed into is the one that executes.
+`uv add` installs into the current project — run `uv init` first if you don't have one. Run your scripts with `uv run my_eval.py` and the CLI with `uv run eq`, so the environment you installed into is the one that executes.
 
-Prefer pip? Use `python -m pip install "evaluatorq[redteam]"`, which installs
-into the interpreter you just named rather than whichever `pip` happens to be
-first on your `PATH`.
+Prefer pip? Use `python -m pip install "evaluatorq[redteam]"`, which installs into the interpreter you just named rather than whichever `pip` happens to be first on your `PATH`.
 
 ### I installed evaluatorq but `import evaluatorq` fails
 
-The install went to a different interpreter than the one running your script.
-This is the single most common setup failure, and it has nothing to do with
-evaluatorq — bare `pip` and bare `python` can resolve to different environments
-(a system Python, a virtualenv you forgot to activate, a container's global
-site-packages).
+The install went to a different interpreter than the one running your script. This is the single most common setup failure, and it has nothing to do with evaluatorq — bare `pip` and bare `python` can resolve to different environments (a system Python, a virtualenv you forgot to activate, a container's global site-packages).
 
 Confirm it by asking both sides where they live:
 
@@ -54,13 +46,10 @@ python -m pip show -f evaluatorq | head -3      # where the package landed
 
 If the paths don't share a prefix, that's the bug. Two fixes:
 
-- **uv** — `uv add evaluatorq` then `uv run my_eval.py`. `uv run` resolves the
-  project environment before executing, so the two can't drift.
-- **pip** — always name the interpreter: `python -m pip install evaluatorq`,
-  and run with the same `python`.
+- **uv** — `uv add evaluatorq` then `uv run my_eval.py`. `uv run` resolves the project environment before executing, so the two can't drift.
+- **pip** — always name the interpreter: `python -m pip install evaluatorq`, and run with the same `python`.
 
-Avoid `uv tool install evaluatorq`: it builds an isolated environment that
-exposes the `eq` CLI but leaves `evaluatorq` unimportable from your own scripts.
+Avoid `uv tool install evaluatorq`: it builds an isolated environment that exposes the `eq` CLI but leaves `evaluatorq` unimportable from your own scripts.
 
 ### Do I need an Orq account or an OpenAI key?
 

--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -16,6 +16,10 @@ transcripts by hand. Three LLMs are in play:
     export ORQ_API_KEY=...
     ```
 
+    Prefer pip? Use `python -m pip install "evaluatorq[simulation]"`, which
+    installs into the interpreter you just named rather than whichever `pip`
+    happens to be first on your `PATH`.
+
 === "OpenAI"
 
     Requires the simulation extra, the `openai` package, and an `OPENAI_API_KEY`:
@@ -24,6 +28,10 @@ transcripts by hand. Three LLMs are in play:
     uv add "evaluatorq[simulation]" openai
     export OPENAI_API_KEY=sk-...
     ```
+
+    Prefer pip? Use `python -m pip install "evaluatorq[simulation]" openai`,
+    which installs into the interpreter you just named rather than whichever
+    `pip` happens to be first on your `PATH`.
 
 ```mermaid
 sequenceDiagram

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -6,6 +6,7 @@ data and a local scorer.
 ## Install
 
 ```bash
+uv init my-evals && cd my-evals   # skip if you already have a uv project
 uv add evaluatorq
 ```
 

--- a/docs/guides/red-teaming.md
+++ b/docs/guides/red-teaming.md
@@ -47,6 +47,10 @@ report = await red_team(target, mode="static", dataset="hf:my-org/my-attacks")
     export ORQ_API_KEY=...   # targets your Orq agent + routes the attacker LLM
     ```
 
+    Prefer pip? Use `python -m pip install "evaluatorq[redteam]"`, which installs
+    into the interpreter you just named rather than whichever `pip` happens to be
+    first on your `PATH`.
+
     ```python
     import asyncio
 
@@ -81,6 +85,10 @@ report = await red_team(target, mode="static", dataset="hf:my-org/my-attacks")
     uv add "evaluatorq[redteam]"
     export OPENAI_API_KEY=sk-...   # the target model + the attacker LLM
     ```
+
+    Prefer pip? Use `python -m pip install "evaluatorq[redteam]"`, which installs
+    into the interpreter you just named rather than whichever `pip` happens to be
+    first on your `PATH`.
 
     ```python
     import asyncio

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,11 @@ $ uv add evaluatorq
 Successfully installed evaluatorq
 ```
 
-Run your code with `uv run my_eval.py` and the CLI with `uv run eq`, so the
-environment you installed into is the one that executes. Using pip instead,
-call it as `python -m pip install evaluatorq` to pin it to the same interpreter
-you run with.
+`uv add` installs into the current project — run `uv init` first if you don't
+have one. Then run your code with `uv run my_eval.py` and the CLI with
+`uv run eq`, so the environment you installed into is the one that executes.
+Using pip instead, call it as `python -m pip install evaluatorq` to pin it to
+the same interpreter you run with.
 
 !!! tip "Optional extras"
     `uv add "evaluatorq[redteam]"` adds adversarial red teaming ·

--- a/docs/orq-deployment.md
+++ b/docs/orq-deployment.md
@@ -21,7 +21,7 @@ the lifetime of the process.
 
 | Requirement | Detail |
 |---|---|
-| Package | `orq-ai-sdk>=4.4.7` — install directly with `uv add orq-ai-sdk` or via `uv add "evaluatorq[orq]"` |
+| Package | `orq-ai-sdk>=4.4.7` — install directly with `uv add orq-ai-sdk` or via `uv add "evaluatorq[orq]"` (pip: `python -m pip install orq-ai-sdk`) |
 | `ORQ_API_KEY` | Required. Set in the environment (the library does not auto-load `.env`; call `load_dotenv()` yourself first — see configuration.md). |
 | `ORQ_BASE_URL` | Optional. Defaults to `https://my.orq.ai`. Override for self-hosted or staging. |
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -32,6 +32,10 @@ uv add opentelemetry-api opentelemetry-sdk \
 uv add "evaluatorq[otel]"
 ```
 
+Prefer pip? Use `python -m pip install "evaluatorq[otel]"`, which installs into
+the interpreter you just named rather than whichever `pip` happens to be first
+on your `PATH`.
+
 If these packages are absent the SDK silently skips initialisation — no error is
 raised.
 
@@ -64,13 +68,13 @@ asyncio.run(
 To send traces to a custom OTLP endpoint instead:
 
 ```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 python my_eval.py
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 uv run my_eval.py
 ```
 
 To debug tracing setup:
 
 ```bash
-ORQ_DEBUG=1 python my_eval.py
+ORQ_DEBUG=1 uv run my_eval.py
 ```
 
 This prints the resolved endpoint, auth header presence, and any initialisation

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,34 +40,36 @@ examples/lib/
 
 ```bash
 # Basics
-python3 examples/lib/basics/examples.py
-python3 examples/lib/basics/pass_fail_simple.py
+uv run examples/lib/basics/examples.py
+uv run examples/lib/basics/pass_fail_simple.py
 
 # Datasets (requires ORQ_API_KEY)
-ORQ_API_KEY=... python3 examples/lib/datasets/dataset_example.py
+ORQ_API_KEY=... uv run examples/lib/datasets/dataset_example.py
 
 # Structured
-python3 examples/lib/structured/structured_rubric_eval.py
+uv run examples/lib/structured/structured_rubric_eval.py
 
 # Integrations (requires OPENAI_API_KEY)
-ORQ_API_KEY=... OPENAI_API_KEY=... python3 examples/lib/integrations/langchain/langgraph_research_eval.py
-ORQ_API_KEY=... OPENAI_API_KEY=... DATASET_ID=... python3 examples/lib/integrations/langchain/langgraph_dataset_eval.py
+ORQ_API_KEY=... OPENAI_API_KEY=... uv run examples/lib/integrations/langchain/langgraph_research_eval.py
+ORQ_API_KEY=... OPENAI_API_KEY=... DATASET_ID=... uv run examples/lib/integrations/langchain/langgraph_dataset_eval.py
 
 # CLI
-python3 examples/lib/cli/example_using_cli.py
+uv run examples/lib/cli/example_using_cli.py
 ```
 
 ## Prerequisites
 
 ```bash
-pip install evaluatorq python-dotenv
+uv add evaluatorq python-dotenv
 
 # For LLM examples
-pip install anthropic openai
+uv add anthropic openai
 
 # For LangGraph integration
-pip install langchain-openai langgraph
+uv add langchain-openai langgraph
 ```
+
+Not using uv? `python -m pip install evaluatorq python-dotenv` installs into the interpreter you just named.
 
 Set API keys:
 ```bash

--- a/examples/agent_simulation/03_tool_simulation.py
+++ b/examples/agent_simulation/03_tool_simulation.py
@@ -8,7 +8,7 @@ intercepts tool calls and returns configurable mock responses.
 Prerequisites:
     Install the agent-simulation research package (not on PyPI - install from source):
 
-        uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+        uv add "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 
 Usage:
     # from the evaluatorq repository root
@@ -38,7 +38,7 @@ try:
 except ImportError as e:
     raise ImportError(
         'agent-simulation package not found. Install from source:\n'
-        '  uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git'
+        '  uv add "agent-simulation @ git+https://github.com/orq-ai/research.git'
         '#subdirectory=projects/agent-simulation"'
     ) from e
 from evaluatorq.contracts import Message

--- a/examples/agent_simulation/04_hardening_loop.py
+++ b/examples/agent_simulation/04_hardening_loop.py
@@ -21,7 +21,7 @@ agent's instructions to pass them reliably.
 Prerequisites:
     Install the agent-simulation research package (not on PyPI - install from source):
 
-        uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+        uv add "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 
 Usage:
     # from the evaluatorq repository root
@@ -48,7 +48,7 @@ try:
 except ImportError as e:
     raise ImportError(
         'agent-simulation package not found. Install from source:\n'
-        '  uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git'
+        '  uv add "agent-simulation @ git+https://github.com/orq-ai/research.git'
         '#subdirectory=projects/agent-simulation"'
     ) from e
 

--- a/examples/agent_simulation/README.md
+++ b/examples/agent_simulation/README.md
@@ -5,14 +5,16 @@ Python examples for simulating user interactions against AI agents - testing goa
 ## Prerequisites
 
 ```bash
-uv pip install "evaluatorq[simulation]"
+uv add "evaluatorq[simulation]"
 ```
+
+Not using uv? `python -m pip install "evaluatorq[simulation]"` installs into the interpreter you just named.
 
 > **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) are **preview**: they depend on the
 > `agent-simulation` research package, which is not on PyPI and not yet part of the production SDK. Install from source:
 >
 > ```bash
-> uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+> uv add "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 > ```
 >
 > Examples 01, 02, and 05 use only the production evaluatorq SDK and are the recommended starting points.

--- a/examples/redteam/17_langgraph_target.py
+++ b/examples/redteam/17_langgraph_target.py
@@ -9,7 +9,7 @@ The agent's model is pointed at the Orq router with ``ORQ_API_KEY`` — no OpenA
 key needed. The red-team attacker + judge auto-route the same way.
 
 Prerequisites:
-    - pip install "evaluatorq[redteam,langgraph]" langchain-openai
+    - uv add "evaluatorq[redteam,langgraph]" langchain-openai
     - ORQ_API_KEY set (drives the agent's model, the attacker LLM, and the judge)
 
 Usage:

--- a/examples/redteam/18_openai_agents_target.py
+++ b/examples/redteam/18_openai_agents_target.py
@@ -8,7 +8,7 @@ The agent's model runs on the Orq router via a custom ``AsyncOpenAI`` client key
 with ``ORQ_API_KEY`` — no OpenAI key needed. The attacker + judge auto-route too.
 
 Prerequisites:
-    - pip install "evaluatorq[redteam,openai-agents]"
+    - uv add "evaluatorq[redteam,openai-agents]"
     - ORQ_API_KEY set (the agent's model, the attacker LLM, and the judge)
 
 Usage:

--- a/examples/redteam/19_pydantic_ai_target.py
+++ b/examples/redteam/19_pydantic_ai_target.py
@@ -9,7 +9,7 @@ The agent's model runs on the Orq router via an ``OpenAIProvider`` keyed with
 ``ORQ_API_KEY`` — no OpenAI key needed. The attacker + judge auto-route too.
 
 Prerequisites:
-    - pip install "evaluatorq[redteam,pydantic-ai]"
+    - uv add "evaluatorq[redteam,pydantic-ai]"
     - ORQ_API_KEY set (the agent's model, the attacker LLM, and the judge)
 
 Usage:

--- a/examples/redteam/20_crewai_target.py
+++ b/examples/redteam/20_crewai_target.py
@@ -13,7 +13,7 @@ The crew's model runs on the Orq router via ``crewai.LLM`` keyed with
 ``ORQ_API_KEY`` — no OpenAI key needed. The attacker + judge auto-route too.
 
 Prerequisites:
-    - pip install "evaluatorq[redteam,crewai]"   (CrewAI needs Python >= 3.11)
+    - uv add "evaluatorq[redteam,crewai]"   (CrewAI needs Python >= 3.11)
     - ORQ_API_KEY set (the crew's model, the attacker LLM, and the judge)
 
 Usage:

--- a/examples/redteam/README.md
+++ b/examples/redteam/README.md
@@ -5,8 +5,10 @@ Python examples for automated security testing of LLMs and AI agents against OWA
 ## Prerequisites
 
 ```bash
-pip install evaluatorq[redteam]
+uv add "evaluatorq[redteam]"
 ```
+
+Not using uv? `python -m pip install "evaluatorq[redteam]"` installs into the interpreter you just named.
 
 ## Quick Start
 
@@ -15,11 +17,11 @@ Most examples work with just an API key:
 ```bash
 # With OpenAI directly (examples use OpenAIModelTarget in Python)
 export OPENAI_API_KEY="sk-..."
-python 08_quick_smoke_test.py
+uv run 08_quick_smoke_test.py
 
 # With ORQ routing for attack/evaluator LLM calls
 export ORQ_API_KEY="orq-..."
-python 08_quick_smoke_test.py
+uv run 08_quick_smoke_test.py
 ```
 
 If your application is an ORQ platform agent:
@@ -27,7 +29,7 @@ If your application is an ORQ platform agent:
 ```bash
 export ORQ_API_KEY="orq-..."
 # Edit 10_orq_agent.py and replace YOUR_AGENT_KEY
-python 10_orq_agent.py
+uv run 10_orq_agent.py
 ```
 
 ## Credential Routing

--- a/scripts/gen_og_card.py
+++ b/scripts/gen_og_card.py
@@ -3,7 +3,7 @@
 One hand-designed 1200x630 link-unfurl card (Slack / Twitter / OpenGraph) that mirrors
 the orq.ai brand system: a warm off-white ground with the signature soft teal/cyan aurora
 glow, the monochrome Orq mark + "orq.ai" lockup, near-black display type, capability pills,
-and a `pip install` line. Uses the real self-hosted brand fonts (Kurrent display, Avio Sans
+and a `uv add` line. Uses the real self-hosted brand fonts (Kurrent display, Avio Sans
 body, Kurrent Mono code) — the same palette/type as the orq.ai site and report.css.
 
 We render a static image (not the mkdocs `social` plugin) because that plugin can only
@@ -48,7 +48,7 @@ FEATURES = [
     ("target", TEAL, INK, "Agent red-teaming"),
     ("chat", TEAL, INK, "Conversation simulation"),
 ]
-INSTALL = "pip install evaluatorq"
+INSTALL = "uv add evaluatorq"
 LEFT = 96
 
 

--- a/src/evaluatorq/common/ui/launch.py
+++ b/src/evaluatorq/common/ui/launch.py
@@ -21,9 +21,8 @@ if TYPE_CHECKING:
 
 def _install_hint(extra: str) -> str:
     return (
-        f'Streamlit is not installed. Install the {extra} extras:\n'
-        f'  uv pip install "evaluatorq[{extra}]"\n'
-        f'  pip install "evaluatorq[{extra}]"'
+        f'Streamlit is not installed. Install the {extra} extras: '
+        f'uv add "evaluatorq[{extra}]" (or: python -m pip install "evaluatorq[{extra}]")'
     )
 
 

--- a/src/evaluatorq/dashboard/launch.py
+++ b/src/evaluatorq/dashboard/launch.py
@@ -24,7 +24,8 @@ def ensure_fasthtml() -> None:
         import typer
 
         typer.echo(
-            'The dashboard requires "dashboard" extra:\n  pip install "evaluatorq[dashboard]"',
+            'The dashboard requires "dashboard" extra. Install with: uv add "evaluatorq[dashboard]" '
+            '(or: python -m pip install "evaluatorq[dashboard]")',
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/evaluatorq/deployment.py
+++ b/src/evaluatorq/deployment.py
@@ -88,12 +88,8 @@ def _get_or_create_client() -> Orq:
         return _cached_client
     except ModuleNotFoundError as e:
         raise ImportError(
-            'The orq_ai_sdk package is not installed. To use deployment features, please install it:\n'
-            '  pip install orq-ai-sdk\n'
-            '  # or\n'
-            '  uv add orq-ai-sdk\n'
-            '  # or\n'
-            '  poetry add orq-ai-sdk'
+            'The orq_ai_sdk package is not installed. To use deployment features, install it with: '
+            'uv add orq-ai-sdk (or: python -m pip install orq-ai-sdk)'
         ) from e
     except Exception as e:
         raise RuntimeError(f'Failed to setup ORQ client: {e}') from e

--- a/src/evaluatorq/fetch_data.py
+++ b/src/evaluatorq/fetch_data.py
@@ -49,11 +49,7 @@ def setup_orq_client(api_key: str) -> 'Orq':
         return Orq(api_key=api_key, server_url=server_url)
     except ModuleNotFoundError as e:
         raise Exception(
-            """orq_ai_sdk is not installed.
-            Please install it using:
-                * pip install orq_ai_sdk.
-                * uv add orq_ai_sdk
-                * poetry add orq_ai_sdk"""
+            'orq_ai_sdk is not installed. Install with: uv add orq-ai-sdk (or: python -m pip install orq-ai-sdk)'
         ) from e
     except Exception as e:
         raise Exception(f'Error setting up Orq client: {e}')

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -224,6 +224,9 @@ uv run eq redteam run --help   # all options
 `uv tool install` here: it builds an isolated environment that exposes the CLI
 but leaves `evaluatorq` unimportable from your own scripts.
 
+Prefer pip? `python -m pip install "evaluatorq[redteam]"` installs into the
+interpreter you just named, and `eq` lands on that environment's `PATH`.
+
 For the full flag reference (multi-target, report export, `eq redteam runs`, etc.), see [`examples/redteam/README.md`](../../../examples/redteam/README.md#cli-reference).
 
 ## Tracing & PII

--- a/src/evaluatorq/redteam/adaptive/agent_context.py
+++ b/src/evaluatorq/redteam/adaptive/agent_context.py
@@ -21,7 +21,10 @@ async def retrieve_agent_context(orq_client: Any, agent_key: str) -> AgentContex
     try:
         from evaluatorq.redteam.backends.orq import ORQAgentTarget
     except ImportError:
-        raise ImportError('orq_ai_sdk is required for ORQ context retrieval. Install with: pip install orq-ai-sdk')
+        raise ImportError(
+            'orq_ai_sdk is required for ORQ context retrieval. '
+            'Install with: uv add orq-ai-sdk (or: python -m pip install orq-ai-sdk)'
+        )
     probe = ORQAgentTarget(agent_key=agent_key, orq_client=orq_client)
     return await probe.get_agent_context()
 

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -571,7 +571,8 @@ class ORQBackend(Backend):
         else:
             if _orq_cls is None:
                 raise ImportError(
-                    'ORQ backend requires the orq-ai-sdk package. Install with: pip install evaluatorq[orq]'
+                    'ORQ backend requires the orq-ai-sdk package. '
+                    'Install with: uv add "evaluatorq[orq]" (or: python -m pip install "evaluatorq[orq]")'
                 )
             self._orq_client = _orq_cls(
                 api_key=_get_orq_api_key(),

--- a/src/evaluatorq/redteam/backends/registry.py
+++ b/src/evaluatorq/redteam/backends/registry.py
@@ -50,7 +50,10 @@ def create_async_llm_client(role_config: LLMCallConfig | None = None) -> AsyncOp
             honor_openai_base_url=True,
         ).client
     except ImportError as exc:
-        msg = 'openai package is required for LLM-based attack generation. Install it with: pip install openai'
+        msg = (
+            'openai package is required for LLM-based attack generation. '
+            'Install it with: uv add openai (or: python -m pip install openai)'
+        )
         raise BackendError(msg) from exc
     except MissingLLMCredentialsError as exc:
         raise CredentialError(str(exc)) from exc

--- a/src/evaluatorq/redteam/cli.py
+++ b/src/evaluatorq/redteam/cli.py
@@ -616,7 +616,8 @@ def validate_dataset(
             from huggingface_hub import hf_hub_download
         except ImportError:
             typer.echo(
-                'huggingface-hub not installed. Install with: pip install evaluatorq[redteam]',
+                'huggingface-hub not installed. Install with: uv add "evaluatorq[redteam]" '
+                '(or: python -m pip install "evaluatorq[redteam]")',
                 err=True,
             )
             raise typer.Exit(code=1)
@@ -643,7 +644,8 @@ def validate_dataset(
             from huggingface_hub import hf_hub_download
         except ImportError:
             typer.echo(
-                'huggingface-hub not installed. Install with: pip install evaluatorq[redteam]',
+                'huggingface-hub not installed. Install with: uv add "evaluatorq[redteam]" '
+                '(or: python -m pip install "evaluatorq[redteam]")',
                 err=True,
             )
             raise typer.Exit(code=1)

--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -371,8 +371,8 @@ def create_owasp_evaluator(
 
 _HF_MISSING_MSG = (
     'Loading static datapoints from HuggingFace requires the huggingface-hub package. '
-    "Install the redteam extra: pip install 'evaluatorq[redteam]' "
-    "(or: uv pip install 'evaluatorq[redteam]'). "
+    "Install the redteam extra: uv add 'evaluatorq[redteam]' "
+    "(or: python -m pip install 'evaluatorq[redteam]'). "
     'Alternatively pass a local --dataset path, or use --mode dynamic to skip static datapoints.'
 )
 
@@ -459,7 +459,7 @@ def _fetch_all_datapoints(dataset_id: str) -> list[DataPoint]:
     except ImportError as e:
         msg = (
             'Fetching datasets from the ORQ platform requires the orq-ai-sdk package. '
-            'Install it with: pip install evaluatorq[orq]'
+            'Install it with: uv add "evaluatorq[orq]" (or: python -m pip install "evaluatorq[orq]")'
         )
         raise ImportError(msg) from e
 

--- a/src/evaluatorq/redteam/runtime/jobs.py
+++ b/src/evaluatorq/redteam/runtime/jobs.py
@@ -76,7 +76,10 @@ def create_model_job(
         try:
             from orq_ai_sdk import Orq
         except ImportError as e:
-            msg = 'Deployment jobs require the orq-ai-sdk package. Install it with: pip install evaluatorq[orq]'
+            msg = (
+                'Deployment jobs require the orq-ai-sdk package. '
+                'Install it with: uv add "evaluatorq[orq]" (or: python -m pip install "evaluatorq[orq]")'
+            )
             raise ImportError(msg) from e
 
         api_key = os.environ.get('ORQ_API_KEY')

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -216,6 +216,9 @@ uv run eq sim generate --help
 `uv tool install` here: it builds an isolated environment that exposes the CLI
 but leaves `evaluatorq` unimportable from your own scripts.
 
+Prefer pip? `python -m pip install "evaluatorq[simulation]"` installs into the
+interpreter you just named, and `eq` lands on that environment's `PATH`.
+
 Examples:
 
 ```bash

--- a/src/evaluatorq/simulation/__init__.py
+++ b/src/evaluatorq/simulation/__init__.py
@@ -294,7 +294,8 @@ def __getattr__(name: str) -> Any:
         extra = _OPTIONAL_TARGET_EXTRAS.get(name)
         if extra is not None:
             raise ImportError(
-                f"{name} requires the optional '{extra}' dependency. Install it with: pip install 'evaluatorq[{extra}]'"
+                f"{name} requires the optional '{extra}' dependency. "
+                f"Install it with: uv add 'evaluatorq[{extra}]' (or: python -m pip install 'evaluatorq[{extra}]')"
             ) from exc
         raise
     globals()[name] = value


### PR DESCRIPTION
Follow-up to #118, which made `uv add` the default install path but only covered part of the repo. Came out of an adversarial review of that PR.

## What changed

**Runtime error messages (`src/`)** — 12 `ImportError`/error strings now lead with `uv add` and offer `python -m pip install` as the fallback. These are the strings a user actually sees at failure time, and several still said bare `pip install` — the exact advice #117 removed from `__init__.py`. One even recommended `uv pip install`, contradicting #118's own standard. `__init__.py` keeps its `sys.executable`-naming message unchanged (a unit test asserts it).

**Docs pip fallback** — #118 kept the pip fallback on 3 of ~10 pages and deleted it from the rest, which stranded anyone not on uv. Every page showing an install command now carries both, with `uv add` recommended: `dashboard.md`, `tracing.md`, `orq-deployment.md`, `faq.md`, and both guides.

**`uv init` first** — `uv add` requires an existing uv project; following `docs/index.md` from an empty directory errored on step one. The entry points now say so.

**`examples/` tree** — skipped entirely by #118. Swept the three READMEs, four framework target docstrings, and two runtime error strings. Left `%pip install` in the notebooks (correct in-notebook magic) and the generated presentation/webinar artifacts alone.

**New FAQ entry** — *"I installed evaluatorq but `import evaluatorq` fails"*: how to confirm that pip and python resolved to different environments (`sys.executable` vs `pip show -f`), and the two ways to fix it. This is the failure that started the whole thread, and it needed a page regardless of which installer someone uses.

**Restored dropped info** — direct-package installs for `orq-ai-sdk` and `langchain`/`langgraph`, removed from the README in #118 with no replacement anywhere.

**`scripts/gen_og_card.py`** — no longer bakes `pip install evaluatorq` into the docs social-preview image.

## Deliberately not done

- **Bare `eq ...` invocations (~40) left as-is.** Prefixing every one with `uv run` hurts readability more than it helps; the install sections say `uv run eq` once, which is where it matters.
- **Corporate/private-index setups (Artifactory, `PIP_INDEX_URL`) not addressed.** uv doesn't read `pip.conf`. Those users have the documented pip path.
- **`uv sync` left alone** where docs describe developing against a local checkout — correct verb there.

## Verification

- `uv run pytest -m 'not integration'` — 3689 passed, 2 skipped
- `uv run --group docs mkdocs build --strict` — clean
- `uv run python scripts/validate_mermaid.py` — 29 files OK
- `uv run ruff check src` / `ruff format --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)