### PR TITLE
ci(coverage): measure coverage on the 3.13 leg and publish a README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
     name: Typecheck + test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only the 3.13 leg publishes coverage (see the two conditional steps below).
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +59,25 @@ jobs:
         run: uv run basedpyright
 
       - name: Test (unit only)
+        if: matrix.python-version != '3.13'
         run: uv run pytest -m 'not integration'
+
+      # Coverage instrumentation costs wall-clock, so only the canonical leg pays
+      # for it. The other legs run the same suite bare, above.
+      - name: Test (unit only, with coverage)
+        if: matrix.python-version == '3.13'
+        run: uv run pytest -m 'not integration' --cov --cov-report=term
+
+      # Posts a coverage comment on PRs and, on push to main, writes badge +
+      # report data to the `python-coverage-comment-action-data` branch. Uses the
+      # built-in GITHUB_TOKEN — no secret to configure. Fork PRs get a read-only
+      # token, so the comment is skipped there; the badge still updates on main.
+      - name: Coverage badge + PR comment
+        if: matrix.python-version == '3.13'
+        uses: py-cov-action/python-coverage-comment-action@v3
+        continue-on-error: true
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
 
   examples:
     name: Examples (static)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/evaluatorq.svg)](https://pypi.org/project/evaluatorq/)
 [![Python versions](https://img.shields.io/pypi/pyversions/evaluatorq.svg)](https://pypi.org/project/evaluatorq/)
 [![CI](https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/orq-ai/evaluatorq/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/orq-ai/evaluatorq/blob/python-coverage-comment-action-data/htmlcov/index.html)
 [![Docs CI](https://img.shields.io/github/actions/workflow/status/orq-ai/evaluatorq/docs.yml?branch=main&label=Docs%20CI)](https://github.com/orq-ai/evaluatorq/actions/workflows/docs.yml)
 [![Docs Site](https://img.shields.io/badge/Docs-Live%20Site-0A7B83)](https://orq-ai.github.io/evaluatorq/)
 [![Release](https://github.com/orq-ai/evaluatorq/actions/workflows/release.yml/badge.svg)](https://github.com/orq-ai/evaluatorq/actions/workflows/release.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,19 @@ markers = [
 ]
 timeout = 120
 
+[tool.coverage.run]
+source = [ "src/evaluatorq" ]
+# relative_files is required by python-coverage-comment-action — the CI job runs
+# coverage in a different absolute path than the action reads it back from.
+relative_files = true
+
+[tool.coverage.report]
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "@overload",
+]
+
 [tool.ruff]
 line-length = 120
 preview = true


### PR DESCRIPTION
## What

CI ran the unit suite four times across the version matrix without ever measuring coverage — no number to point at, no signal when a change drops it. This adds coverage measurement and a README badge.

- **`pyproject.toml`** — `[tool.coverage.run]` scoped to `src/evaluatorq`, with `relative_files = true` (the action requires it; CI writes the data in a different absolute path than the action reads it back from). `exclude_also` skips `TYPE_CHECKING` blocks, `NotImplementedError` bodies, and `@overload` stubs.
- **`.github/workflows/ci.yml`** — the canonical 3.13 leg runs `pytest -m 'not integration' --cov`; the other matrix legs run the suite bare. Instrumentation costs wall-clock the compatibility legs don't need to pay 4×. Then `py-cov-action/python-coverage-comment-action@v3` publishes the result.
- **`README.md`** — coverage badge next to the CI badge, linking the HTML report.

## Baseline

**81%** — 23787 statements, 4525 missed, across 3851 unit tests.

## Why this action over Codecov

No secret, no PAT, no external service account: it uses the built-in `GITHUB_TOKEN`. On PRs it comments the coverage delta; on push to `main` it writes badge + HTML report data to a dedicated `python-coverage-comment-action-data` branch. That branch is not `main`, so the `Protect-main` ruleset is untouched.

Verified `repos/orq-ai/evaluatorq/actions/permissions/workflow` returns `default_workflow_permissions: "write"`, so the job-level `contents: write` grant actually lands. **Nothing to configure on merge.**

## Expected, not bugs

- The badge 404s until the first push to `main` creates the data branch. On this PR you get the coverage comment, not the badge.
- Fork PRs get a read-only token, so the comment is skipped there; the badge still updates on `main`. Fixable later with the action's `workflow_run` companion — skipped as YAGNI for an internal repo.
- The badge step is `continue-on-error`: a badge-publishing hiccup should never turn CI red.

## Deliberately skipped

No `fail_under` gate. Add one when there's a number worth defending — 81% would be the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)