### PR TITLE
docs: fix drift found by first docs-drift sweep

### DIFF
--- a/.claude/skills/docs-coverage/axes.md
+++ b/.claude/skills/docs-coverage/axes.md
@@ -53,6 +53,12 @@ Marked `N/A` in the matrix, never reported as a gap.
 | dashboard × evaluator kind | renders scores, does not choose evaluators |
 | `wrap_simulation_agent()` × data source | wraps a target for reuse; does not consume a dataset |
 | `generate_and_simulate()` × data source `ORQ dataset id` | generation *is* the data source |
+| Python-only entry points × surface `CLI` | `build_report()`, `wrap_simulation_agent()`, `deployment()` / `invoke()` have no `eq` command |
+| `evaluatorq()` × target kind | it scores rows you already have; the target is your own task function |
+| dashboard × target kind | it reads saved artifacts; no target is invoked |
+| dashboard × entry points that write no artifacts | nothing lands in the run store, so there is nothing to browse |
+| `red_team()` × target kind `Vercel` | Vercel AI SDK agents are a simulation target kind only |
+| `red_team()` × data source `inline DataPoint`s | `dataset` takes a `Path` or specifier string; there is no inline-datapoint parameter |
 | `static` mode × generated data source | static mode consumes a fixed dataset by definition |
 | CLI × custom `AgentTarget` | custom targets are constructed in Python; the CLI resolves string identifiers |
 

--- a/.claude/skills/docs-coverage/axes.md
+++ b/.claude/skills/docs-coverage/axes.md
@@ -19,9 +19,25 @@ feature that changed it.
 | **entry point** | `evaluatorq.__all__` + `evaluatorq.simulation.__all__` + `evaluatorq.redteam.__all__` | `evaluatorq()`, `red_team()`, `simulate()`, `generate_and_simulate()`, `wrap_simulation_agent()`, pairwise `build_report()`, `deployment()` / `invoke()` |
 | **surface** | fixed | Python API · CLI (`eq`) · dashboard (`eq dashboard` / `eq ui`) |
 | **target kind** | `_BACKEND_REGISTRY` in `redteam/backends/registry.py` + CLI `--target` prefixes | `agent:<key>`, `deployment:<key>`, direct OpenAI backend, custom `AgentTarget` / `CallableTarget` |
-| **mode** | `--mode` on `eq redteam run` | `dynamic`, `static`, `hybrid` |
+| **mode** | `--mode` on `eq redteam run`, **plus `replay`** (see below) | `dynamic`, `static`, `hybrid`, `replay` |
 | **data source** | `evaluatorq()` / `red_team()` dataset params | inline `DataPoint`s, ORQ dataset id, HuggingFace dataset, generated |
 | **evaluator kind** | `VULNERABILITY_EVALUATOR_REGISTRY`, `SIMULATION_EVALUATORS`, pairwise types | built-in scorer, LLM jury, pairwise jury, custom `Evaluator` |
+
+### `replay` is a mode value that no enum contains
+
+`--mode` accepts only `dynamic`, `static` and `hybrid` (validated as a plain
+string in `redteam/runner.py`). Replay is reached by a *different* flag,
+`--from-run`, which is explicitly **incompatible** with `--mode` — it re-runs a
+previous run's exact attacks, so only the target and models may differ.
+
+Behaviourally that makes replay a fourth mode: it is the same choice a user makes
+at the same point, expressed through another flag. Source-derived values can
+never see it, so it is hardcoded here on purpose. **Do not resolve this by adding
+`replay` to the accepted `--mode` values in code** — that would be a public
+surface change, and it contradicts the two flags being mutually exclusive.
+
+Replay exists on both `eq redteam run` and `eq sim simulate`; treat it as a mode
+value for both when building the matrix.
 
 ## Impossible or meaningless combinations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,47 @@ src/evaluatorq/
 ├── contracts.py             # Cross-subpackage shared data models (RunManifest, StageRecord, ManifestStatus, ManifestSurface, etc.)
 ├── deployment.py            # ORQ deployment integration
 ├── fetch_data.py            # Dataset fetching
+├── pairwise.py              # Pairwise comparison evaluation entry point
+├── pairwise_run.py          # Pairwise run orchestration
+├── pairwise_reports/        # Pairwise HTML report generation
+│   ├── export_html.py       # HTML report renderer
+│   └── sections.py          # Report section builders
 ├── common/                  # Cross-surface shared utilities (redteam + simulation)
