### PR TITLE
refactor(simulation): group first-message generation under one span

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -169,7 +169,9 @@ The root `Evaluatorq - Red Teaming` span additionally carries:
 
 ```
 Evaluatorq - Agent Simulation    # root — one per simulate() / generate_and_simulate() call
-  ├── chat/responses {model}     # persona/scenario/first-message generation calls
+  ├── chat/responses {model}     # persona/scenario generation calls
+  ├── orq.simulation.first_message_generation   # ONE span for the whole persona x scenario sweep
+  │     └── chat/responses {model} (x N pairs)
   └── orq.simulation.run         # one per datapoint
         ├── orq.simulation.first_message_generation   # only when no first message was pre-generated
         │     └── chat/responses {model} (orq.llm.purpose="first_message")
@@ -217,6 +219,18 @@ Span attributes on `orq.simulation.run`:
 | `orq.simulation.turn_count` | Number of turns completed |
 
 Span attributes on `orq.simulation.first_message_generation`:
+
+Under the root (one span covering the whole persona x scenario sweep):
+
+| Attribute | Value |
+|---|---|
+| `orq.simulation.model` | Model used for generation |
+| `orq.simulation.pair_count` | persona x scenario pairs attempted |
+| `orq.simulation.persona_count` / `orq.simulation.scenario_count` | Input counts |
+| `orq.simulation.generated_count` | Datapoints successfully generated |
+| `orq.simulation.failed_count` | Pairs that failed (each also gets an `orq.simulation.first_message_generation_failed` span event with persona, scenario, and error) |
+
+Under `orq.simulation.run` (only when a datapoint carried no pre-generated first message):
 
 | Attribute | Value |
 |---|---|

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -1532,6 +1532,7 @@ async def _resolve_or_generate_datapoints(
 
     from evaluatorq.openresponses.client import build_simulation_client
     from evaluatorq.simulation.generators import FirstMessageGenerator
+    from evaluatorq.simulation.tracing import with_simulation_span
 
     gen_client, gen_owned = build_simulation_client(generation_client)
     try:
@@ -1540,24 +1541,54 @@ async def _resolve_or_generate_datapoints(
 
         generated: list[SimulationDatapoint] = []
         batch_size = 5
-        for i in range(0, len(pairs), batch_size):
-            batch = pairs[i : i + batch_size]
-            batch_results = await asyncio.gather(
-                *[_generate_single_datapoint(first_msg_gen, p, s) for p, s in batch],
-                return_exceptions=True,
-            )
-            for (p, s), outcome in zip(batch, batch_results, strict=True):
-                if isinstance(outcome, BaseException):
-                    logger.warning(
-                        'first-message generation failed for persona=%r scenario=%r: %r — skipping',
-                        p.name,
-                        s.name,
-                        outcome,
-                    )
-                    continue
-                generated.append(outcome)
-        if not generated:
-            raise RuntimeError('first-message generation produced no datapoints - every persona x scenario pair failed')
+        # One span for the whole generation phase; the per-pair LLM calls nest
+        # under it as the client's own spans.
+        async with with_simulation_span(
+            'orq.simulation.first_message_generation',
+            {
+                'orq.simulation.model': model,
+                'orq.simulation.pair_count': len(pairs),
+                'orq.simulation.persona_count': len(personas),
+                'orq.simulation.scenario_count': len(scenarios),
+            },
+        ) as gen_span:
+            for i in range(0, len(pairs), batch_size):
+                batch = pairs[i : i + batch_size]
+                batch_results = await asyncio.gather(
+                    *[_generate_single_datapoint(first_msg_gen, p, s) for p, s in batch],
+                    return_exceptions=True,
+                )
+                for (p, s), outcome in zip(batch, batch_results, strict=True):
+                    if isinstance(outcome, BaseException):
+                        logger.warning(
+                            'first-message generation failed for persona=%r scenario=%r: %r — skipping',
+                            p.name,
+                            s.name,
+                            outcome,
+                        )
+                        # The per-pair span is gone, so the phase span carries
+                        # the failure identity instead — otherwise a partial
+                        # failure is only visible in the logs.
+                        if gen_span is not None:
+                            gen_span.add_event(
+                                'orq.simulation.first_message_generation_failed',
+                                {
+                                    'orq.simulation.persona': p.name,
+                                    'orq.simulation.scenario': s.name,
+                                    'error.type': type(outcome).__name__,
+                                    'error.message': str(outcome),
+                                },
+                            )
+                        continue
+                    generated.append(outcome)
+            if gen_span is not None:
+                gen_span.set_attribute('orq.simulation.generated_count', len(generated))
+                gen_span.set_attribute('orq.simulation.failed_count', len(pairs) - len(generated))
+            # Raise inside the span so a total failure marks it ERROR.
+            if not generated:
+                raise RuntimeError(
+                    'first-message generation produced no datapoints - every persona x scenario pair failed'
+                )
         return generated
     finally:
         if gen_owned:
@@ -1591,18 +1622,11 @@ async def _fetch_simulation_datapoints_from_orq(api_key: str, dataset_id: str) -
 async def _generate_single_datapoint(
     gen: FirstMessageGenerator, persona: Persona, scenario: Scenario
 ) -> SimulationDatapoint:
-    from evaluatorq.simulation.tracing import with_simulation_span
     from evaluatorq.simulation.utils.prompt_builders import generate_datapoint
 
-    async with with_simulation_span(
-        'orq.simulation.first_message_generation',
-        {
-            'orq.simulation.persona': persona.name,
-            'orq.simulation.scenario': scenario.name,
-            'orq.simulation.model': getattr(gen, '_model', None),
-        },
-    ):
-        first_message = await gen.generate(persona, scenario)
+    # ponytail: no per-pair span — the caller wraps the whole generation phase
+    # in a single orq.simulation.first_message_generation span.
+    first_message = await gen.generate(persona, scenario)
     return generate_datapoint(persona, scenario, first_message)
 
 

--- a/src/evaluatorq/simulation/tracing.py
+++ b/src/evaluatorq/simulation/tracing.py
@@ -5,8 +5,9 @@ Generic recording utilities are imported from evaluatorq.common.tracing.
 
 Span hierarchy:
     Evaluatorq - Agent Simulation (root)
+      ├── orq.simulation.first_message_generation (once, whole persona x scenario sweep)
       ├── orq.simulation.run (per datapoint)
-      │   ├── orq.simulation.first_message_generation
+      │   ├── orq.simulation.first_message_generation (only when not pre-generated)
       │   └── orq.simulation.turn (per turn)
       │       ├── orq.simulation.target_call
       │       ├── orq.simulation.judge_evaluation

--- a/tests/simulation/test_tracing.py
+++ b/tests/simulation/test_tracing.py
@@ -898,8 +898,11 @@ async def test_generated_datapoint_first_message_has_simulation_span(
     scenario = Scenario(name='Billing', goal='Fix a billing issue')
     gen = FirstMessageGenerator(model='test', client=fake_client)
 
+    # The generation phase gets ONE span for all persona x scenario pairs; the
+    # per-pair helper adds no span of its own.
     async with with_simulation_span('Evaluatorq - Agent Simulation', None):
-        datapoint = await _generate_single_datapoint(gen, persona, scenario)
+        async with with_simulation_span('orq.simulation.first_message_generation', None):
+            datapoint = await _generate_single_datapoint(gen, persona, scenario)
 
     assert datapoint.first_message == 'Hello there'
     pipeline = _find(span_collector, 'Evaluatorq - Agent Simulation')
@@ -1308,3 +1311,131 @@ async def test_executive_summary_no_span_when_disabled(span_collector: _Collecti
 
     assert run.executive_summary is None
     assert not [s for s in span_collector.spans if s.name == 'chat openai/gpt-4o']
+
+
+@pytest.mark.asyncio
+async def test_batched_first_message_generation_uses_one_span(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The persona x scenario sweep opens ONE generation span; every pair's LLM
+    span nests under it, and the counts land on that span.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
+
+    class _Choice:
+        finish_reason = 'stop'
+
+        class message:  # noqa: N801
+            content = 'Hello there'
+            role = 'assistant'
+
+    class _Usage:
+        prompt_tokens = 1
+        completion_tokens = 1
+        total_tokens = 2
+        prompt_tokens_details = None
+
+    class _Resp:
+        id = 'dp_1'
+        model = 'test'
+        usage = _Usage()
+        choices = [_Choice()]
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=_Resp())
+
+    from evaluatorq.simulation.api import _resolve_or_generate_datapoints
+    from evaluatorq.simulation.types import CommunicationStyle, Persona, Scenario
+
+    personas = [
+        Persona(
+            name=f'P{i}',
+            patience=0.5,
+            assertiveness=0.5,
+            politeness=0.5,
+            technical_level=0.5,
+            communication_style=CommunicationStyle.casual,
+            background='A test user',
+        )
+        for i in range(2)
+    ]
+    scenarios = [Scenario(name=f'S{i}', goal='Fix it') for i in range(3)]
+
+    datapoints = await _resolve_or_generate_datapoints(
+        caller='simulate',
+        datapoints=None,
+        personas=personas,
+        scenarios=scenarios,
+        dataset_id=None,
+        model='test',
+        generation_client=fake_client,
+    )
+
+    assert len(datapoints) == 6
+    gen_spans = [s for s in span_collector.spans if s.name == 'orq.simulation.first_message_generation']
+    assert len(gen_spans) == 1
+    a = _attrs(gen_spans[0])
+    assert a['orq.simulation.pair_count'] == 6
+    assert a['orq.simulation.persona_count'] == 2
+    assert a['orq.simulation.scenario_count'] == 3
+    assert a['orq.simulation.generated_count'] == 6
+    assert a['orq.simulation.failed_count'] == 0
+
+    llm_spans = [s for s in span_collector.spans if s.name == 'chat test']
+    assert len(llm_spans) == 6
+    assert all(s.parent.span_id == gen_spans[0].context.span_id for s in llm_spans)  # pyright: ignore[reportOptionalMemberAccess]
+
+
+@pytest.mark.asyncio
+async def test_first_message_generation_span_records_failures(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Every pair failing marks the phase span ERROR and records one event per
+    failed pair (the per-pair spans that used to carry this are gone).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv('ORQ_API_KEY', 'test-key')
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(side_effect=RuntimeError('boom'))
+
+    from evaluatorq.simulation.api import _resolve_or_generate_datapoints
+    from evaluatorq.simulation.types import CommunicationStyle, Persona, Scenario
+
+    persona = Persona(
+        name='P0',
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background='A test user',
+    )
+    scenario = Scenario(name='S0', goal='Fix it')
+
+    with pytest.raises(RuntimeError, match='produced no datapoints'):
+        await _resolve_or_generate_datapoints(
+            caller='simulate',
+            datapoints=None,
+            personas=[persona],
+            scenarios=[scenario],
+            dataset_id=None,
+            model='test',
+            generation_client=fake_client,
+        )
+
+    gen = _find(span_collector, 'orq.simulation.first_message_generation')
+    assert gen.status.status_code.name == 'ERROR'
+    assert _attrs(gen)['orq.simulation.failed_count'] == 1
+    events = [e for e in gen.events if e.name == 'orq.simulation.first_message_generation_failed']
+    assert len(events) == 1
+    assert dict(events[0].attributes or {})['orq.simulation.persona'] == 'P0'


### PR DESCRIPTION
## What

The persona × scenario first-message sweep opened one `orq.simulation.first_message_generation` span **per pair**, so a 5×5 sweep produced 25 near-identical spans in the trace. Now the whole generation phase gets **one** span; each pair's `chat/responses {model}` LLM span nests directly under it (OTel context is copied into the `asyncio.gather` tasks at creation time, so nesting holds).

Phase-span attributes: `orq.simulation.model`, `pair_count`, `persona_count`, `scenario_count`, `generated_count`, `failed_count`.

## Failure visibility

Dropping the per-pair spans would have lost the per-pair ERROR spans, so:
- each failed pair adds an `orq.simulation.first_message_generation_failed` span event (persona, scenario, error type/message);
- the "every pair failed" `RuntimeError` is now raised *inside* the span, so it ends ERROR instead of OK.

## Unchanged

The per-datapoint `orq.simulation.first_message_generation` span in `runner/simulation.py` — it fires once per run, only when a datapoint carries no pre-generated first message.

## Tests

Two new tests on the real batched path: one asserts a single phase span with correct counts and all 6 LLM spans parented to it; one asserts the all-fail case marks the span ERROR and records the failure event. `tests/simulation`: 782 passed, 2 skipped. `ruff check src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)