### PR TITLE
fix: stop corrupting content at four serialization boundaries

### DIFF
--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -92,6 +92,22 @@ def content_to_text(content: str | list[ContentPart] | None) -> str:
     return ''.join(out)
 
 
+def tool_result_to_text(result: object) -> str:
+    """Render a tool's return value for ``ToolCallOutputItem.result``.
+
+    Tools routinely return structured data (``{"temp": 12}``), and ``result``
+    has to be text because it ends up as a tool ``Message.content``. ``str()``
+    would give the Python repr — single-quoted, ``None``/``True`` instead of
+    ``null``/``true`` — which no downstream reader can parse back, so the data
+    is there but unusable. JSON keeps it readable by both a model and a parser.
+    """
+    if isinstance(result, str):
+        return result
+    # default=str: a value JSON cannot encode degrades to its repr rather than
+    # failing the whole response over one odd tool return.
+    return json.dumps(result, default=str)
+
+
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
@@ -806,16 +822,21 @@ class AgentResponse(BaseModel):
         for item in _gf(response, 'output') or []:
             item_type = _gf(item, 'type')
             if item_type == 'message':
-                items.extend(
-                    TextOutputItem(
-                        type='output_text',
-                        text=_gf(part, 'text'),
-                        annotations=[],
-                        logprobs=[],
-                    )
-                    for part in _gf(item, 'content') or []
-                    if _gf(part, 'type') == 'output_text' and _gf(part, 'text')
-                )
+                for part in _gf(item, 'content') or []:
+                    part_type = _gf(part, 'type')
+                    # A message part is 'output_text' or 'refusal'. Keeping only
+                    # the former loses the refusal entirely, and an item with
+                    # nothing but a refusal then parses to empty output — which
+                    # callers report as a failed call. A refusal is a real
+                    # answer (and for red teaming, the *resistant* outcome), so
+                    # it is carried as text rather than discarded.
+                    text = _gf(part, 'text') if part_type == 'output_text' else _gf(part, 'refusal')
+                    if part_type in ('output_text', 'refusal') and text:
+                        items.append(TextOutputItem(type='output_text', text=text, annotations=[], logprobs=[]))
+                    elif part_type not in ('output_text', 'refusal'):
+                        logger.warning(
+                            'AgentResponse.from_openresponses: skipping unknown message part type={!r}', part_type
+                        )
             # 'function_call' is the standard Responses shape; the Orq router
             # instead types agent tool calls as 'orq:<tool_name>' (e.g.
             # 'orq:query_knowledge_base'). Treat both as tool calls so the
@@ -833,7 +854,7 @@ class AgentResponse(BaseModel):
                         name=str(name),
                         call_id=str(call_id),
                         arguments=raw_args if isinstance(raw_args, str) else json.dumps(raw_args),
-                        result=str(result) if result is not None else None,
+                        result=tool_result_to_text(result) if result is not None else None,
                     )
                 )
             elif item_type == 'reasoning':
@@ -1342,4 +1363,5 @@ __all__ = [
     'ToolCallOutputItem',
     'ToolInfo',
     'content_to_text',
+    'tool_result_to_text',
 ]

--- a/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -32,6 +32,37 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Carried by other channels, so skipping them loses nothing: tool_use blocks are
+# read from ``msg.tool_calls``, and reasoning is dropped from ``output`` anyway.
+_NON_TEXT_BLOCKS_HANDLED_ELSEWHERE = frozenset({'tool_use', 'thinking', 'redacted_thinking'})
+
+
+def _lc_content_to_text(content: Any) -> str:
+    """Extract the text of a LangChain message's ``content``.
+
+    ``content`` is a plain string on OpenAI-backed models but a list of typed
+    blocks on Anthropic-backed ones — even for a turn that is purely text.
+    ``str()`` on that list yields its Python repr (``"[{'type': 'text', ...}]"``),
+    which then flows into transcripts, judges and reports looking like the
+    model's answer. Corrupted text is worse than missing text: a judge scores it
+    and nothing appears broken.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict):
+            kind = block.get('type')
+            if kind == 'text':
+                parts.append(str(block.get('text') or ''))
+            elif kind not in _NON_TEXT_BLOCKS_HANDLED_ELSEWHERE:
+                logger.warning('LangGraphTarget: dropping unrenderable content block type=%r', kind)
+    return ''.join(parts)
+
 
 class _TokenUsageCollector(BaseCallbackHandler):
     """Sync LangChain callback handler that accumulates token usage across LLM calls.