-│   └── run_manifest.py      # Run-lifecycle manifest behavior (create/update/finalize RunManifest)
+│   ├── run_manifest.py      # Run-lifecycle manifest behavior (create/update/finalize RunManifest)
+│   ├── judge.py             # LLM-as-judge helper shared across surfaces
+│   ├── jury.py              # Multi-judge aggregation
+│   ├── llm_call.py          # Shared LLM invocation wrapper
+│   ├── llm_client.py        # LLM client construction
+│   ├── retry.py             # Retry/backoff helpers
+│   ├── tracing.py           # OTel span helpers shared across surfaces
+│   ├── template_engine.py   # Prompt templating
+│   ├── reports/             # Shared report rendering (console, HTML, vega charts)
+│   │   ├── console.py       # Rich console report rendering
+│   │   ├── executive_summary.py # Executive summary section builder
+│   │   ├── render.py        # HTML/MD render orchestration
+│   │   └── vega.py          # Vega-Lite chart spec builders
+│   └── ui/                  # Shared Streamlit dashboard launch helper
+│       └── launch.py        # Streamlit app launch helper
 ├── integrations/            # Third-party integrations (LangChain, etc.)
 ├── tracing/                 # OpenTelemetry tracing
 ├── openresponses/           # OpenAI Responses API integration
+├── simulation/              # Agent simulation subpackage (eq simulate) — persona/scenario-driven multi-turn agent testing
+│   ├── api.py               # Public simulate() entry point
+│   ├── cli.py                # Typer CLI for simulation
+│   ├── types.py               # Simulation data models
+│   ├── traces.py              # Trace capture/reconstruction
+│   ├── wrap_agent.py          # Agent wrapping/instrumentation helper
+│   ├── runner/                 # Simulation execution loop
+│   │   └── simulation.py       # Persona x scenario run orchestration
+│   ├── agents/                  # Simulated user + judge agents
+│   │   ├── judge.py             # Judging agent
+│   │   └── user_simulator.py    # Simulated user agent
+│   ├── generators/                # LLM-driven persona/scenario/datapoint generation
+│   ├── reports/                    # Report generation (console, HTML, MD, exec summary)
+│   ├── quality/                     # Robustness checks
+│   │   └── message_perturbation.py  # Message perturbation testing
+│   └── ui/                           # Streamlit dashboard for simulation results
+│       └── dashboard.py
 ├── dashboard/               # FastHTML web dashboard (eq dashboard — preview, in dev; ui commands still serve the Streamlit dashboards)
 │   ├── app.py               # build_app(roots) — ASGI app factory + all routes
 │   ├── _compat.py           # Starlette 1.3.x / FastHTML 0.12.x compat shim (applied on import)
@@ -86,6 +122,14 @@ src/evaluatorq/
 │   ├── filters.py           # FilterDef registry (redteam 7-dim, sim 4-dim)
 │   ├── filter_request.py    # parse_selections() — query-string filter parser
 │   ├── styles.py            # Shared CSS constants / class-name helpers
+│   ├── theme.py             # Theme tokens / light-dark styling
+│   ├── metrics.py           # Aggregate metric computation for dashboard views
+│   ├── report_kit.py        # Shared report-card component helpers
+│   ├── report_tabs.py       # Report tab navigation
+│   ├── orq_links.py         # Orq UI deep-link builders
+│   ├── orq_workspace.py     # Orq workspace slug resolution
+│   ├── trace_links.py       # Trace deep-link builders
+│   ├── sim_compare.py       # Simulation run comparison view
 │   ├── redteam_views.py     # HTMX fragment routes for 4 interactive redteam views
 │   ├── redteam_charts.py    # Interactive breakdown chart + agent heatmap fragments
 │   ├── redteam_transcripts.py # Conversation viewer + disagreement viewer fragments
@@ -101,6 +145,9 @@ src/evaluatorq/
     ├── hooks.py             # Pipeline lifecycle hooks (DefaultHooks, RichHooks)
     ├── tracing.py           # OTel span helpers
     ├── exceptions.py        # Custom exceptions
+    ├── judge.py             # LLM judge invocation for red-team evaluators
+    ├── replay.py            # Replay a prior red-team run from stored artifacts
+    ├── utils.py             # Misc red-team helpers
     ├── adaptive/            # Dynamic pipeline components
     │   ├── pipeline.py      # Datapoint generation pipeline
     │   ├── orchestrator.py  # Attack execution orchestrator
@@ -110,12 +157,15 @@ src/evaluatorq/
     │   ├── attack_generator.py    # Adversarial prompt generation
     │   ├── objective_generator.py # Attack objective generation
     │   ├── capability_classifier.py # LLM-based agent capability classification
-    │   └── agent_context.py # Agent context retrieval
+    │   ├── agent_context.py # Agent context retrieval
+    │   └── tool_chaining.py # Multi-tool attack chaining strategy support
     ├── backends/            # Target backends (ORQ agents, OpenAI models)
     │   ├── base.py          # AgentTarget protocol
     │   ├── orq.py           # ORQ agent backend
     │   ├── openai.py        # Direct OpenAI backend
