### PR TITLE
fix(dashboard): backfill full manifest summary; scope fingerprint to reports

### DIFF
--- a/src/evaluatorq/common/run_manifest.py
+++ b/src/evaluatorq/common/run_manifest.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from evaluatorq.contracts import (
-    RUN_SUMMARY_TOTAL_KEY,
+    RUN_SUMMARY_VERSION,
     ManifestStatus,
     RunManifest,
     RunSummary,
@@ -136,9 +136,12 @@ class ManifestWriter:
         if report_path is not None:
             self.manifest.report_path = str(report_path)
         # Compact headline stats so a run-list row can be built from the manifest
-        # alone — no full-report read needed for completed runs.
+        # alone — no full-report read needed for completed runs. Stamped with the
+        # shape's version here, the one place a summary is stored, so no writer
+        # can persist an unversioned (or stale-shaped) one.
         if summary is not None:
             self.manifest.summary = summary
+            self.manifest.summary_version = RUN_SUMMARY_VERSION
         self.flush()
 
     def cancel(self) -> None:
@@ -207,22 +210,18 @@ def list_manifests(runs_dir: Path) -> list[RunManifest]:
     return sorted(out, key=lambda m: m.started_at, reverse=True)
 
 
-def summary_is_complete(summary: RunSummary | None) -> bool:
-    """Whether a manifest ``summary`` carries a full run-list row.
+def summary_is_current(manifest: RunManifest) -> bool:
+    """Whether *manifest* carries a summary of the current shape.
 
-    A summary written by a run writer (``manifest_summary()`` on the report
-    model) always carries more than ``total_results``; an early version of the
-    dashboard's legacy backfill wrote that one field alone, which renders the
-    dashboard card fine but blanks the pipeline / agents / rate columns of
-    ``eq redteam runs``. Such a sidecar reads as incomplete, so callers fall back
-    to the full report (and the dashboard rewrites the sidecar on its next scan).
-
-    ponytail: "more than total_results", not a per-surface required-key list — a
-    second list of the fields each surface writes is exactly the drift this
-    guards against. Tighten to per-surface keys only if a writer summary ever
-    legitimately shrinks.
+    A stamp comparison, not a shape guess: the summary is usable only when it was
+    written by a ``manifest_summary()`` of today's ``RUN_SUMMARY_VERSION``.
+    Anything older — an unstamped sidecar from before versioning, or the thin
+    ``{'total_results': N}`` an early dashboard backfill wrote — is not usable,
+    so callers fall back to the full report (and the dashboard rewrites the
+    sidecar on its next scan). Bumping ``RUN_SUMMARY_VERSION`` when a surface's
+    summary shape changes re-reads every stored run exactly once.
     """
-    return bool(summary) and not set(summary).issubset({RUN_SUMMARY_TOTAL_KEY})
+    return bool(manifest.summary) and manifest.summary_version == RUN_SUMMARY_VERSION
 
 
 def iter_report_files(runs_dir: Path) -> Iterator[Path]:
@@ -256,7 +255,7 @@ def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | No
     * A LEGACY report with no manifest yields ``(None, report_path)`` — the
       backwards-compatible path (read the full report for its stats). A completed
       manifest whose ``summary`` is too thin to build a row (see
-      :func:`summary_is_complete`) is demoted to this path rather than listed
+      :func:`summary_is_current`) is demoted to this path rather than listed
       with blank columns.
 
     Reports already covered by a manifest's ``report_path`` are de-duplicated out
@@ -267,7 +266,7 @@ def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | No
     covered: set[Path] = set()
     for m in list_manifests(runs_dir):
         report_path = Path(m.report_path) if m.report_path else None
-        if m.status == ManifestStatus.COMPLETED and report_path is not None and not summary_is_complete(m.summary):
+        if m.status == ManifestStatus.COMPLETED and report_path is not None and not summary_is_current(m):
             # Thin sidecar: leave the report uncovered so the legacy full-report
             # row below carries the run instead of a half-blank manifest row.
             continue

--- a/src/evaluatorq/common/run_manifest.py
+++ b/src/evaluatorq/common/run_manifest.py
@@ -201,6 +201,24 @@ def list_manifests(runs_dir: Path) -> list[RunManifest]:
     return sorted(out, key=lambda m: m.started_at, reverse=True)
 
 
+def summary_is_complete(summary: RunSummary | None) -> bool:
+    """Whether a manifest ``summary`` carries a full run-list row.
+
+    A summary written by a run writer (``manifest_summary()`` on the report
+    model) always carries more than ``total_results``; an early version of the
+    dashboard's legacy backfill wrote that one field alone, which renders the
+    dashboard card fine but blanks the pipeline / agents / rate columns of
+    ``eq redteam runs``. Such a sidecar reads as incomplete, so callers fall back
+    to the full report (and the dashboard rewrites the sidecar on its next scan).
+
+    ponytail: "more than total_results", not a per-surface required-key list — a
+    second list of the fields each surface writes is exactly the drift this
+    guards against. Tighten to per-surface keys only if a writer summary ever
+    legitimately shrinks.
+    """
+    return bool(summary) and not set(summary).issubset({'total_results'})
+
+
 def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | None]]:
     """Unified, manifest-first run listing for a runs dir, newest first.
 
@@ -210,7 +228,10 @@ def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | No
       runs carry a ``report_path``; in-flight (running/error/cancelled) runs have
       ``None`` — they render from the manifest's status/stage/summary alone.
     * A LEGACY report with no manifest yields ``(None, report_path)`` — the
-      backwards-compatible path (read the full report for its stats).
+      backwards-compatible path (read the full report for its stats). A completed
+      manifest whose ``summary`` is too thin to build a row (see
+      :func:`summary_is_complete`) is demoted to this path rather than listed
+      with blank columns.
 
     Reports already covered by a manifest's ``report_path`` are de-duplicated out
     of the legacy set, so a run is never listed twice. Sorted newest-first by
@@ -219,9 +240,12 @@ def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | No
     records: list[tuple[RunManifest | None, Path | None, float]] = []
     covered: set[Path] = set()
     for m in list_manifests(runs_dir):
-        report_path: Path | None = None
-        if m.report_path:
-            report_path = Path(m.report_path)
+        report_path = Path(m.report_path) if m.report_path else None
+        if m.status == ManifestStatus.COMPLETED and report_path is not None and not summary_is_complete(m.summary):
+            # Thin sidecar: leave the report uncovered so the legacy full-report
+            # row below carries the run instead of a half-blank manifest row.
+            continue
+        if report_path is not None:
             covered.add(report_path.resolve())
         records.append((m, report_path, m.started_at.timestamp()))
 

--- a/src/evaluatorq/common/run_manifest.py
+++ b/src/evaluatorq/common/run_manifest.py
@@ -23,11 +23,12 @@ import operator
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from evaluatorq.contracts import (
+    RUN_SUMMARY_TOTAL_KEY,
     ManifestStatus,
     RunManifest,
     RunSummary,
@@ -37,7 +38,12 @@ from evaluatorq.contracts import (
     ManifestSurface as Surface,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 MANIFESTS_DIR_NAME = '.manifests'
+# Stage artifacts (save='detail') sit beside reports but are not runs.
+_ARTIFACT_PREFIXES = ('01_', '02_', '03_')
 
 
 def _manifests_dir(runs_dir: Path) -> Path:
@@ -216,7 +222,27 @@ def summary_is_complete(summary: RunSummary | None) -> bool:
     guards against. Tighten to per-surface keys only if a writer summary ever
     legitimately shrinks.
     """
-    return bool(summary) and not set(summary).issubset({'total_results'})
+    return bool(summary) and not set(summary).issubset({RUN_SUMMARY_TOTAL_KEY})
+
+
+def iter_report_files(runs_dir: Path) -> Iterator[Path]:
+    """Report files in *runs_dir*, sorted: non-recursive ``*.json`` minus stage artifacts.
+
+    The one definition of "is a report" shared by every reader — the run listings
+    here, the dashboard's scan and its store fingerprint. ``save='detail'`` writes
+    ``01_``/``02_``/``03_`` stage artifacts next to reports; they are not runs, and
+    a reader that globs them lists phantom rows (and invalidates caches) for files
+    nothing renders.
+
+    Yields:
+        Each report file in *runs_dir*, in sorted path order. Nothing when the
+        directory does not exist.
+    """
+    if not runs_dir.is_dir():
+        return
+    for p in sorted(runs_dir.glob('*.json')):
+        if not p.name.startswith(_ARTIFACT_PREFIXES):
+            yield p
 
 
 def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | None]]:
@@ -250,7 +276,7 @@ def list_run_records(runs_dir: Path) -> list[tuple[RunManifest | None, Path | No
         records.append((m, report_path, m.started_at.timestamp()))
 
     if runs_dir.is_dir():
-        for p in runs_dir.glob('*.json'):
+        for p in iter_report_files(runs_dir):
             try:
                 if p.resolve() in covered:
                     continue

--- a/src/evaluatorq/contracts.py
+++ b/src/evaluatorq/contracts.py
@@ -1433,6 +1433,17 @@ class ManifestStatus(StrEnum):
 # populate — a typo here can't silently read back as 0.
 RUN_SUMMARY_TOTAL_KEY = 'total_results'
 
+RUN_SUMMARY_VERSION = 1
+"""Format version of ``RunManifest.summary``, stamped by ``ManifestWriter.complete()``.
+
+**Bump this whenever a surface's ``manifest_summary()`` changes shape** (a key
+added, renamed, or dropped). Readers compare the stamp instead of guessing
+whether a stored summary is current: an older or unstamped summary is re-read
+from the full report rather than rendered with blank columns. Without it a
+partially-populated summary reads as complete forever, which is how a thin
+backfill silently blanked the ``runs`` tables (RES-1276).
+"""
+
 
 class RunSummary(TypedDict, total=False):
     """Compact headline stats stashed on ``RunManifest.summary`` at completion.
@@ -1498,6 +1509,15 @@ class RunManifest(BaseModel):
             'without reading the full report. Small scalars / short lists only — never full results.'
         ),
     )