@@ -253,8 +284,7 @@ class LangGraphTarget(AgentTarget):
                 msg_content = getattr(msg, 'content', '')
                 tool_calls_iter = getattr(msg, 'tool_calls', None) or []
 
-            if not isinstance(msg_content, str):
-                msg_content = str(msg_content)
+            msg_content = _lc_content_to_text(msg_content)
             if msg_content:
                 output_items.append(TextOutputItem(text=msg_content, annotations=[]))
 
@@ -281,9 +311,7 @@ class LangGraphTarget(AgentTarget):
                 type(last).__name__,
             )
             last_content = last.get('content', '') if isinstance(last, dict) else getattr(last, 'content', '')
-            if not isinstance(last_content, str):
-                last_content = str(last_content)
-            output_items.append(TextOutputItem(text=last_content, annotations=[]))
+            output_items.append(TextOutputItem(text=_lc_content_to_text(last_content), annotations=[]))
         return AgentResponse(output=output_items, usage=usage)
 
     def reset_conversation(self) -> None:

--- a/src/evaluatorq/integrations/pydantic_ai_integration/target.py
+++ b/src/evaluatorq/integrations/pydantic_ai_integration/target.py
@@ -18,6 +18,7 @@ from evaluatorq.contracts import (
     TokenUsage,
     ToolCallOutputItem,
     content_to_text,
+    tool_result_to_text,
 )
 
 if TYPE_CHECKING:
@@ -218,8 +219,7 @@ def _build_output(result: Any) -> list[OutputMessage]:
                 idx = tool_index.get(call_id)
                 if idx is not None and isinstance(items[idx], ToolCallOutputItem):
                     out = getattr(part, 'content', '')
-                    out_str = out if isinstance(out, str) else str(out)
-                    items[idx] = items[idx].model_copy(update={'result': out_str})
+                    items[idx] = items[idx].model_copy(update={'result': tool_result_to_text(out)})
     return items
 
 

--- a/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -212,10 +212,16 @@ def _message_to_ai_sdk_message(m: Message, *, version: AISdkMessageFormat = 'v5'
             'toolCallId': m.tool_call_id or '',
             'toolName': m.name or '',
         }
+        # content_to_text, not the raw content: every other branch below goes
+        # through it, and a parts list assigned here would reach httpx as
+        # Pydantic models and die in json.dumps. The v5 shape is typed
+        # ``{type: 'text'}`` anyway, so text is all this can carry — better to
+        # raise NotImplementedError naming the part than to fail in the encoder.
+        result_text = content_to_text(m.content)
         if version == 'v4':
-            result_part['result'] = m.content or ''
+            result_part['result'] = result_text
         else:
-            result_part['output'] = {'type': 'text', 'value': m.content or ''}
+            result_part['output'] = {'type': 'text', 'value': result_text}
         return {'role': 'tool', 'content': [result_part]}
     if m.role == 'assistant' and m.tool_calls:
         parts: list[dict[str, Any]] = []

--- a/tests/contracts/test_agent_response_from_openresponses.py
+++ b/tests/contracts/test_agent_response_from_openresponses.py
@@ -154,3 +154,33 @@ def test_accepts_dict_and_object_shaped_response_items():
     assert json.loads(r.output[1].arguments) == {"q": "x"}
     assert r.usage is not None
     assert r.usage.total_tokens == 7
+
+
+def test_refusal_part_is_kept_as_text():
+    # A message part is 'output_text' or 'refusal'. Dropping the refusal left
+    # `output` empty, which callers report as a failed call — and for red
+    # teaming a refusal is the resistant outcome we are trying to measure.
+    r = AgentResponse.from_openresponses(_resp(
+        output=[{"type": "message", "content": [{"type": "refusal", "refusal": "I can't help with that."}]}],
+    ))
+    assert [type(i) for i in r.output] == [TextOutputItem]
+    assert r.text == "I can't help with that."
+
+
+def test_unknown_message_part_type_is_logged_and_skipped(caplog):
+    r = AgentResponse.from_openresponses(_resp(
+        output=[{"type": "message", "content": [{"type": "output_audio", "data": "..."}]}],
+    ))
+    assert r.output == []
+    assert "output_audio" in caplog.text
+
+
+def test_structured_tool_result_becomes_json_not_repr():
+    # str() would give "{'temp': 12}" — single quotes, unparseable downstream.
+    r = AgentResponse.from_openresponses(_resp(
+        output=[{"type": "function_call", "name": "f", "arguments": "{}", "call_id": "c1",
+                 "result": {"temp": 12, "ok": True}}],
+    ))
+    item = r.output[0]
+    assert isinstance(item, ToolCallOutputItem)
+    assert item.result == '{"temp": 12, "ok": true}'