-    │   └── registry.py      # Backend/client factory
+    │   ├── openresponses.py # OpenAI Responses API backend
+    │   ├── registry.py      # Backend/client factory
+    │   └── _errors.py       # Backend error normalization
     ├── frameworks/          # Framework-specific strategies and evaluators
     │   ├── owasp_asi.py     # OWASP ASI attack strategies
     │   ├── owasp_llm.py     # OWASP LLM Top 10 attack strategies
@@ -127,10 +177,17 @@ src/evaluatorq/
     │       └── evaluatorq_bridge.py # Static dataset loading + scoring
     ├── reports/             # Report generation
     │   ├── converters.py    # Result → report conversion
-    │   └── display.py       # Rich terminal display
-    └── runtime/             # Job execution
-        ├── jobs.py          # Async job runner
-        └── orq_agent_job.py # ORQ-specific job implementation
+    │   ├── display.py       # Rich terminal display
+    │   ├── executive_summary.py # Executive summary section builder
+    │   ├── export_html.py   # HTML report export
+    │   ├── export_md.py     # Markdown report export
+    │   ├── guidance.py      # Remediation guidance text
+    │   ├── recommendations.py # Recommendation generation
+    │   └── sections.py      # Report section builders
+    ├── runtime/             # Job execution
+    │   └── jobs.py          # Async job runner
+    └── ui/                  # Streamlit dashboard for red-team results
+        └── dashboard.py
 ```
 
 ## Key Patterns
@@ -158,9 +215,11 @@ src/evaluatorq/
 
 ### Dependencies
 
-- Runtime: `pydantic`, `httpx`, `rich`, `loguru`
-- Red team extra: `openai`, `typer`, `python-dotenv`, `huggingface-hub`
-- Dashboard extra: `python-fasthtml`, `uvicorn` (install as `evaluatorq[dashboard]`)
+- Runtime (required): `pydantic`, `httpx`, `rich`, `loguru`, `typer`, `openai`
+- Red team extra: `huggingface-hub`, `streamlit`, `plotly`, `watchdog`, `vl-convert-python` (install as `evaluatorq[redteam]`)
+- Simulation extra: `orq-ai-sdk`, `streamlit`, `plotly`, `watchdog`, `vl-convert-python` (install as `evaluatorq[simulation]`)
+- Dashboard extra: `python-fasthtml`, `uvicorn`, `vl-convert-python` (install as `evaluatorq[dashboard]`)
+- Other extras: `orq` (`orq-ai-sdk`), `otel` (OpenTelemetry SDK/exporter), `langchain`, `langgraph`, `openai-agents`, `pydantic-ai`, `crewai`; `all` installs every extra
 - Dev: `pytest`, `pytest-asyncio`, `basedpyright`, `ruff`
 - Package manager: `uv` (not pip)
 - Build system: `hatchling`

--- a/README.md
+++ b/README.md
@@ -861,7 +861,7 @@ No personas yet? `generate_and_simulate(agent_description=...)` invents personas
 
 ## 📚 API Reference
 
-### `evaluatorq(name, params?, *, data?, jobs?, evaluators?, parallelism?, print_results?, description?) -> EvaluatorqResult`
+### `evaluatorq(name, params?, *, data?, jobs?, evaluators?, parallelism?, print_results?, description?, path?) -> EvaluatorqResult`
 
 Main async function to run evaluations.
 
@@ -878,6 +878,7 @@ async def evaluatorq(
     parallelism: int = 1,
     print_results: bool = True,
     description: str | None = None,
+    path: str | None = None,
 ) -> EvaluatorqResult
 ```
 
@@ -913,7 +914,7 @@ class DataPoint(BaseModel):
     inputs: dict[str, Any]
     expected_output: Output | None = None
 
-EvaluationResultCellValue = str | float | dict[str, "str | float | dict[str, str | float]"]
+EvaluationResultCellValue = str | int | float | dict[str, "str | float | dict[str, str | float]"]
 
 class EvaluationResultCell(BaseModel):
     """Structured evaluation result with multi-dimensional metrics."""
@@ -922,7 +923,7 @@ class EvaluationResultCell(BaseModel):
 
 class EvaluationResult(BaseModel):
     """Result from an evaluator."""
-    value: str | float | bool | EvaluationResultCell
+    value: str | int | float | bool | EvaluationResultCell | dict[str, Any]
     explanation: str | None = None
     pass_: bool | None = None  # Optional pass/fail indicator for CI/CD integration
 

--- a/docs/cli-reference/redteam.md
+++ b/docs/cli-reference/redteam.md
@@ -31,11 +31,13 @@ eq redteam run --target agent:<key> [OPTIONS]
 | `--max-static-datapoints` | `int \| None` / `None` | Cap static (dataset) datapoints. |
 | `--no-cleanup-memory` | `bool` / `False` | Skip memory entity cleanup after dynamic runs. |
 | `--dataset` | `str \| None` / `None` | Dataset source: local path, `hf:org/repo`, or `hf:org/repo/file.json`. |