+    summary_version: int | None = Field(
+        default=None,
+        description=(
+            'Format version of the summary above (see RUN_SUMMARY_VERSION), stamped when it is '
+            'written. None for manifests saved before versioning, and for a manifest with no '
+            'summary at all; either way a reader treats the summary as not current and falls back '
+            'to the full report.'
+        ),
+    )
 
     @property
     def duration_seconds(self) -> float | None:
@@ -1512,6 +1532,7 @@ __all__ = [
     'DEFAULT_TARGET_TIMEOUT_MS',
     'JURY_RAW_OUTPUT_KEY',
     'RUN_SUMMARY_TOTAL_KEY',
+    'RUN_SUMMARY_VERSION',
     'AgentContext',
     'AgentResponse',
     'AgentResponseError',

--- a/src/evaluatorq/dashboard/library.py
+++ b/src/evaluatorq/dashboard/library.py
@@ -13,14 +13,13 @@ from typing import TYPE_CHECKING, TypeVar
 
 from loguru import logger
 
-from evaluatorq.common.run_manifest import MANIFESTS_DIR_NAME, summary_is_complete
+from evaluatorq.common.run_manifest import MANIFESTS_DIR_NAME, iter_report_files, summary_is_complete
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
     from evaluatorq.contracts import RunManifest
 
-_ARTIFACT_PREFIXES = ('01_', '02_', '03_')
 _Model = TypeVar('_Model')
 
 
@@ -143,12 +142,13 @@ def default_roots() -> list[Path]:
 
 
 def _iter_report_files(roots: list[Path]) -> Iterator[Path]:
+    """Report files across *roots* — the shared per-dir predicate, flattened.
+
+    Yields:
+        Each report file, root by root, sorted within a root.
+    """
     for root in roots:
-        if not root.is_dir():
-            continue
-        for p in sorted(root.glob('*.json')):
-            if not p.name.startswith(_ARTIFACT_PREFIXES):
-                yield p
+        yield from iter_report_files(root)
 
 
 def _card(path: Path) -> ReportCard | None:
@@ -295,8 +295,11 @@ def _backfill_manifest(path: Path, card: ReportCard) -> None:
     try:
         # Full model validate (mtime-keyed LRU): the price of one migration read.
         summary = ADAPTERS[card.surface].load(path).manifest_summary()
-    except Exception as exc:  # a report we can't model is simply not migrated
-        logger.debug(f'Skipping manifest backfill for {path}: {exc}')
+    except Exception as exc:
+        # The card already parsed, so a model failure here is a schema mismatch,
+        # not routine noise: warn (as list_manifests does) rather than migrate
+        # silently-never. The run still lists via the full-report path.
+        logger.warning(f'Skipping manifest backfill for {path}: {exc}')
         return
     manifest = RunManifest(
         run_id=path.stem,
@@ -328,7 +331,7 @@ def scan(roots: list[Path] | None = None) -> list[ReportCard]:
     inside another's expansion — and a duplicated root would double-count every
     report in the landing rollups (jobs, spend, costed runs).
     """
-    from evaluatorq.common.run_manifest import list_manifests
+    from evaluatorq.common.run_manifest import list_run_records
 
     roots = roots or default_roots()
     seen_roots: set[Path] = set()
@@ -338,26 +341,17 @@ def scan(roots: list[Path] | None = None) -> list[ReportCard]:
         if resolved not in seen_roots:
             seen_roots.add(resolved)
             deduped_roots.append(root)
-    roots = deduped_roots
     cards: list[ReportCard] = []
-    covered: set[Path] = set()
-    for root in roots:
-        for m in list_manifests(root):
-            # A completed manifest whose summary is too thin to build a full
-            # `eq runs` row is ignored here: leaving its report uncovered sends
-            # it down the legacy full-read path, which rewrites the sidecar.
-            if m.status.value == 'completed' and m.report_path and not summary_is_complete(m.summary):
-                continue
-            card = _card_from_manifest(m)
-            cards.append(card)
-            if card.path is not None:
-                covered.add(card.path.resolve())
-    for p in _iter_report_files(roots):
-        if p.resolve() in covered:
-            continue
-        if (c := _card(p)) is not None:
-            cards.append(c)
-            _backfill_manifest(p, c)
+    for root in deduped_roots:
+        # list_run_records owns manifest-first ordering, report de-duplication and
+        # the demotion of thin-summary sidecars to a legacy row — the CLI run
+        # tables read the same function, so the two views can't drift apart.
+        for manifest, path in list_run_records(root):
+            if manifest is not None:
+                cards.append(_card_from_manifest(manifest))
+            elif path is not None and (c := _card(path)) is not None:
+                cards.append(c)
+                _backfill_manifest(path, c)
     return sorted(cards, key=lambda c: c.created_at, reverse=True)
 
 

--- a/src/evaluatorq/dashboard/library.py
+++ b/src/evaluatorq/dashboard/library.py
@@ -13,12 +13,13 @@ from typing import TYPE_CHECKING, TypeVar
 
 from loguru import logger
 
-from evaluatorq.common.run_manifest import MANIFESTS_DIR_NAME, iter_report_files, summary_is_complete
+from evaluatorq.common.run_manifest import MANIFESTS_DIR_NAME, iter_report_files
+from evaluatorq.contracts import RUN_SUMMARY_VERSION
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
-    from evaluatorq.contracts import RunManifest
+    from evaluatorq.contracts import RunManifest, RunSummary
 
 _Model = TypeVar('_Model')
 
@@ -261,47 +262,45 @@ def fingerprint(roots: list[Path] | None = None) -> tuple[int, int]:
 
 
 def _backfill_manifest(path: Path, card: ReportCard) -> None:
-    """Write a manifest sidecar for a legacy (manifest-less) report.
+    """Write (or re-stamp) a manifest sidecar for a report the run list read in full.
 
     Migration-on-read: the first scan pays the full-report read it already pays
     today, then leaves a tiny ``.manifests/`` sidecar behind so every later scan
     (and ``eq runs``) builds this row from the manifest alone. No separate
-    migration command to run — the runs dir heals itself as it is browsed.
+    migration command to run — the runs dir heals itself as it is browsed. That
+    covers both a legacy manifest-less report and a sidecar whose summary predates
+    the current ``RUN_SUMMARY_VERSION``.
 
     The summary comes from the report model's own ``manifest_summary()`` — the
     same builder the live runners use — so a backfilled row is field-identical
     to one written by the run itself.
 
-    Best-effort in every direction: a complete existing sidecar is never
-    overwritten (a thin one from an earlier version is), an errored/pairwise
-    report is skipped (pairwise has no ``ManifestSurface``), and a failed read or
-    write only costs the next scan another full read.
+    An existing sidecar is *patched*, never rebuilt: a real run's manifest carries
+    a true ``started_at`` and a stage history that the report cannot reconstruct,
+    and a shape bump must not cost that.
+
+    Best-effort in every direction: a current sidecar is left alone, an
+    errored/pairwise report is skipped (pairwise has no ``ManifestSurface``), and
+    a failed read or write only costs the next scan another full read.
     """
-    from evaluatorq.common.run_manifest import ManifestWriter
+    from evaluatorq.common.run_manifest import ManifestWriter, summary_is_current
     from evaluatorq.contracts import ManifestStatus, ManifestSurface, RunManifest
-    from evaluatorq.dashboard.surfaces import ADAPTERS
 
     if card.error or card.surface not in (ManifestSurface.SIM, ManifestSurface.REDTEAM):
         return
     mpath = path.parent / MANIFESTS_DIR_NAME / f'{path.stem}.json'
+    existing: RunManifest | None = None
     if mpath.exists():
         try:
-            existing = read_json_cached(mpath)
-        except (json.JSONDecodeError, OSError):
-            existing = {}
-        raw = existing.get('summary')
-        if summary_is_complete(raw if isinstance(raw, dict) else None):
+            existing = RunManifest.model_validate_json(mpath.read_text(encoding='utf-8'))
+        except (ValueError, OSError) as exc:
+            logger.warning(f'Rewriting unreadable run manifest {mpath}: {exc}')
+        if existing is not None and summary_is_current(existing):
             return
-    try:
-        # Full model validate (mtime-keyed LRU): the price of one migration read.
-        summary = ADAPTERS[card.surface].load(path).manifest_summary()
-    except Exception as exc:
-        # The card already parsed, so a model failure here is a schema mismatch,
-        # not routine noise: warn (as list_manifests does) rather than migrate
-        # silently-never. The run still lists via the full-report path.
-        logger.warning(f'Skipping manifest backfill for {path}: {exc}')
+    summary = _report_summary(path, card.surface)
+    if summary is None:
         return
-    manifest = RunManifest(
+    manifest = existing or RunManifest(
         run_id=path.stem,
         surface=ManifestSurface(card.surface),
         run_name=card.name,
@@ -310,9 +309,27 @@ def _backfill_manifest(path: Path, card: ReportCard) -> None:
         updated_at=card.created_at,
         ended_at=card.created_at,
         report_path=str(path),
-        summary=summary,
     )
+    # complete() is a no-op on an already-terminal manifest, so stamp directly —
+    # ManifestWriter.flush() is still the single writer of a sidecar.
+    manifest.summary = summary
+    manifest.summary_version = RUN_SUMMARY_VERSION
     ManifestWriter(manifest, mpath).flush()
+
+
+def _report_summary(path: Path, surface: str) -> RunSummary | None:
+    """``manifest_summary()`` of the report at *path*, or ``None`` if it won't model."""
+    from evaluatorq.dashboard.surfaces import ADAPTERS
+
+    try:
+        # Full model validate (mtime-keyed LRU): the price of one migration read.
+        return ADAPTERS[surface].load(path).manifest_summary()
+    except Exception as exc:
+        # The card already parsed, so a model failure here is a schema mismatch,
+        # not routine noise: warn (as list_manifests does) rather than migrate
+        # silently-never. The run still lists via the full-report path.
+        logger.warning(f'Skipping manifest backfill for {path}: {exc}')
+        return None
 
 
 def scan(roots: list[Path] | None = None) -> list[ReportCard]:

--- a/src/evaluatorq/dashboard/library.py
+++ b/src/evaluatorq/dashboard/library.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from loguru import logger
 
-from evaluatorq.common.run_manifest import MANIFESTS_DIR_NAME
+from evaluatorq.common.run_manifest import MANIFESTS_DIR_NAME, summary_is_complete
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -234,10 +234,14 @@ def fingerprint(roots: list[Path] | None = None) -> tuple[int, int]:
     """``(file count, newest mtime_ns)`` across every run store — a cheap staleness key.
 
     Callers cache expensive whole-store aggregates against this: one stat sweep
-    (~5 ms per 1000 files) instead of re-reading every report. Reports are
-    write-once, so a new run always bumps the count; manifests are *not* (an
-    in-flight run rewrites its own on every stage), so ``.manifests/`` is swept
-    too and the newest mtime catches that stage advance.
+    instead of re-reading every report. Reports are write-once, so a new run
+    always bumps the count; manifests are *not* (an in-flight run rewrites its
+    own on every stage), so ``.manifests/`` is swept too and the newest mtime
+    catches that stage advance.
+
+    The report sweep goes through :func:`_iter_report_files`, the same predicate
+    the aggregate itself reads, so stage artifacts (``01_``/``02_``/``03_``) that
+    no aggregate looks at can't invalidate the cache when they are rewritten.
 
     Unreadable entries are skipped rather than raised on: a fingerprint that
     fails is a dashboard that fails, and a missed file only costs staleness
@@ -247,7 +251,7 @@ def fingerprint(roots: list[Path] | None = None) -> tuple[int, int]:
     count = 0
     newest = 0
     for root in roots:
-        for p in (*root.glob('*.json'), *(root / MANIFESTS_DIR_NAME).glob('*.json')):
+        for p in (*_iter_report_files([root]), *(root / MANIFESTS_DIR_NAME).glob('*.json')):
             count += 1
             try:
                 newest = max(newest, p.stat().st_mtime_ns)
@@ -264,20 +268,36 @@ def _backfill_manifest(path: Path, card: ReportCard) -> None:
     (and ``eq runs``) builds this row from the manifest alone. No separate
     migration command to run — the runs dir heals itself as it is browsed.
 
-    Best-effort in every direction: an existing sidecar is never overwritten, an
-    errored/pairwise report is skipped (pairwise has no ``ManifestSurface``), and
-    a failed write only costs the next scan another full read.
+    The summary comes from the report model's own ``manifest_summary()`` — the
+    same builder the live runners use — so a backfilled row is field-identical
+    to one written by the run itself.
+
+    Best-effort in every direction: a complete existing sidecar is never
+    overwritten (a thin one from an earlier version is), an errored/pairwise
+    report is skipped (pairwise has no ``ManifestSurface``), and a failed read or
+    write only costs the next scan another full read.
     """
     from evaluatorq.common.run_manifest import ManifestWriter
     from evaluatorq.contracts import ManifestStatus, ManifestSurface, RunManifest
+    from evaluatorq.dashboard.surfaces import ADAPTERS
 
     if card.error or card.surface not in (ManifestSurface.SIM, ManifestSurface.REDTEAM):
         return
     mpath = path.parent / MANIFESTS_DIR_NAME / f'{path.stem}.json'
     if mpath.exists():
+        try:
+            existing = read_json_cached(mpath)
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+        raw = existing.get('summary')
+        if summary_is_complete(raw if isinstance(raw, dict) else None):
+            return
+    try:
+        # Full model validate (mtime-keyed LRU): the price of one migration read.
+        summary = ADAPTERS[card.surface].load(path).manifest_summary()
+    except Exception as exc:  # a report we can't model is simply not migrated
+        logger.debug(f'Skipping manifest backfill for {path}: {exc}')
         return
-    _, data = load_surface(path)  # mtime-keyed LRU hit — _card just read this file
-    total = data.get('total_results')
     manifest = RunManifest(
         run_id=path.stem,
         surface=ManifestSurface(card.surface),
@@ -287,7 +307,7 @@ def _backfill_manifest(path: Path, card: ReportCard) -> None:
         updated_at=card.created_at,
         ended_at=card.created_at,
         report_path=str(path),
-        summary={'total_results': total if isinstance(total, int) else 0},
+        summary=summary,
     )
     ManifestWriter(manifest, mpath).flush()
 
@@ -323,6 +343,11 @@ def scan(roots: list[Path] | None = None) -> list[ReportCard]:
     covered: set[Path] = set()
     for root in roots:
         for m in list_manifests(root):
+            # A completed manifest whose summary is too thin to build a full
+            # `eq runs` row is ignored here: leaving its report uncovered sends
+            # it down the legacy full-read path, which rewrites the sidecar.
+            if m.status.value == 'completed' and m.report_path and not summary_is_complete(m.summary):
+                continue
             card = _card_from_manifest(m)
             cards.append(card)
             if card.path is not None:

--- a/src/evaluatorq/redteam/cli.py
+++ b/src/evaluatorq/redteam/cli.py
@@ -841,6 +841,9 @@ def runs(
                 'total_attacks': summary.get('total_attacks', summary.get('total_results')),
                 'vulnerability_rate': summary.get('vulnerability_rate'),
                 'file': report_path.name if report_path is not None else None,
+                # Which summary shape these stats came from; None on a legacy row
+                # built by reading the report itself (see RUN_SUMMARY_VERSION).
+                'summary_version': manifest.summary_version,
             }
         # Legacy report with no manifest — read the full report for its stats.
         if report_path is None:
@@ -864,6 +867,7 @@ def runs(
             'total_attacks': summary.get('total_attacks', data.get('total_results')),
             'vulnerability_rate': summary.get('vulnerability_rate'),
             'file': report_path.name,
+            'summary_version': None,  # read from the report, not from a stored summary
         }
 
     rows: list[dict[str, Any]] = []

--- a/src/evaluatorq/redteam/contracts.py
+++ b/src/evaluatorq/redteam/contracts.py
@@ -22,7 +22,7 @@ from pydantic import (
 from typing_extensions import NotRequired, TypedDict
 
 from evaluatorq.common.target_call import classify_error_type as classify_error_type
-from evaluatorq.contracts import StrEnum
+from evaluatorq.contracts import RunSummary, StrEnum
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
@@ -1680,6 +1680,23 @@ class RedTeamReport(BaseModel):
         'Explorer sample count. None when the upload failed or was skipped (uploaded_count then records the '
         'attempt) or the report predates this field — None with a set uploaded_count means "not confirmed".',
     )
+
+    def manifest_summary(self) -> RunSummary:
+        """Compact run-list summary stored on this run's ``RunManifest``.
+
+        Single source of truth for the shape: the runner writes it on completion
+        and the dashboard's backfill writes it for legacy reports. `eq redteam
+        runs` reads every field here, so a second hand-rolled shape silently
+        blanks columns.
+        """
+        return {
+            'pipeline': self.pipeline.value,
+            'total_results': self.total_results,
+            'total_attacks': self.summary.total_attacks,
+            'vulnerability_rate': self.summary.vulnerability_rate,
+            'resistance_rate': self.summary.resistance_rate,
+            'tested_agents': list(self.tested_agents),
+        }
 
     @field_validator('pipeline', mode='before')
     @classmethod

--- a/src/evaluatorq/redteam/runner.py
+++ b/src/evaluatorq/redteam/runner.py
@@ -1130,17 +1130,7 @@ async def red_team(
             # Only mark completion after the user completion hook succeeds.  If
             # it raises, the lifecycle context above records the surfaced error.
             if manifest_writer is not None:
-                manifest_writer.complete(
-                    report_path=run_path,
-                    summary={
-                        'pipeline': report.pipeline.value,
-                        'total_results': report.total_results,
-                        'total_attacks': report.summary.total_attacks,
-                        'vulnerability_rate': report.summary.vulnerability_rate,
-                        'resistance_rate': report.summary.resistance_rate,
-                        'tested_agents': list(report.tested_agents),
-                    },
-                )
+                manifest_writer.complete(report_path=run_path, summary=report.manifest_summary())
 
             return report
 

--- a/src/evaluatorq/simulation/api.py
+++ b/src/evaluatorq/simulation/api.py
@@ -1336,15 +1336,7 @@ async def _simulate_core(
         # compact summary (the exact fields the `runs` table + dashboard sim card
         # render) so a list row needs zero full-report reads.
         if manifest_writer is not None:
-            manifest_writer.complete(
-                report_path=saved_path,
-                summary={
-                    'mode': run.mode,
-                    'target_kind': run.target_kind,
-                    'total_results': run.total_results,
-                    'scorer_averages': dict(run.scorer_averages),
-                },
-            )
+            manifest_writer.complete(report_path=saved_path, summary=run.manifest_summary())
     except SimulationCancelledError:
         # A declined on_confirm is a clean cancel, not a failure (Dec1): the run
         # is 'cancelled' and any already-completed stage (e.g. GENERATE in the

--- a/src/evaluatorq/simulation/cli.py
+++ b/src/evaluatorq/simulation/cli.py
@@ -1850,6 +1850,9 @@ def runs(
                 'total_results': summary.get('total_results'),
                 'scorer_averages': summary.get('scorer_averages', {}),
                 'file': report_path.name if report_path is not None else None,
+                # Which summary shape these stats came from; None on a legacy row
+                # built by reading the report itself (see RUN_SUMMARY_VERSION).
+                'summary_version': manifest.summary_version,
             }
         if report_path is None:
             return None
@@ -1869,6 +1872,7 @@ def runs(
             'total_results': data.get('total_results'),
             'scorer_averages': data.get('scorer_averages', {}),
             'file': report_path.name,
+            'summary_version': None,  # read from the report, not from a stored summary
         }
 
     records: list[dict[str, Any]] = []

--- a/src/evaluatorq/simulation/types.py
+++ b/src/evaluatorq/simulation/types.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
-from evaluatorq.contracts import Message, ResponseTrace, StrEnum, TokenUsage
+from evaluatorq.contracts import Message, ResponseTrace, RunSummary, StrEnum, TokenUsage
 
 DEFAULT_MODEL = 'openai/gpt-5.4-mini'
 
@@ -457,6 +457,21 @@ class SimulationRun(BaseModel):
     recommendations: list[SimulationRecommendation] | None = None
     """LLM-generated remediation suggestions for remediable failures
     (see ``reports.recommendations``). None when never generated."""
+
+    def manifest_summary(self) -> RunSummary:
+        """Compact run-list summary stored on this run's ``RunManifest``.
+
+        Single source of truth for the shape: the runner writes it on completion
+        and the dashboard's backfill writes it for legacy runs. `eq sim runs`
+        reads every field here, so a second hand-rolled shape silently blanks
+        columns.
+        """
+        return {
+            'mode': self.mode,
+            'target_kind': self.target_kind,
+            'total_results': self.total_results,
+            'scorer_averages': dict(self.scorer_averages),
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dashboard/test_library.py
+++ b/tests/dashboard/test_library.py
@@ -145,6 +145,22 @@ def _start_manifest(runs_dir: Path, run_id: str, surface: str, name: str):
     return start_manifest(run_id=run_id, surface=surface, run_name=name, runs_dir=runs_dir)
 
 
+def _rt_summary(total: int) -> dict:
+    """The summary shape a real red-team run writes (RedTeamReport.manifest_summary).
+
+    A summary carrying only ``total_results`` reads as incomplete and is demoted
+    to a full-report read, so manifest-first tests must use the full shape.
+    """
+    return {
+        'pipeline': 'static',
+        'total_results': total,
+        'total_attacks': total,
+        'vulnerability_rate': 0.0,
+        'resistance_rate': 1.0,
+        'tested_agents': [],
+    }
+
+
 def test_scan_builds_card_from_manifest_without_reading_report(tmp_path):
     # report_path points at a NON-EXISTENT file; the card must still build from
     # the manifest's compact summary (proving no full-report read happens).
@@ -152,7 +168,7 @@ def test_scan_builds_card_from_manifest_without_reading_report(tmp_path):
     rt.mkdir()
     bogus = rt / 'nonexistent_20260101.json'  # deliberately not written
     w = _start_manifest(rt, 'm1', 'redteam', 'from-manifest')
-    w.complete(report_path=bogus, summary={'total_results': 7})
+    w.complete(report_path=bogus, summary=_rt_summary(7))
 
     cards = scan([rt])
     assert len(cards) == 1
@@ -215,7 +231,7 @@ def test_scan_mixed_dir_dedups_by_report_path(tmp_path):
     report = rt / 'covered_20260101_000000.json'
     _write(report, _redteam_payload())
     w = _start_manifest(rt, 'cov', 'redteam', 'covered')
-    w.complete(report_path=report, summary={'total_results': 3})
+    w.complete(report_path=report, summary=_rt_summary(3))
     # A legacy report with no manifest alongside it.
     _write(rt / 'legacy_20250101_000000.json', _redteam_payload())
 
@@ -282,3 +298,57 @@ def test_fingerprint_changes_when_a_report_lands(tmp_path):
     before = fingerprint([rt])
     _write(rt / 'redteam_20260101_000000.json', _redteam_payload())
     assert fingerprint([rt]) != before
+
+
+def test_fingerprint_ignores_stage_artifacts(tmp_path):
+    """Stage artifacts (``01_``…) are excluded from every aggregate, so rewriting
+    one must not invalidate the caches keyed on this fingerprint."""
+    from evaluatorq.dashboard.library import fingerprint
+
+    rt = tmp_path / 'runs'
+    rt.mkdir()
+    _write(rt / 'redteam_20260101_000000.json', _redteam_payload())
+    before = fingerprint([rt])
+    _write(rt / '01_objectives.json', {'objectives': []})
+    assert fingerprint([rt]) == before
+
+
+def test_backfilled_manifest_carries_the_full_writer_summary(tmp_path):
+    """The sidecar must hold every field `eq redteam runs` reads, not just the
+    one the dashboard card renders."""
+    from evaluatorq.redteam.contracts import RedTeamReport
+
+    rt = tmp_path / 'runs'
+    rt.mkdir()
+    payload = _redteam_payload()
+    payload['total_results'] = 4
+    payload['tested_agents'] = ['agent:x']
+    payload['summary'] = {'total_attacks': 4, 'vulnerability_rate': 0.25, 'resistance_rate': 0.75}
+    _write(rt / 'redteam_20260101_000000.json', payload)
+
+    scan([rt])
+
+    written = json.loads((rt / '.manifests' / 'redteam_20260101_000000.json').read_text())
+    assert written['summary'] == RedTeamReport.model_validate(payload).manifest_summary()
+
+
+def test_scan_rewrites_a_thin_sidecar(tmp_path):
+    """A sidecar written by the first backfill version holds only total_results;
+    it must be re-read and upgraded rather than served as-is forever."""
+    rt = tmp_path / 'runs'
+    rt.mkdir()
+    payload = _redteam_payload()
+    payload['total_results'] = 4
+    payload['summary'] = {'total_attacks': 4, 'vulnerability_rate': 0.25, 'resistance_rate': 0.75}
+    report = rt / 'redteam_20260101_000000.json'
+    _write(report, payload)
+    _start_manifest(rt, report.stem, 'redteam', 'thin').complete(
+        report_path=report, summary={'total_results': 4}
+    )
+
+    cards = scan([rt])
+
+    assert len(cards) == 1  # not listed twice
+    written = json.loads((rt / '.manifests' / f'{report.stem}.json').read_text())
+    assert written['summary']['total_attacks'] == 4
+    assert written['summary']['pipeline'] == 'static'

--- a/tests/dashboard/test_library.py
+++ b/tests/dashboard/test_library.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from evaluatorq.contracts import RUN_SUMMARY_VERSION
 from evaluatorq.dashboard.library import ReportCard, report_id, resolve, scan, sniff_kind
 
 
@@ -143,6 +144,14 @@ def _start_manifest(runs_dir: Path, run_id: str, surface: str, name: str):
     from evaluatorq.common.run_manifest import start_manifest
 
     return start_manifest(run_id=run_id, surface=surface, run_name=name, runs_dir=runs_dir)
+
+
+def _strip_summary_version(mpath: Path) -> Path:
+    """Age a sidecar to pre-stamp format, as everything written before versioning is."""
+    data = json.loads(mpath.read_text())
+    data.pop('summary_version', None)
+    mpath.write_text(json.dumps(data))
+    return mpath
 
 
 def _rt_summary(total: int) -> dict:
@@ -333,8 +342,8 @@ def test_backfilled_manifest_carries_the_full_writer_summary(tmp_path):
 
 
 def test_scan_rewrites_a_thin_sidecar(tmp_path):
-    """A sidecar written by the first backfill version holds only total_results;
-    it must be re-read and upgraded rather than served as-is forever."""
+    """A sidecar predating the summary stamp (the thin one the first backfill
+    wrote) must be re-read and upgraded in place, not served as-is forever."""
     rt = tmp_path / 'runs'
     rt.mkdir()
     payload = _redteam_payload()
@@ -345,10 +354,15 @@ def test_scan_rewrites_a_thin_sidecar(tmp_path):
     _start_manifest(rt, report.stem, 'redteam', 'thin').complete(
         report_path=report, summary={'total_results': 4}
     )
+    mpath = _strip_summary_version(rt / '.manifests' / f'{report.stem}.json')
+    started_at = json.loads(mpath.read_text())['started_at']
 
     cards = scan([rt])
 
     assert len(cards) == 1  # not listed twice
-    written = json.loads((rt / '.manifests' / f'{report.stem}.json').read_text())
+    written = json.loads(mpath.read_text())
     assert written['summary']['total_attacks'] == 4
     assert written['summary']['pipeline'] == 'static'
+    assert written['summary_version'] == RUN_SUMMARY_VERSION
+    # Patched in place: the run's real start time survives the shape upgrade.
+    assert written['started_at'] == started_at

--- a/tests/redteam/test_cli_runs_manifest.py
+++ b/tests/redteam/test_cli_runs_manifest.py
@@ -121,3 +121,21 @@ def test_backfilled_sidecar_keeps_the_full_read_stats(tmp_path: Path) -> None:
     scan([runs])  # the dashboard visit that backfills the sidecar
     assert (runs / '.manifests' / 'rt_20260101_000000.json').exists()
     assert _row() == before
+
+
+def test_runs_ignores_stage_artifacts(tmp_path: Path) -> None:
+    """`save='detail'` writes 01_/02_/03_ stage artifacts beside reports. They are
+    not runs: listing them would spend --limit slots and emit skip warnings for
+    files nobody asked about."""
+    runs = tmp_path / 'runs'
+    runs.mkdir()
+    (runs / 'rt_20260101_000000.json').write_text(
+        json.dumps({'pipeline': 'static', 'summary': {}, 'total_results': 1}), encoding='utf-8'
+    )
+    (runs / '01_all_datapoints.json').write_text('[]', encoding='utf-8')
+    (runs / '02_attack_results.json').write_text('[]', encoding='utf-8')
+
+    result = CliRunner().invoke(redteam_app, ['runs', str(runs), '--json'])
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.stdout)
+    assert [r['file'] for r in rows] == ['rt_20260101_000000.json']

--- a/tests/redteam/test_cli_runs_manifest.py
+++ b/tests/redteam/test_cli_runs_manifest.py
@@ -82,3 +82,42 @@ def test_runs_legacy_fallback_still_works(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert 'legacy' in result.stdout
     assert 'completed' in result.stdout
+
+
+def test_backfilled_sidecar_keeps_the_full_read_stats(tmp_path: Path) -> None:
+    """Opening the dashboard writes a manifest sidecar for a legacy report; the
+    `runs` row must then carry the same stats it carried from the full read.
+
+    Regression: the first backfill wrote only ``total_results``, so browsing the
+    dashboard silently blanked this table's pipeline / agents / rate columns.
+    """
+    from evaluatorq.dashboard.library import scan
+
+    runs = tmp_path / 'runs'
+    runs.mkdir()
+    (runs / 'rt_20260101_000000.json').write_text(
+        json.dumps({
+            'version': '2.0.0',
+            'created_at': '2026-01-01T00:00:00+00:00',
+            'pipeline': 'dynamic',
+            'categories_tested': ['ASI01'],
+            'tested_agents': ['agent:x'],
+            'total_results': 4,
+            'results': [],
+            'summary': {'total_attacks': 4, 'vulnerability_rate': 0.25, 'resistance_rate': 0.75},
+        }),
+        encoding='utf-8',
+    )
+    stats = ('pipeline', 'tested_agents', 'total_attacks', 'vulnerability_rate')
+
+    def _row() -> dict[str, object]:
+        result = CliRunner().invoke(redteam_app, ['runs', str(runs), '--json'])
+        assert result.exit_code == 0, result.output
+        rows = json.loads(result.stdout)
+        assert len(rows) == 1
+        return {k: rows[0][k] for k in stats}
+
+    before = _row()
+    scan([runs])  # the dashboard visit that backfills the sidecar
+    assert (runs / '.manifests' / 'rt_20260101_000000.json').exists()
+    assert _row() == before

--- a/tests/redteam/test_manifest_lifecycle.py
+++ b/tests/redteam/test_manifest_lifecycle.py
@@ -19,6 +19,8 @@ def _fake_report() -> MagicMock:
     # A stand-in report: only the attributes red_team touches post-pipeline.
     report = MagicMock()
     report.pipeline_warnings = []
+    # The runner stores this on the manifest, which validates it as a dict.
+    report.manifest_summary.return_value = {'pipeline': 'dynamic', 'total_results': 0, 'total_attacks': 0}
     return report
 
 

--- a/tests/redteam/test_manifest_lifecycle.py
+++ b/tests/redteam/test_manifest_lifecycle.py
@@ -19,8 +19,16 @@ def _fake_report() -> MagicMock:
     # A stand-in report: only the attributes red_team touches post-pipeline.
     report = MagicMock()
     report.pipeline_warnings = []
-    # The runner stores this on the manifest, which validates it as a dict.
-    report.manifest_summary.return_value = {'pipeline': 'dynamic', 'total_results': 0, 'total_attacks': 0}
+    # The runner stores this on the manifest, which validates it as a dict. Full
+    # production shape, so a runner that stopped forwarding it would be visible.
+    report.manifest_summary.return_value = {
+        'pipeline': 'dynamic',
+        'total_results': 0,
+        'total_attacks': 0,
+        'vulnerability_rate': None,
+        'resistance_rate': None,
+        'tested_agents': [],
+    }
     return report
 
 

--- a/tests/simulation/test_cli_runs_manifest.py
+++ b/tests/simulation/test_cli_runs_manifest.py
@@ -85,3 +85,42 @@ def test_runs_legacy_fallback_still_works(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert 'legacy-sim' in result.stdout
     assert 'completed' in result.stdout
+
+
+def test_backfilled_sidecar_keeps_the_full_read_stats(tmp_path: Path) -> None:
+    """Opening the dashboard writes a manifest sidecar for a legacy sim run; the
+    `runs` row must then carry the same stats it carried from the full read.
+
+    Mirror of the red-team case — the backfill is surface-agnostic, so sim needs
+    its own guard or a sim-only regression would ship unnoticed.
+    """
+    from evaluatorq.dashboard.library import scan
+
+    runs = tmp_path / 'sim-runs'
+    runs.mkdir()
+    (runs / 'sim_20260101_000000.json').write_text(
+        json.dumps({
+            'run_name': 'legacy-sim',
+            'created_at': '2026-01-01T00:00:00+00:00',
+            'mode': 'simulate',
+            'target_kind': 'openai_model',
+            'evaluator_names': [],
+            'total_results': 3,
+            'scorer_averages': {'goal_achieved': 0.5},
+            'results': [],
+        }),
+        encoding='utf-8',
+    )
+    stats = ('mode', 'target_kind', 'total_results', 'scorer_averages')
+
+    def _row() -> dict[str, object]:
+        result = runner.invoke(sim_app, ['runs', str(runs), '--json'])
+        assert result.exit_code == 0, result.output
+        rows = json.loads(result.stdout)
+        assert len(rows) == 1
+        return {k: rows[0][k] for k in stats}
+
+    before = _row()
+    scan([runs])  # the dashboard visit that backfills the sidecar
+    assert (runs / '.manifests' / 'sim_20260101_000000.json').exists()
+    assert _row() == before

--- a/tests/unit/test_run_manifest.py
+++ b/tests/unit/test_run_manifest.py
@@ -247,18 +247,37 @@ def test_list_run_records_manifest_first_dedups_and_falls_back(tmp_path: Path) -
     assert live.status == 'running'
 
 
-def test_list_run_records_demotes_a_thin_summary_to_a_full_read(tmp_path: Path) -> None:
-    """A sidecar carrying only ``total_results`` can't fill a runs row, so the
-    record falls back to the report instead of listing with blank columns."""
+def test_list_run_records_demotes_an_unstamped_summary_to_a_full_read(tmp_path: Path) -> None:
+    """A summary written before versioning (or by an older shape) can't be trusted
+    to fill a runs row, so the record falls back to the report instead of listing
+    with blank columns."""
+    import json
+
     from evaluatorq.common.run_manifest import list_run_records
 
     runs = tmp_path / 'runs'
     runs.mkdir()
     report = runs / 'thin_20250101.json'
     report.write_text('{"pipeline": "dynamic", "summary": {}}', encoding='utf-8')
-    start_manifest(run_id='thin', surface='redteam', run_name='thin', runs_dir=runs).complete(
-        report_path=report, summary={'total_results': 1}
-    )
+    w = start_manifest(run_id='thin', surface='redteam', run_name='thin', runs_dir=runs)
+    w.complete(report_path=report, summary={'total_results': 1})
+    aged = json.loads(w.path.read_text())
+    del aged['summary_version']  # as every sidecar written before the stamp is
+    w.path.write_text(json.dumps(aged))
 
     records = list_run_records(runs)
     assert records == [(None, report)]  # listed once, as a legacy full-read row
+
+
+def test_complete_stamps_the_summary_version(tmp_path: Path) -> None:
+    """The stamp is written wherever a summary is, so no writer can persist an
+    unversioned one — that is what makes the reader's check a comparison and not
+    a shape guess."""
+    from evaluatorq.contracts import RUN_SUMMARY_VERSION
+
+    runs = tmp_path / 'runs'
+    w = start_manifest(run_id='r1', surface='sim', run_name='x', runs_dir=runs)
+    w.complete(summary={'total_results': 2, 'mode': 'run'})
+
+    m = list_manifests(runs)[0]
+    assert m.summary_version == RUN_SUMMARY_VERSION

--- a/tests/unit/test_run_manifest.py
+++ b/tests/unit/test_run_manifest.py
@@ -225,7 +225,7 @@ def test_list_run_records_manifest_first_dedups_and_falls_back(tmp_path: Path) -
     report = runs / 'done_20250101.json'
     report.write_text('{"pipeline": "dynamic", "summary": {}}', encoding='utf-8')
     start_manifest(run_id='done', surface='redteam', run_name='done', runs_dir=runs).complete(
-        report_path=report, summary={'total_results': 1}
+        report_path=report, summary={'pipeline': 'dynamic', 'total_results': 1, 'total_attacks': 1}
     )
     # In-flight run — manifest only, no report.
     start_manifest(run_id='live', surface='redteam', run_name='live', runs_dir=runs)
@@ -245,3 +245,20 @@ def test_list_run_records_manifest_first_dedups_and_falls_back(tmp_path: Path) -
     live = next(m for m, _ in records if m is not None and m.run_name == 'live')
     assert live.report_path is None
     assert live.status == 'running'
+
+
+def test_list_run_records_demotes_a_thin_summary_to_a_full_read(tmp_path: Path) -> None:
+    """A sidecar carrying only ``total_results`` can't fill a runs row, so the
+    record falls back to the report instead of listing with blank columns."""
+    from evaluatorq.common.run_manifest import list_run_records
+
+    runs = tmp_path / 'runs'
+    runs.mkdir()
+    report = runs / 'thin_20250101.json'
+    report.write_text('{"pipeline": "dynamic", "summary": {}}', encoding='utf-8')
+    start_manifest(run_id='thin', surface='redteam', run_name='thin', runs_dir=runs).complete(
+        report_path=report, summary={'total_results': 1}
+    )
+
+    records = list_run_records(runs)
+    assert records == [(None, report)]  # listed once, as a legacy full-read row


### PR DESCRIPTION
Follow-up to #138 review findings ([RES-1276](https://linear.app/orqai/issue/RES-1276/dashboard-manifest-backfill-degrades-eq-runs-rows-fingerprint-sweeps)).

## 1. Manifest backfill degraded `eq runs` rows

`_backfill_manifest()` wrote a sidecar whose summary was `{'total_results': N}` — enough for the dashboard card, not for the CLI tables, which read the same summary. Once the dashboard had been opened, `eq redteam runs` lost pipeline / tested_agents / vulnerability_rate for that run, and `eq sim runs` lost mode / target kind / scorer averages. Silent, and only for runs the dashboard had seen.

- `RedTeamReport.manifest_summary()` and `SimulationRun.manifest_summary()` are now the single definition of the summary shape. The live runners and the dashboard backfill both call it, so a backfilled row is field-identical to one the run wrote itself.
- `summary_is_complete()` (in `common/run_manifest.py`) treats a summary carrying only `total_results` as incomplete. `list_run_records()` demotes such a record to the legacy full-report row (so the CLI never renders half-blank columns), and `scan()` re-reads the report and rewrites the sidecar — thin sidecars already on disk heal on the next dashboard visit.

## 2. `fingerprint()` swept files no aggregate reads

It globbed every root `*.json`, including the `01_`/`02_`/`03_` stage artifacts `_iter_report_files()` deliberately excludes. Rewriting an artifact invalidated the whole-store cache for nothing. It now sweeps through `_iter_report_files()`, so one predicate decides what counts as a report. The "~5 ms per 1000 files" figure in #138 measured that wrong file set — claim dropped rather than re-measured.

## Tests

- `eq redteam runs --json` stats row is unchanged across a dashboard `scan()` that backfills the sidecar (the acceptance test for the regression).
- Backfilled sidecar summary equals `RedTeamReport.manifest_summary()`.
- A thin sidecar is rewritten by `scan()` and demoted to a full-read row by `list_run_records()`.
- Rewriting a `01_` artifact does not change the fingerprint.

Existing manifest-first fixtures were updated from `{'total_results': N}` to a realistic writer summary — a thin summary is now, by design, not manifest-servable.

`ruff check` / `ruff format --check` on `src`, bare `basedpyright`, and `pytest -m 'not integration'` (4072 passed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)