### PR TITLE
ci: sync releases to Linear

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,17 @@ jobs:
         with:
           password: ${{ secrets.PYPI_TOKEN }}
 
+      # Sync the released commits to Linear (scans commits for issue IDs and
+      # creates/updates the release there). Cosmetic like the notes below — never
+      # fail a run whose package already published.
+      - name: Sync release to Linear
+        if: steps.ver.outputs.released == 'true'
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ steps.ver.outputs.tag }}
+
       # Release notes are cosmetic — create them LAST and never let a notes hiccup
       # fail a run whose package already published (that half-release bit us before).
       - name: Create GitHub Release


### PR DESCRIPTION
Adds [linear/linear-release-action](https://github.com/linear/linear-release-action) to `release.yml` so tagged releases land in Linear's release pipeline (scans the released commits for issue IDs).

- Runs after the PyPI publish, `continue-on-error` — same treatment as the GitHub release notes. A Linear hiccup must never fail a run whose package already published.
- Uses the default `sync` command, `version` = the pushed tag.
- `LINEAR_ACCESS_KEY` repo secret is already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)