+| `--from-run` | `str \| None` / `None` | Replay a previous run instead of generating data: pass its file name, run id, path, or `latest`. Re-runs the exact same attacks, so only the target and models may differ. Cannot be combined with `--mode`, `--dataset`, `--category`, `--vulnerability`, `--strategy`, `--delivery-method`, or the `--max-*-datapoints` caps. |
 | `--artifacts-dir` | `Path \| None` / `None` | Directory for saved JSON files. Required when `--save detail`. (`--output-dir` was removed; use `--artifacts-dir`.) |
 | `--save` | `none \| final \| detail` / `final` | What to persist: `none` (no files), `final` (summary only), or `detail` (all stage artifacts). |
 | `--report` | `Path \| None` / `None` | Path to write the report JSON. |
 | `--report-md` | `Path \| None` / `None` | Directory for an auto-named Markdown report. |
 | `--report-html` | `Path \| None` / `None` | Directory for an auto-named HTML report. |
+| `--executive-summary` / `--no-executive-summary` | `bool` / `--executive-summary` | Generate an LLM narrative executive summary at the top of the report (needs LLM credentials). Pass `--no-executive-summary` to skip the extra LLM call. |
 | `--system-prompt` | `str \| None` / `None` | System prompt for the target model/agent. |
 | `--yes` / `-y` | `bool` / `False` | Skip confirmation prompt. |
 | `--verbose` / `-v` | count / `0` | Increase verbosity. `-v` per-attack progress + info logs; `-vv` debug logs. |
@@ -91,10 +93,11 @@ eq redteam validate-dataset [DATASET]
 List previously saved red team runs.
 
 ```bash
-eq redteam runs [PATH] [--limit N]
+eq redteam runs [PATH] [--limit N] [--json]
 ```
 
 | Flag / Argument | Type / Default | Description |
 |---|---|---|
 | `PATH` | `Path \| None` / `None` | Directory containing run reports. Defaults to `.evaluatorq/runs/`. |
 | `--limit` / `-n` | `int` / `20` | Maximum number of runs to show. |
+| `--json` | `bool` / `False` | Emit runs as a JSON array on stdout (machine-readable). |

--- a/docs/cli-reference/simulation.md
+++ b/docs/cli-reference/simulation.md
@@ -40,6 +40,7 @@ Targets — provide **exactly one**:
 | `--num-scenarios` | `int` / `5` | Number of scenarios to generate. |
 | `--evaluator` | `str` (repeatable) / API defaults | Evaluator name(s). Repeatable. |
 | `--no-save` | `bool` / `False` | Skip writing to `.evaluatorq/sim-runs/`. |
+| `--recommendations` | `bool` / `False` | Generate LLM remediation suggestions for failures, tied to their concrete cause. Extra LLM cost; uses `--sim-model`. |
 | `--datapoints` / `-d` | `Path \| None` / `None` | Write generated datapoints to JSONL for reproducible re-runs. |
 | `--results` / `-r` | `Path \| None` / `None` | Path to write results JSONL (results + scorer averages + metadata). |
 | `--report` | `Path \| None` / `None` | Path to write full SimulationRun report JSON. |