--- a/tests/unit/test_langgraph_target.py
+++ b/tests/unit/test_langgraph_target.py
@@ -9,6 +9,8 @@ import pytest
 
 pytest.importorskip('langgraph')
 
+from langchain_core.messages import AIMessage  # noqa: E402
+
 from evaluatorq.contracts import Message  # noqa: E402
 from evaluatorq.integrations.langgraph_integration import LangGraphTarget  # noqa: E402
 from evaluatorq.redteam.contracts import AgentResponse  # noqa: E402
@@ -584,3 +586,51 @@ class TestLangGraphTargetTokenUsage:
         result = await target.respond([Message(role='user', content='hi')])
         # ainvoke mock doesn't fire callbacks, so collector gets no calls
         assert result.usage is None
+
+
+class TestAnthropicBlockContent:
+    """Claude-backed graphs return list-of-block content even for plain text.
+
+    ``str()`` on that list yields its Python repr, which used to land in
+    ``AgentResponse.text`` and flow on into transcripts and judges as if it were
+    the model's answer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_text_blocks_are_extracted_not_repr(self) -> None:
+        graph = MagicMock()
+        graph.name = 'test_graph'
+        msg = AIMessage(content=[{'type': 'text', 'text': 'Hello'}])
+        graph.ainvoke = AsyncMock(return_value={'messages': [msg]})
+
+        result = await LangGraphTarget(graph).respond([Message(role='user', content='hi')])
+        assert result.text == 'Hello'
+
+    @pytest.mark.asyncio
+    async def test_interleaved_text_blocks_are_joined(self) -> None:
+        graph = MagicMock()
+        graph.name = 'test_graph'
+        msg = AIMessage(
+            content=[
+                {'type': 'text', 'text': 'Let me check. '},
+                {'type': 'tool_use', 'id': 't1', 'name': 'search', 'input': {}},
+                {'type': 'text', 'text': 'Found it.'},
+            ]
+        )
+        graph.ainvoke = AsyncMock(return_value={'messages': [msg]})
+
+        result = await LangGraphTarget(graph).respond([Message(role='user', content='hi')])
+        # tool_use is read separately from .tool_calls, so it contributes no text.
+        assert result.text == 'Let me check. Found it.'
+
+    @pytest.mark.asyncio
+    async def test_unrenderable_block_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        graph = MagicMock()
+        graph.name = 'test_graph'
+        msg = AIMessage(content=[{'type': 'image', 'source': {}}, {'type': 'text', 'text': 'see above'}])
+        graph.ainvoke = AsyncMock(return_value={'messages': [msg]})
+
+        with caplog.at_level('WARNING'):
+            result = await LangGraphTarget(graph).respond([Message(role='user', content='hi')])
+        assert result.text == 'see above'
+        assert 'image' in caplog.text

--- a/tests/unit/test_pydantic_ai_target.py
+++ b/tests/unit/test_pydantic_ai_target.py
@@ -66,6 +66,18 @@ class TestPydanticAIRespond:
         assert tools[0].result == 'the answer'
 
     @pytest.mark.asyncio
+    async def test_structured_tool_return_is_json_not_repr(self) -> None:
+        # Tools routinely return a dict. str() gave "{'temp': 12, 'ok': True}" —
+        # data preserved on screen but unparseable by anything downstream.
+        parts = [
+            ToolCallPart(tool_name='weather', args={}, tool_call_id='c1'),
+            ToolReturnPart(tool_name='weather', content={'temp': 12, 'ok': True}, tool_call_id='c1'),
+        ]
+        res = await PydanticAITarget(_agent(_result([parts]))).respond(_user())
+        tools = [o for o in res.output if isinstance(o, ToolCallOutputItem)]
+        assert tools[0].result == '{"temp": 12, "ok": true}'
+
+    @pytest.mark.asyncio
     async def test_empty_text_part_skipped_then_falls_back_to_output(self) -> None:
         res = await PydanticAITarget(_agent(_result([[TextPart(content='')]], output='fallback'))).respond(_user())
         assert res.text == 'fallback'

--- a/tests/unit/test_vercel_ai_sdk_target.py
+++ b/tests/unit/test_vercel_ai_sdk_target.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
-from evaluatorq.contracts import FunctionCall, Message, StrategyToolCall
+from evaluatorq.contracts import (
+    FunctionCall,
+    InputImageContent,
+    InputTextContent,
+    Message,
+    StrategyToolCall,
+)
 from evaluatorq.integrations.vercel_ai_sdk_integration import VercelAISdkTarget
 from evaluatorq.integrations.vercel_ai_sdk_integration.target import (
+    _message_to_ai_sdk_message,
     _parse_data_stream,
     _parse_json_response,
 )
@@ -497,3 +505,38 @@ class TestVercelAISdkTargetAgentContext:
         target = VercelAISdkTarget("http://test/api/chat", agent_context=override)
         cloned = target.new()
         assert cloned._agent_context is override
+
+
+class TestToolResultContentParts:
+    """The tool branch used to assign `m.content` raw into the request body.
+
+    Every other branch of the converter goes through `content_to_text`; this one
+    skipped it, so a parts list reached httpx as Pydantic models and died in
+    json.dumps — every turn after a tool returned an image.
+    """
+
+    @pytest.mark.parametrize("version", ["v4", "v5"])
+    def test_text_parts_are_flattened(self, version: Literal["v4", "v5"]) -> None:
+        m = Message(
+            role="tool",
+            tool_call_id="c1",
+            name="lookup",
+            content=[InputTextContent(type="input_text", text="42")],
+        )
+        rendered = _message_to_ai_sdk_message(m, version=version)
+        part = rendered["content"][0]
+        assert (part["result"] if version == "v4" else part["output"]["value"]) == "42"
+
+    @pytest.mark.parametrize("version", ["v4", "v5"])
+    def test_image_part_raises_naming_the_part(self, version: Literal["v4", "v5"]) -> None:
+        # The AI SDK tool-result shape is typed `{type: 'text'}`, so an image
+        # cannot be carried. Failing here names the part; failing in the JSON
+        # encoder does not.
+        m = Message(
+            role="tool",
+            tool_call_id="c1",
+            name="screenshot",
+            content=[InputImageContent(type="input_image", image_url="https://x/y.png")],
+        )
+        with pytest.raises(NotImplementedError, match="input_image"):
+            _message_to_ai_sdk_message(m, version=version)


### PR DESCRIPTION
Follow-up to #119. RES-1231 was one instance of a pattern — code assuming a narrower type than the model declares, losing data silently — so I audited the rest of the conversion surface. Six instances; these are the four worth fixing together. RES-1238 tracks the other two plus the full audit.

### LangGraph target wrote a Python repr into `AgentResponse.text`

`AIMessage.content` is a list of typed blocks on Anthropic-backed models, even for a plain-text turn. `str()` on it produced `"[{'type': 'text', 'text': 'Hello'}]"`, which flowed into transcripts, judges and reports.

Corrupted text is worse than missing text — a judge scores it and nothing looks broken. Now extracts text blocks and warns on anything unrenderable, skipping only blocks carried elsewhere (`tool_use` comes from `.tool_calls`, reasoning is dropped from `output` by design).

### Refusals were dropped, then reported as a failure

`from_openresponses` kept only `output_text` parts. A response whose only part is a `refusal` parsed to empty `output` and tripped `"response contained no extractable output items"`.

That inverts a red-team result: a refusal is the *resistant* outcome we're measuring, and we turned it into a run error. Refusal text is carried through now, and unknown part types get the same warning unknown item types already had.

### Vercel AI SDK target crashed on multi-part tool results

Its tool branch assigned `m.content` raw into a body posted with `json=`, while every other branch went through `content_to_text`. A tool returning an image gave `TypeError: Object of type InputImageContent is not JSON serializable` on every following turn. Now uses `content_to_text`, so an image raises `NotImplementedError` naming the part rather than failing inside the encoder.

### Structured tool results became Python reprs

A tool returning `{"temp": 12}` rendered as `"{'temp': 12}"` — visible but unparseable. New `tool_result_to_text` helper emits JSON, applied at both sites (`from_openresponses` and the pydantic-ai target).

Worth noting on the "keep it as an object" question: we can't. `result` ends up as a tool `Message.content`, typed `str | list[ContentPart] | None`. JSON is the lossless option available.

## Testing

11 new tests, each failing before its fix. `ruff check src`, `ruff format --check src`, bare `basedpyright`, and `pytest -m 'not integration'` (3771 passed) all clean locally.