@@ -60,20 +61,25 @@ Run simulations from a pre-built datapoints JSONL file.
 eq sim simulate --input dp.jsonl --target agent:<key>
 ```
 
-Targets — same three flags as `eq sim run`. Provide exactly one of `--input` (`-i`)
-and `--dataset-id`; the latter fetches the datapoints from an Orq dataset.
+Targets — same three flags as `eq sim run`. Provide exactly one of four input
+sources: `--input` (`-i`), `--dataset-id`, `--experiment-id` (optionally narrowed
+by `--experiment-run-id`), or `--from-run`.
 
 | Flag | Type / Default | Description |
 |---|---|---|
-| `--input` / `-i` | `Path \| None` | Path to datapoints JSONL file. Mutually exclusive with `--dataset-id`. |
+| `--input` / `-i` | `Path \| None` | Path to datapoints JSONL file. Mutually exclusive with the other input sources. |
 | `--dataset-id` | `str \| None` | Fetch datapoints from an Orq dataset instead of a local file. Requires `ORQ_API_KEY`. |
+| `--experiment-id` | `str \| None` | Fetch datapoints from an Orq experiment's rows instead of a local file. Requires `ORQ_API_KEY`. |
+| `--experiment-run-id` | `str \| None` | Specific run of `--experiment-id` to load. Latest run if omitted. |
+| `--from-run` | `str \| None` | Replay a previous run from `.evaluatorq/sim-runs/`: pass its file name, run id, path, or `"latest"`. Re-runs the exact same personas, scenarios, and first messages; only the target/evaluators may differ. |
 | `--memory-entity` | `str \| None` / `None` | Memory `entity_id` sent with every `agent:<key>` (or bare `<key>`) target call, for agents with a memory store attached. Omit to mint a fresh id per conversation; pass one to reuse a specific (e.g. seeded) entity, shared across the run. |
 | `--name` / `-n` | `str` / `sim` | Run name for the run-store entry. |
 | `--sim-model` | `str` / `openai/gpt-5.4-mini` | Model for user-simulator and judge. |
-| `--max-turns` | `int` / `10` | Maximum conversation turns. |
+| `--max-turns` | `int` / `10` | Maximum conversation turns. Defaults to the replayed run's cap with `--from-run`. |
 | `--parallelism` | `int` / `5` | Concurrent simulations. |
 | `--evaluator` | `str` (repeatable) / API defaults | Evaluator name(s). Repeatable. |
 | `--no-save` | `bool` / `False` | Skip writing to `.evaluatorq/sim-runs/`. |
+| `--recommendations` | `bool` / `False` | Generate LLM remediation suggestions for failures, tied to their concrete cause. Extra LLM cost; uses `--sim-model`. |
 | `--results` / `-r` | `Path \| None` / `None` | Path to write results JSONL. |
 | `--report` | `Path \| None` / `None` | Path to write full SimulationRun report JSON. |
 | `--report-md` | `Path \| None` / `None` | Directory for an auto-named Markdown report. |
@@ -124,7 +130,39 @@ eq sim generate --datapoints dp.jsonl --agent-description "..."
 | `--sim-model` | `str` / `openai/gpt-5.4-mini` | Model for persona/scenario/first-message generation. |
 | `--num-personas` | `int` / `5` | Number of personas to generate. |
 | `--num-scenarios` | `int` / `5` | Number of scenarios to generate. |
+| `--persona-seed` | `str` (repeatable) / `None` | Archetype seed for a persona, e.g. `"angry retiree"` (repeatable). Each seed becomes one persona the LLM fleshes out — overrides `--num-personas`. Omit to auto-generate. |
+| `--scenario-seed` | `str` (repeatable) / `None` | Situation seed for a scenario, e.g. `"disputes refund denial"` (repeatable). Each seed becomes one scenario — overrides `--num-scenarios`. Omit to auto-generate. |
 | `--dataset-format` | `bool` / `False` | Write Orq dataset-row envelopes instead of raw simulation datapoints. |
+| `--verbose` / `-v` | count / `0` | Increase verbosity. |
+| `--quiet` / `-q` | `bool` / `False` | Suppress non-error output. |
+
+---
+
+## `eq sim from-traces`
+
+Build simulation datapoints from Orq production traces.
+
+```bash
+eq sim from-traces --output dp.jsonl --limit 50 --lookback-hours 24
+eq sim from-traces --output dp.jsonl --extend 20 --agent-description "..."
+```
+
+Fetches recent traces from the Orq traces API (requires `ORQ_API_KEY`) and builds
+one datapoint per trace conversation: persona and scenario are inferred from the
+transcript, and the first message is the real user's opening message verbatim.
+Pass `--extend N` to additionally generate `N` new datapoints matching the traffic
+distribution of the fetched traces (extra LLM calls). Feed the output file to
+`eq sim simulate --input` to run it.
+
+| Flag | Type / Default | Description |
+|---|---|---|
+| `--output` / `-o` | `Path` (required) | Path to write generated datapoints JSONL. |
+| `--limit` | `int` / `20` | Maximum number of traces to fetch. |
+| `--lookback-hours` | `float \| None` | Only fetch traces from the last N hours. Default: no time filter. |
+| `--search` | `str \| None` | Free-text search applied to the trace list. |
+| `--extend` | `int` / `0` | Also generate N distribution-matched datapoints on top of the direct per-trace ones (extra LLM calls). `0` disables extension. |
+| `--agent-description` | `str \| None` | Agent description used for `--extend` generation. Optional; inferred from the traffic profile if omitted. |
+| `--sim-model` | `str` / `openai/gpt-5.4-mini` | Model for persona/scenario inference and extension generation. |
 | `--verbose` / `-v` | count / `0` | Increase verbosity. |
 | `--quiet` / `-q` | `bool` / `False` | Suppress non-error output. |
 
@@ -132,16 +170,25 @@ eq sim generate --datapoints dp.jsonl --agent-description "..."
 
 ## `eq sim export`
 
-Convert simulation results JSONL to OpenResponses payload JSON.
+Export simulation results: OpenResponses payload JSON, or an HTML/Markdown report.
 
 ```bash
 eq sim export --input results.jsonl --output payload.json
+eq sim export --input sim-report.json --output report.html --format html --recommendations
 ```
+
+Markdown/HTML exports include remediation suggestions if the input run JSON
+already carries them (a run executed with `--recommendations`), or if
+`--recommendations` is passed here to generate them at export time.
 
 | Flag | Type / Default | Description |
 |---|---|---|
-| `--input` / `-i` | `Path` (required) | Path to results JSONL file. |
-| `--output` / `-o` | `Path` (required) | Path to write OpenResponses payload JSON. |
+| `--input` / `-i` | `Path` (required) | Path to a results JSONL file or a SimulationRun report JSON (`--report` / `--report-output`). |
+| `--output` / `-o` | `Path` (required) | Path to write the exported file. |
+| `--format` | `str` / `openresponses` | Export format: `openresponses` (payload JSON), `md` (Markdown report), `html` (HTML report). |
+| `--recommendations` | `bool` / `False` | For `md`/`html`: generate LLM remediation suggestions at export time if none are stored. Extra LLM cost; uses `--sim-model`. |
+| `--sim-model` | `str` / `openai/gpt-5.4-mini` | Model for `--recommendations` generation. |
+| `--target-label` | `str` / `agent` | Target name shown in md/html report headers. |
 
 ---
 
@@ -151,11 +198,13 @@ Validate a simulation datapoints JSONL file.
 
 ```bash
 eq sim validate --input dp.jsonl
+eq sim validate dp.jsonl
 ```
 
-| Flag | Type / Default | Description |
+| Flag / Argument | Type / Default | Description |
 |---|---|---|
-| `--input` / `-i` | `Path` (required) | Path to datapoints JSONL file to validate. (`validate-dataset` is retained as a compatibility alias.) |
+| `PATH` | `Path \| None` | Path to datapoints JSONL file (legacy positional form). |
+| `--input` / `-i` | `Path \| None` | Path to datapoints JSONL file to validate. (`validate-dataset` is retained as a compatibility alias.) |
 
 ---
 
@@ -185,6 +234,8 @@ eq sim runs [DIRECTORY] [--limit N]
 |---|---|---|
 | `DIRECTORY` | `Path \| None` / `None` | Directory to scan. Defaults to `.evaluatorq/sim-runs/`. |
 | `--limit` / `-n` | `int` / `20` | Maximum number of runs to show. |
+| `--full` / `-f` | `bool` / `False` | Render at full content width; do not truncate columns. |
+| `--json` | `bool` / `False` | Emit runs as a JSON array on stdout. |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,11 @@ All configuration is via environment variables. No config file is required.
 | `OPENAI_BASE_URL` | No | OpenAI default | Redirect OpenAI-compatible calls to a different host (vLLM, OpenRouter, Azure, local). Honoured by the red teaming and simulation LLM client. |
 | `ORQ_DISABLE_TRACING` | No | unset | Set to `1` or `true` to suppress all OpenTelemetry spans even when `ORQ_API_KEY` or `OTEL_EXPORTER_OTLP_ENDPOINT` is present. |
 | `ORQ_DEBUG` | No | unset | Set to any non-empty value to print tracing setup diagnostics to stdout (endpoint, auth headers, initialization errors). |
+| `EQ_DEBUG` | No | unset | Set to any non-empty value to show the full traceback on CLI errors instead of the one-line message. CLI-wide; distinct from `ORQ_DEBUG`, which only affects tracing diagnostics. |
+| `EVALUATORQ_DIR` | No | `.evaluatorq` in the current directory | Base directory for the run store, where both red teaming (`runs/`) and simulation (`sim-runs/`) persist reports. Must point at the store directory itself (e.g. `/tmp/x/.evaluatorq`), not its parent — only the working-directory fallback appends `.evaluatorq`. Empty is treated as unset. |
+| `EVALUATORQ_LOG_LEVEL` | No | `INFO` | Log level for the dashboard server. Accepts any level name (e.g. `DEBUG`). |
+| `ORQ_WORKSPACE` / `ORQ_WORKSPACE_SLUG` | No | unset | Workspace slug used to build dashboard deep-links into the Orq UI. `ORQ_WORKSPACE` wins when both are set. When neither is set, the deep-link buttons are hidden. See [Dashboard](dashboard.md). |
+| `ORQ_UI_BASE_URL` | No | `ORQ_BASE_URL`, else `https://my.orq.ai` | Base URL for dashboard deep-links into the Orq UI. Set this when the UI host differs from the API host. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | — | Explicit OTLP HTTP endpoint. Takes precedence over the `ORQ_BASE_URL`-derived endpoint. See [Tracing](tracing.md). |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | — | Comma-separated `key=value` pairs added to every OTLP export request. Format: `key1=value1,key2=value2`. |
 | `OTEL_SERVICE_NAME` | No | `evaluatorq` | Service name recorded on every span's `service.name` resource attribute. |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -72,7 +72,7 @@ Simulator/attacker/judge LLM calls go to OpenAI or the Orq router. Results uploa
 
 ### How much does a run cost, and how do I keep it cheap?
 
-Cost and wall-clock scale with cases × turns × LLM calls. The levers are how many cases you run (`max_dynamic_datapoints` / `max_static_datapoints` for red teaming, `num_personas` × `num_scenarios` for simulation), `max_turns`, and `parallelism` (default 10 — lower it if your provider rate-limits). Red teaming's report tracks spend in `report.summary.token_usage_total`.
+Cost and wall-clock scale with cases × turns × LLM calls. The levers are how many cases you run (`max_dynamic_datapoints` / `max_static_datapoints` for red teaming, `num_personas` × `num_scenarios` for simulation), `max_turns`, and `parallelism` (default 10 for red teaming, 5 for simulation — lower it if your provider rate-limits). Red teaming's report tracks spend in `report.summary.token_usage_total`.
 
 ### Where do results go, and how do I view a past run?
 

--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -393,15 +393,42 @@ results = await simulate(
 )
 ```
 
-`dataset_id`, `datapoints`, and `personas` + `scenarios` are mutually exclusive:
-pass exactly one source per run.
+`simulate()` takes five mutually exclusive sources — `datapoints`, `dataset_id`,
+`experiment_id`, `previous_run`, and `personas` + `scenarios`. Pass exactly one
+per run.
 
 ### Ground new cases in real traces
 
 Replay reruns what you already have. The other move is to generate *new* cases
 that are shaped by what really happened. Production traces show you the user
-archetypes and situations your agent actually meets, and those become the seeds
-for generation. Pull the recurring patterns out of your traces (the impatient
+archetypes and situations your agent actually meets.
+
+The direct route is `eq sim from-traces`, which pulls recent traces from the Orq
+traces API and writes one datapoint per conversation — persona and scenario
+inferred from the transcript, first message taken from the real user verbatim:
+
+```bash
+eq sim from-traces --output traces_datapoints.jsonl --limit 50 --lookback-hours 24
+eq sim simulate --input traces_datapoints.jsonl --target agent:my-agent
+```
+
+Add `--extend N` to also generate N new datapoints matching the traffic
+distribution of the fetched traces, so you get cases *around* real traffic rather
+than only the recorded ones. The same thing is available from Python as
+`datapoints_from_traces()` and `extend_from_traces()`:
+
+```python
+from evaluatorq.simulation import datapoints_from_traces
+
+datapoints = await datapoints_from_traces(limit=50, lookback_hours=24)
+```
+
+Full flag list: [`eq sim from-traces`](../cli-reference/simulation.md).
+
+#### Hand-picked seeds
+
+When you want curated archetypes rather than a straight pull from traffic, seed
+generation yourself. Pull the recurring patterns out of your traces (the impatient
 buyer disputing a charge, the confused first-time user, the edge case that broke
 last week), then hand them to `generate_personas()` / `generate_scenarios()` as
 short seed phrases:
@@ -442,11 +469,11 @@ space around the pattern rather than replaying one recorded conversation. Persis
 the generated cases (`eq sim generate --datapoints`, or `eq sim run
 --datapoints`) and they become a replayable bank for the section above.
 
-!!! note "Reading the archetypes out of traces is manual today"
-    Turning raw traces into seed phrases is a step you do yourself, by reading the
-    conversations or grouping them however you already triage production. There is
-    no built-in trace-to-persona extractor yet; the seed list is the hand-off point
-    between your trace history and the generators.
+!!! note "Seeds are a deliberate choice, not the only route"
+    Writing seed phrases by hand means you decide which archetypes matter, rather
+    than inheriting whatever your recent traffic happened to contain. When you'd
+    rather start from real traffic, use `eq sim from-traces` above — it infers the
+    personas and scenarios for you.
 
 --8<-- "docs/_snippets/dashboard-tip.md"
 

--- a/docs/pairwise-judging.md
+++ b/docs/pairwise-judging.md
@@ -200,6 +200,17 @@ calls itself, so you can drive the swap-and-reconcile logic with your own judge.
 Most callers want `llm_jury_pairwise()`; reach for `run_pairwise()` when you are
 plugging in a non-LLM judge or testing the reconciliation directly.
 
+All three live in `evaluatorq.pairwise` — not `evaluatorq.pairwise_run`, which
+holds the run-persistence helpers used above:
+
+```python
+from evaluatorq.pairwise import pairwise_consensus, reconcile_pair, run_pairwise
+```
+
+`run_pairwise()` is also re-exported at the top level as `evaluatorq.run_pairwise`;
+`reconcile_pair()` and `pairwise_consensus()` are not. `run_jury()` is internal to
+`evaluatorq.common.jury` and is not part of the public top-level API.
+
 Both `run_pairwise()` and the shared `run_jury()` accept `max_concurrency` as an
 int or an existing `asyncio.Semaphore`; pass the same semaphore to several runs
 to bound their combined fan-out with one budget.


### PR DESCRIPTION
First real run of the `docs-drift` skill (merged in #121). Split across four parallel sonnet agents — CLI reference, guides, top-level docs, README+CLAUDE.md — reporting only, with every finding verified against `--help`, `inspect.signature`, or the filesystem before anything was applied.

Smaller than the coverage sweep, as expected: drift is patchy where coverage gaps are structural. 8 files, +190/−33.

## The headline fix

`docs/guides/agent-simulation.md` told readers that trace-to-persona extraction was manual and **"there is no built-in trace-to-persona extractor yet"**. `eq sim from-traces` has shipped, along with public `datapoints_from_traces()` / `extend_from_traces()`. The section now leads with the built-in path and keeps hand-picked seeds as the deliberate alternative — they're still the right call when you want curated archetypes rather than whatever recent traffic happened to contain.

Same defect RES-1232 found from the other direction: the coverage sweep saw a gap, the drift sweep saw a false claim.

## Everything else

**CLI reference** — `eq sim from-traces` was the only sim subcommand with no section; added. Missing flags documented: `redteam run --from-run`, `--executive-summary`/`--no-executive-summary`, `redteam runs --json`, `sim run`/`simulate --recommendations`, `sim simulate --experiment-id`/`--experiment-run-id`/`--from-run` (prose claimed two input sources; there are four), `sim generate --persona-seed`/`--scenario-seed`, `sim validate`'s legacy positional `PATH`, `sim runs --full`/`--json`. Rewrote `sim export`, documented as OpenResponses-payload-only since it gained `--format` with md/html output.

**configuration.md** — the table asserts "All configuration is via environment variables" but omitted five the code reads: `EQ_DEBUG`, `EVALUATORQ_DIR`, `EVALUATORQ_LOG_LEVEL`, `ORQ_WORKSPACE`/`_SLUG`, `ORQ_UI_BASE_URL`. `EVALUATORQ_DIR` relocates the entire run store and was undiscoverable.

**faq.md** — `parallelism` documented as "default 10" in a sentence covering both surfaces. It's 10 for red teaming, 5 for simulation.

**pairwise-judging.md** — `reconcile_pair()`/`pairwise_consensus()` referenced with no import path, immediately after an example importing from `evaluatorq.pairwise_run`, where they don't live. `from evaluatorq.pairwise_run import reconcile_pair` raises `ImportError`. Added real paths; noted `run_jury()` is internal.

**CLAUDE.md** — Dependencies claimed `typer`/`openai` were redteam extras (they're required runtime deps; `__init__` hard-fails without them) and listed `python-dotenv`, not declared in `pyproject.toml` at all. The structure tree omitted the entire `simulation/` subpackage, the pairwise surface, and most of `common/` — and listed `redteam/runtime/orq_agent_job.py`, which doesn't exist.

**README.md** — `EvaluationResultCellValue` and `EvaluationResult.value` both omitted `int` (and `dict[str, Any]`); `evaluatorq()`'s API signature omitted `path`.

## On verification

The skill's rule is that removals are never automatic — an absent symbol is usually a bad check, not a real deletion. Two findings here were deletion-class and both were confirmed against the filesystem first: `orq_agent_job.py` (`ls` shows only `__init__.py` and `jobs.py`) and `python-dotenv` (`grep -c dotenv pyproject.toml` → 0).

One self-correction worth recording: I'd claimed `sim export` was missing `--report`/`--report-output` rows. It isn't. Those strings appear in `--input`'s *description* because they're the flags on `sim simulate`/`sim run` that produce the report JSON — my flag extraction had grepped description text alongside option names. The agent's narrower reading was right; nothing was added.

All 125 paths in the rewritten CLAUDE.md tree were programmatically checked to exist.

## Rebase note

Originally opened against an older `main`. Rebased onto `a2fa5890` after #120/#122/#123 landed. One conflict, in `faq.md`: main had reflowed the FAQ to one line per paragraph (`docs: unwrap the FAQ`) while this branch had wrapped the same paragraph. Resolved in favour of main's one-line style, carrying the parallelism correction.

Worth knowing for anyone who hits the same thing: while the PR was in a conflicting state, GitHub silently declined to run the `pull_request` workflows — only `Label PR` (which is `pull_request_target`) fired. Checks appeared as soon as the rebase landed.

## Checks

All 13 green. `mkdocs build --strict`, `validate_mermaid.py` (30 files) and `check_examples.py` (238 imports) pass locally and in CI. Two pre-existing build warnings unrelated to this diff: wireframe pages not in nav, and a git-follow timestamp quirk.

## Not addressed here

`docs-coverage` gaps stay in [RES-1232](https://linear.app/orqai/issue/RES-1232) — this PR is drift only (claims that are wrong), not coverage (paths that are missing). The `axes.md` maintenance items from that ticket are untouched, including the open modelling question of whether replay (`--from-run`) should become an explicit axis value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)