### PR TITLE
Make the repo's conventions mechanical instead of prose (RES-1298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,136 +95,84 @@ CI does not run integration tests. Real-API coverage runs weekly via
 `.github/workflows/examples-weekly.yml`, which opens an issue on failure rather
 than blocking a PR.
 
-## Package Structure
+## Package Map
 
 ```
 src/evaluatorq/
-├── __init__.py              # Public API: evaluate(), DataPoint, EvaluationResult
-├── cli.py                   # CLI entry point (evaluatorq / eq commands)
-├── evaluatorq.py            # Core evaluation runner
-├── evaluators.py            # Built-in evaluator definitions
-├── types.py                 # Shared types (ScorerParameter, etc.)
-├── contracts.py             # Cross-subpackage shared data models (RunManifest, StageRecord, ManifestStatus, ManifestSurface, etc.)
-├── deployment.py            # ORQ deployment integration
-├── fetch_data.py            # Dataset fetching
-├── pairwise.py              # Pairwise comparison evaluation entry point
-├── pairwise_run.py          # Pairwise run orchestration
-├── pairwise_reports/        # Pairwise HTML report generation
-│   ├── export_html.py       # HTML report renderer
-│   └── sections.py          # Report section builders
-├── common/                  # Cross-surface shared utilities (redteam + simulation)
-│   ├── run_manifest.py      # Run-lifecycle manifest behavior (create/update/finalize RunManifest)
-│   ├── judge.py             # LLM-as-judge helper shared across surfaces
-│   ├── jury.py              # Multi-judge aggregation
-│   ├── llm_call.py          # Shared LLM invocation wrapper
-│   ├── llm_client.py        # LLM client construction
-│   ├── retry.py             # Retry/backoff helpers
-│   ├── tracing.py           # OTel span helpers shared across surfaces
-│   ├── template_engine.py   # Prompt templating
-│   ├── reports/             # Shared report rendering (console, HTML, vega charts)
-│   │   ├── console.py       # Rich console report rendering
-│   │   ├── executive_summary.py # Executive summary section builder
-│   │   ├── render.py        # HTML/MD render orchestration
-│   │   └── vega.py          # Vega-Lite chart spec builders
-│   └── ui/                  # Shared Streamlit dashboard launch helper
-│       └── launch.py        # Streamlit app launch helper
-├── integrations/            # Third-party integrations (LangChain, etc.)
-├── tracing/                 # OpenTelemetry tracing
+├── evaluatorq.py, evaluators.py, pairwise*.py  # Core evaluation + pairwise entry points
+├── contracts.py, types.py   # Cross-subpackage data models (RunManifest, LLMConfig, …)
+├── cli.py                   # CLI entry point (evaluatorq / eq)
+├── common/                  # SHARED MACHINERY — read the table below before writing anything here or near it
+├── redteam/                 # eq redteam: adaptive/ (pipeline), backends/, frameworks/, reports/
+├── simulation/              # eq simulate: runner/, agents/, generators/, reports/
+├── dashboard/               # FastHTML dashboard (eq dashboard)
 ├── openresponses/           # OpenAI Responses API integration
-├── simulation/              # Agent simulation subpackage (eq simulate) — persona/scenario-driven multi-turn agent testing
-│   ├── api.py               # Public simulate() entry point
-│   ├── cli.py                # Typer CLI for simulation
-│   ├── types.py               # Simulation data models
-│   ├── traces.py              # Trace capture/reconstruction
-│   ├── wrap_agent.py          # Agent wrapping/instrumentation helper
-│   ├── runner/                 # Simulation execution loop
-│   │   └── simulation.py       # Persona x scenario run orchestration
-│   ├── agents/                  # Simulated user + judge agents
-│   │   ├── judge.py             # Judging agent
-│   │   └── user_simulator.py    # Simulated user agent
-│   ├── generators/                # LLM-driven persona/scenario/datapoint generation
-│   ├── reports/                    # Report generation (console, HTML, MD, exec summary)
-│   ├── quality/                     # Robustness checks
-│   │   └── message_perturbation.py  # Message perturbation testing
-│   └── ui/                           # Streamlit dashboard for simulation results
-│       └── dashboard.py
-├── dashboard/               # FastHTML web dashboard (eq dashboard — preview, in dev; ui commands still serve the Streamlit dashboards)
-│   ├── app.py               # build_app(roots) — ASGI app factory + all routes
-│   ├── _compat.py           # Starlette 1.3.x / FastHTML 0.12.x compat shim (applied on import)
-│   ├── shell.py             # page() — full HTML page shell with head assets
-│   ├── view.py              # HTML fragment helpers (index, filter form, downloads)
-│   ├── library.py           # File discovery, sniff_kind(), report_id(), scan(), read_json_cached()
-│   ├── surfaces.py          # SurfaceAdapter registry (redteam + sim adapters)
-│   ├── filters.py           # FilterDef registry (redteam 7-dim, sim 4-dim)
-│   ├── filter_request.py    # parse_selections() — query-string filter parser
-│   ├── styles.py            # Shared CSS constants / class-name helpers
-│   ├── theme.py             # Theme tokens / light-dark styling
-│   ├── metrics.py           # Aggregate metric computation for dashboard views
-│   ├── report_kit.py        # Shared report-card component helpers
-│   ├── report_tabs.py       # Report tab navigation
-│   ├── orq_links.py         # Orq UI deep-link builders
-│   ├── orq_workspace.py     # Orq workspace slug resolution
-│   ├── trace_links.py       # Trace deep-link builders
-│   ├── sim_compare.py       # Simulation run comparison view
-│   ├── redteam_views.py     # HTMX fragment routes for 4 interactive redteam views
-│   ├── redteam_charts.py    # Interactive breakdown chart + agent heatmap fragments
-│   ├── redteam_transcripts.py # Conversation viewer + disagreement viewer fragments
-│   ├── sim_views.py         # HTMX fragment routes: sim row list, transcript viewer, filter plumbing
-│   ├── launch.py            # CLI launch helper (uvicorn entry point)
-│   └── static/              # Vendored JS: htmx, vega trio, dashboard.js
-└── redteam/                 # Red teaming subpackage
-    ├── contracts.py         # Red-team-specific data models, enums, Pydantic schemas (shared cross-subpackage models live in top-level contracts.py)
-    ├── vulnerability_registry.py  # Single source of truth for vulnerabilities
-    ├── delivery_method_registry.py # Canonical + custom delivery methods (register/resolve/is_known)
-    ├── runner.py            # Unified red_team() entry point
-    ├── cli.py               # Typer CLI for red teaming
-    ├── hooks.py             # Pipeline lifecycle hooks (DefaultHooks, RichHooks)
-    ├── tracing.py           # OTel span helpers
-    ├── exceptions.py        # Custom exceptions
-    ├── judge.py             # LLM judge invocation for red-team evaluators
-    ├── replay.py            # Replay a prior red-team run from stored artifacts
-    ├── utils.py             # Misc red-team helpers
-    ├── adaptive/            # Dynamic pipeline components
-    │   ├── pipeline.py      # Datapoint generation pipeline
-    │   ├── orchestrator.py  # Attack execution orchestrator
-    │   ├── evaluator.py     # OWASPEvaluator wrapper
-    │   ├── strategy_planner.py    # Strategy selection + LLM generation
-    │   ├── strategy_registry.py   # Strategy lookup by vulnerability/category
-    │   ├── attack_generator.py    # Adversarial prompt generation
-    │   ├── objective_generator.py # Attack objective generation
-    │   ├── capability_classifier.py # LLM-based agent capability classification
-    │   ├── agent_context.py # Agent context retrieval
-    │   └── tool_chaining.py # Multi-tool attack chaining strategy support
-    ├── backends/            # Target backends (ORQ agents, OpenAI models)
-    │   ├── base.py          # AgentTarget protocol
-    │   ├── orq.py           # ORQ agent backend
-    │   ├── openai.py        # Direct OpenAI backend
-    │   ├── openresponses.py # OpenAI Responses API backend
-    │   ├── registry.py      # Backend/client factory
-    │   └── _errors.py       # Backend error normalization
-    ├── frameworks/          # Framework-specific strategies and evaluators
-    │   ├── owasp_asi.py     # OWASP ASI attack strategies
-    │   ├── owasp_llm.py     # OWASP LLM Top 10 attack strategies
-    │   └── owasp/           # OWASP evaluators
-    │       ├── evaluators.py       # Evaluator registry
-    │       ├── agent_evaluators.py # ASI evaluator prompts
-    │       ├── llm_evaluators.py   # LLM Top 10 evaluator prompts
-    │       ├── models.py           # LlmEvaluatorEntity, etc.
-    │       └── evaluatorq_bridge.py # Static dataset loading + scoring
-    ├── reports/             # Report generation
-    │   ├── converters.py    # Result → report conversion
-    │   ├── display.py       # Rich terminal display
-    │   ├── executive_summary.py # Executive summary section builder
-    │   ├── export_html.py   # HTML report export
-    │   ├── export_md.py     # Markdown report export
-    │   ├── guidance.py      # Remediation guidance text
-    │   ├── recommendations.py # Recommendation generation
-    │   └── sections.py      # Report section builders
-    ├── runtime/             # Job execution
-    │   └── jobs.py          # Async job runner
-    └── ui/                  # Streamlit dashboard for red-team results
-        └── dashboard.py
+├── tracing/                 # OTel setup + evaluation/run/job spans
+└── integrations/            # LangChain, LangGraph, CrewAI, pydantic-ai, openai-agents
 ```
+
+Read the directory itself for the file list — it is always current, this file is not.
+
+## Need X? Use Y. Do not reinvent.
+
+`common/` is the shared layer. Every module there exists because two surfaces
+drifted apart and a review consolidated them. Adding a third copy is the failure
+mode this table exists to prevent.
+
+| Doing | Use | Never |
+|---|---|---|
+| Any chat completion | `common.llm_call.execute_chat_completion` / `execute_chat_parse` | `client.chat.completions.create(...)` at a new call site |
+| Structured / schema output | `common.structured_output` (parse + `json_object` fallback) | hand-rolled `response_format` + `json.loads` |
+| Parsing JSON out of model text | `common.extract_json.extract_json_from_response` | bespoke fence-stripping regex |
+| Building call params | `LLMConfig.completion_params(...)` (`contracts.py`) | hand-built `extra_kwargs` dict — it skips the reserved-key guard |
+| Resolving an LLM client | `common.llm_client.resolve_llm_client` | `AsyncOpenAI(...)` anywhere but that module |
+| Retry / backoff | `common.retry.with_retry`, or the SDK's own `max_retries` — **exactly one of the two** | a second retry layer on a client that already retries (they multiply) |
+| Calling the target under test | `common.target_call.call_target_with_retry` | ad-hoc `respond()` + try/except |
+| LLM-as-judge | `common.judge.run_judge`; multi-judge via `common.jury` | new judge prompt + parse loop |
+| OTel spans, token usage, cost | `common.tracing` (`with_llm_span`, `record_token_usage`, `record_llm_response`) | `get_tracer` / `start_as_current_span` outside a `tracing.py` module |
+| Surface-specific span naming | `redteam/tracing.py`, `simulation/tracing.py` — thin wrappers that delegate | new span vocabulary |
+| Prompt templating | `common.template_engine.render_template` | f-string prompt assembly |
+| Untrusted text into a prompt | `common.sanitize.delimit` | raw interpolation |
+| Run lifecycle state | `common.run_manifest` (`start_manifest`, `list_manifests`) | new status dict / sidecar file |
+| Applying recommendations to an agent | `common.apply.apply_recommendations` | surface-local merge logic |
+| Console / HTML / MD report output | `common/reports/` (`console`, `render`, `vega`, `palette`) | new renderer or colour set |
+| CLI output, errors, JSON, width | `common/cli_*.py` | bespoke `typer.echo` formatting |
+| Normalising agent output shapes | `common.output_adapters`, `common.messages` | per-surface `isinstance` ladders |
+| Turning message content or a tool result into text | `contracts.content_to_text` / `tool_result_to_text` | `str()` on a `str \| list[ContentPart]` — it renders a Python repr that a judge then scores |
+| Building an Orq SDK client | `common.orq_client.resolve_orq_client` | `Orq(...)` anywhere but that module |
+
+
+## House rules
+
+Distilled from review findings that recurred. Each cost a review round.
+
+- **One retry layer.** SDK `max_retries` and `with_retry` compose multiplicatively. Pick one per call path, and say which in the docstring.
+- **No optimistic defaults on unknown shapes.** A result whose schema you cannot read must log and count as unknown — never as passed, resisted, or $0. Silence reads as a clean run.
+- **A degraded path announces itself.** Falling back, skipping, or returning a literal gets a `logger.warning` naming the cause. Two branches next to each other must not differ in whether they log.
+- **Never bypass a wrapper to get at its inner call.** If a helper's signature is in your way, change the helper. Going around it drops its validation — that is how `_RESERVED_COMPLETION_KEYS` got skipped.
+- **Caller-supplied values win merges.** `{**defaults, **caller}`, and the docstring states it.
+- **No drive-by reformatting.** Quote-style and signature re-wrapping in an unrelated file hides the behaviour change and collides with parallel sessions.
+- **Test the failure branch you documented.** If the docstring promises degradation to inconclusive, a test exercises it. All-success fakes prove nothing.
+- **A helper with no caller is a bug.** Either call it or delete it; do not recompute its body inline.
+- **Nothing stateful is shared across concurrent work.** `evaluate()` / `simulate()` / `red_team()` run datapoints concurrently: give each task its own target via `new()` (a shared `ORQAgentTarget` races on `_task_id`), and key per-item assignment on the dataset row, never on an arrival-order cursor. An `asyncio` primitive binds to the loop that first blocks on it — don't reuse one across loops.
+- **A new registry copies `vulnerability_registry.py`.** Assert `set(Enum) == set(registry)` at import time and freeze with `MappingProxyType`; a plain mutable dict drifts silently as the enum grows.
+- **Every filtered UI section renders an empty state.** A section that disappears on zero matches is indistinguishable from a bug.
+- **Provider usage/cost shapes are not interchangeable.** Anthropic reports cache reads top-level where Orq/OpenAI nest them. Build the test fixture from the provider SDK's own models so a schema move fails the test instead of confirming the guess.
+
+Guardrails for the mechanical parts live in `tests/test_reuse_guardrails.py`.
+A failure there names the canonical helper — use it, don't extend the allowlist.
+
+## Keeping this file true
+
+This file only works if it absorbs what review teaches. When a review comment,
+CI failure, or bug traces back to a convention that was not written down:
+
+1. Add it **in the same PR** — one table row or one house rule, not a paragraph.
+2. Add the mechanical check too, if one is possible (`tests/test_reuse_guardrails.py`, a ruff rule).
+3. Delete something stale while you are here. Above ~200 lines this file gets skimmed, and skimmed is the same as absent.
+
+Do not add a directory tree, a file inventory, or anything else the filesystem
+already answers.
 
 ## Key Patterns
 
@@ -251,14 +199,9 @@ src/evaluatorq/
 
 ### Dependencies
 
-- Runtime (required): `pydantic`, `httpx`, `rich`, `loguru`, `typer`, `openai`
-- Red team extra: `huggingface-hub`, `streamlit`, `plotly`, `watchdog`, `vl-convert-python` (install as `evaluatorq[redteam]`)
-- Simulation extra: `orq-ai-sdk`, `streamlit`, `plotly`, `watchdog`, `vl-convert-python` (install as `evaluatorq[simulation]`)
-- Dashboard extra: `python-fasthtml`, `uvicorn`, `vl-convert-python` (install as `evaluatorq[dashboard]`)
-- Other extras: `orq` (`orq-ai-sdk`), `otel` (OpenTelemetry SDK/exporter), `langchain`, `langgraph`, `openai-agents`, `pydantic-ai`, `crewai`; `all` installs every extra
-- Dev: `pytest`, `pytest-asyncio`, `basedpyright`, `ruff`
-- Package manager: `uv` (not pip)
-- Build system: `hatchling`
+- `uv` (not pip), `hatchling` build. Runtime deps and extras are listed in `pyproject.toml` — read it there.
+- Only `pydantic`/`httpx`/`rich`/`loguru`/`typer`/`openai` are always installed. Everything else is behind an extra: a module that imports one at module scope must itself only be imported behind that extra (that is why `redteam/ui/`, `dashboard/` and the integrations can import `streamlit`/`fasthtml`/`langchain` at the top). Anywhere else, import inside the function.
+- Adding a new dependency needs a reason a few lines of stdlib cannot cover.
 
 ### Environment Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,8 @@ src = [ "src" ]
   "UP",
   "FURB",
   "RUF",
-  "TRY"
+  "TRY",
+  "BLE001"
 ]
   ignore = [
   "G001",
@@ -134,6 +135,54 @@ src = [ "src" ]
   "S311",
   "RUF027"
 ]
+
+    # BLE001 debt register: blind `except Exception` swallowing real errors is a
+    # documented silent-failure source (PR #96 — a TypeError made every evaluation
+    # return passed=None). The rule is on repo-wide; these files predate it. Shrink
+    # this list, never grow it. Tracked for burn-down in RES-1298.
+    [tool.ruff.lint.per-file-ignores]
+    "src/evaluatorq/common/apply.py" = ["BLE001"]
+    "src/evaluatorq/common/async_utils.py" = ["BLE001"]
+    "src/evaluatorq/common/judge.py" = ["BLE001"]
+    "src/evaluatorq/common/output_adapters.py" = ["BLE001"]
+    "src/evaluatorq/common/reports/executive_summary.py" = ["BLE001"]
+    "src/evaluatorq/common/reports/vega.py" = ["BLE001"]
+    "src/evaluatorq/common/target_call.py" = ["BLE001"]
+    "src/evaluatorq/common/tracing.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/app.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/apply_ui.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/library.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/redteam_views.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/report_tabs.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/sim_compare.py" = ["BLE001"]
+    "src/evaluatorq/dashboard/sim_views.py" = ["BLE001"]
+    "src/evaluatorq/fetch_data.py" = ["BLE001"]
+    "src/evaluatorq/integrations/callable_integration/target.py" = ["BLE001"]
+    "src/evaluatorq/integrations/langgraph_integration/target.py" = ["BLE001"]
+    "src/evaluatorq/integrations/pydantic_ai_integration/target.py" = ["BLE001"]
+    "src/evaluatorq/openresponses/tracing.py" = ["BLE001"]
+    "src/evaluatorq/processings.py" = ["BLE001"]
+    "src/evaluatorq/redteam/cli.py" = ["BLE001"]
+    "src/evaluatorq/redteam/reports/recommendations.py" = ["BLE001"]
+    "src/evaluatorq/redteam/runner.py" = ["BLE001"]
+    "src/evaluatorq/redteam/runtime/jobs.py" = ["BLE001"]
+    "src/evaluatorq/redteam/ui/dashboard.py" = ["BLE001"]
+    "src/evaluatorq/simulation/cli.py" = ["BLE001"]
+    "src/evaluatorq/simulation/generators/persona_generator.py" = ["BLE001"]
+    "src/evaluatorq/simulation/generators/scenario_generator.py" = ["BLE001"]
+    "src/evaluatorq/simulation/reports/recommendations.py" = ["BLE001"]
+    "src/evaluatorq/simulation/runner/simulation.py" = ["BLE001"]
+    "src/evaluatorq/simulation/traces.py" = ["BLE001"]
+    "src/evaluatorq/simulation/utils/run_store.py" = ["BLE001"]
+    "src/evaluatorq/tracing/setup.py" = ["BLE001"]
+
+    # Keep competing stacks out. Call-site rules (which module may build a client or
+    # call the API) live in tests/test_reuse_guardrails.py — banning the imports here
+    # would also hit the ~36 modules that import AsyncOpenAI purely for typing.
+    [tool.ruff.lint.flake8-tidy-imports.banned-api]
+    "tenacity".msg = "Use evaluatorq.common.retry.with_retry, or the SDK's own max_retries — one retry layer, not two."
+    "backoff".msg = "Use evaluatorq.common.retry.with_retry."
+    "requests".msg = "Use httpx (already a runtime dependency); async paths need it anyway."
 
 [tool.basedpyright]
 exclude = [ "examples", "scripts", ".venv", "src/evaluatorq/redteam/ui", "src/evaluatorq/simulation/ui" ]

--- a/src/evaluatorq/common/extract_json.py
+++ b/src/evaluatorq/common/extract_json.py
@@ -1,4 +1,9 @@
-"""JSON extraction utilities for parsing LLM responses."""
+"""JSON extraction utilities for parsing LLM responses.
+
+Canonical fence-tolerant parser for model output — do not write another
+code-fence regex. ``common.structured_output`` hands its ``json_object``
+fallback content here.
+"""
 
 from __future__ import annotations
 

--- a/src/evaluatorq/common/judge.py
+++ b/src/evaluatorq/common/judge.py
@@ -1,4 +1,4 @@
-"""Generic Orq-format LLM judge.
+"""Generic Orq-format LLM judge — canonical, do not write another judge loop.
 
 Renders an evaluator template, calls an OpenAI-compatible chat completion, and
 parses a structured ``{"value", "explanation"}`` verdict. Domain callers own

--- a/src/evaluatorq/common/messages.py
+++ b/src/evaluatorq/common/messages.py
@@ -1,4 +1,9 @@
-"""Shared helpers for normalizing chat-message content."""
+"""Shared helpers for normalizing chat-message content.
+
+Canonical for every surface. Content is typed ``str | list[ContentPart]``:
+never call ``str()`` on it — that renders a Python repr into a transcript a
+judge then scores. Use these helpers or ``contracts.content_to_text``.
+"""
 
 from __future__ import annotations
 

--- a/src/evaluatorq/common/orq_client.py
+++ b/src/evaluatorq/common/orq_client.py
@@ -1,0 +1,52 @@
+"""Canonical Orq SDK client construction — do not build ``Orq(...)`` elsewhere.
+
+Five call sites each carried their own copy of the same four steps: lazy-import
+the optional SDK, translate ``ModuleNotFoundError`` into an install hint, read
+``ORQ_API_KEY``, and apply the ``ORQ_BASE_URL`` default. Two of the five had
+drifted and never passed ``server_url`` at all, so a self-hosted deployment was
+silently ignored on those paths.
+
+Callers that need a domain-specific exception (e.g. red team's
+``CredentialError``) should check the key themselves and pass it in — this
+module raises ``ValueError`` for a missing key and ``ImportError`` for a missing
+SDK, nothing else.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from orq_ai_sdk import Orq
+
+_INSTALL_HINT = (
+    'The orq_ai_sdk package is not installed. Install it with: '
+    'uv add "evaluatorq[orq]" (or: python -m pip install "evaluatorq[orq]")'
+)
+
+DEFAULT_ORQ_BASE_URL = 'https://my.orq.ai'
+
+
+def orq_server_url() -> str:
+    """Return the Orq API base URL, honouring ``ORQ_BASE_URL``."""
+    return os.environ.get('ORQ_BASE_URL', DEFAULT_ORQ_BASE_URL)
+
+
+def resolve_orq_client(api_key: str | None = None) -> Orq:
+    """Build an Orq SDK client from ``api_key`` or ``ORQ_API_KEY``.
+
+    Raises:
+        ImportError: the optional ``orq-ai-sdk`` dependency is not installed.
+        ValueError: no API key was passed and ``ORQ_API_KEY`` is unset.
+    """
+    key = api_key or os.environ.get('ORQ_API_KEY')
+    if not key:
+        raise ValueError('ORQ_API_KEY environment variable must be set to reach the Orq API.')
+
+    try:
+        from orq_ai_sdk import Orq
+    except ModuleNotFoundError as e:  # pragma: no cover - extra not installed
+        raise ImportError(_INSTALL_HINT) from e
+
+    return Orq(api_key=key, server_url=orq_server_url())

--- a/src/evaluatorq/common/output_adapters.py
+++ b/src/evaluatorq/common/output_adapters.py
@@ -1,3 +1,9 @@
+"""Canonical adapters between agent output shapes and messages/text.
+
+Every surface normalises third-party agent output here — a per-surface
+``isinstance`` ladder is how the shapes drifted apart the last time.
+"""
+
 from __future__ import annotations
 
 import json

--- a/src/evaluatorq/common/retry.py
+++ b/src/evaluatorq/common/retry.py
@@ -1,4 +1,14 @@
-"""Shared retry helper for LLM API calls."""
+"""Shared retry helper for LLM API calls.
+
+Canonical retry for every surface — do not add a second layer. An OpenAI/Orq
+client already carries its own ``max_retries``; wrapping such a call in
+``with_retry`` multiplies the two budgets, so the default ``MAX_RETRY_ATTEMPTS``
+of 5 over a client with the SDK default of 2 retries is 15 requests, not 5. The
+SDK's wall-clock guard is measured from before the first attempt, so the outer
+layer can also exhaust it. Per call path, either configure the client's
+``max_retries`` or use ``with_retry`` — not both — and name the choice in the
+caller's docstring.
+"""
 
 from __future__ import annotations
 

--- a/src/evaluatorq/common/run_manifest.py
+++ b/src/evaluatorq/common/run_manifest.py
@@ -1,5 +1,7 @@
 """Run lifecycle manifests: track a run's stage + status while it executes.
 
+Canonical run-state record for both surfaces — no sidecar status dict of your own.
+
 Reports only land on disk when a run *completes* — a run that is still running
 or that crashed leaves no artifact. The manifest fills that gap: a tiny record
 written when a run starts (``status='running'``), patched as stages advance, and

--- a/src/evaluatorq/common/sanitize.py
+++ b/src/evaluatorq/common/sanitize.py
@@ -1,5 +1,8 @@
 """Shared sanitization utilities for prompt injection prevention.
 
+Canonical for every surface: untrusted text reaching a prompt goes through
+``delimit`` — do not hand-roll boundary markers.
+
 Two complementary functions are provided:
 
 * ``delimit(text, tag="data")`` — wraps user-controlled text in XML-like

--- a/src/evaluatorq/dashboard/apply_ui.py
+++ b/src/evaluatorq/dashboard/apply_ui.py
@@ -43,6 +43,7 @@ from loguru import logger
 from starlette.requests import Request  # noqa: TC002 — FastHTML inspects this annotation at runtime
 from starlette.responses import Response
 
+from evaluatorq.common.orq_client import resolve_orq_client
 from evaluatorq.common.reports import esc
 
 if TYPE_CHECKING:
@@ -469,15 +470,13 @@ def _build_clients() -> tuple[Any, Any, str]:
     api_key = os.environ.get('ORQ_API_KEY', '')
     if not api_key:
         raise ValueError('ORQ_API_KEY is not set; the dashboard cannot reach the Orq API to apply recommendations.')
-    try:
-        from orq_ai_sdk import Orq
-    except ModuleNotFoundError as e:  # pragma: no cover - extra not installed
-        raise ValueError("The 'orq-ai-sdk' package is required to apply recommendations (install extra 'orq').") from e
-
     from evaluatorq.redteam.backends.registry import create_async_llm_client
     from evaluatorq.redteam.contracts import PIPELINE_CONFIG
 
-    orq_client = Orq(api_key=api_key, server_url=os.environ.get('ORQ_BASE_URL', 'https://my.orq.ai'))
+    try:
+        orq_client = resolve_orq_client(api_key)
+    except ImportError as e:  # pragma: no cover - extra not installed
+        raise ValueError("The 'orq-ai-sdk' package is required to apply recommendations (install extra 'orq').") from e
     llm_client = create_async_llm_client(
         role_config=PIPELINE_CONFIG.evaluator.as_call_config(), max_retries=PIPELINE_CONFIG.retry_count
     )

--- a/src/evaluatorq/deployment.py
+++ b/src/evaluatorq/deployment.py
@@ -7,10 +7,10 @@ from within evaluation jobs.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from evaluatorq.common.orq_client import resolve_orq_client
 from evaluatorq.contracts import TokenUsage
 
 __all__ = [
@@ -73,26 +73,9 @@ def _get_or_create_client() -> Orq:
     """
     global _cached_client
 
-    if _cached_client is not None:
-        return _cached_client
-
-    api_key = os.environ.get('ORQ_API_KEY')
-    if not api_key:
-        raise ValueError('ORQ_API_KEY environment variable must be set to use the deployment helper.')
-
-    try:
-        from orq_ai_sdk import Orq
-
-        server_url = os.environ.get('ORQ_BASE_URL', 'https://my.orq.ai')
-        _cached_client = Orq(api_key=api_key, server_url=server_url)
-        return _cached_client
-    except ModuleNotFoundError as e:
-        raise ImportError(
-            'The orq_ai_sdk package is not installed. To use deployment features, install it with: '
-            'uv add orq-ai-sdk (or: python -m pip install orq-ai-sdk)'
-        ) from e
-    except Exception as e:
-        raise RuntimeError(f'Failed to setup ORQ client: {e}') from e
+    if _cached_client is None:
+        _cached_client = resolve_orq_client()
+    return _cached_client
 
 
 async def deployment(

--- a/src/evaluatorq/fetch_data.py
+++ b/src/evaluatorq/fetch_data.py
@@ -12,6 +12,7 @@ import httpx
 from loguru import logger
 
 from .common.llm_client import ORQ_DEFAULT_HOST
+from .common.orq_client import resolve_orq_client
 from .types import DataPoint
 
 if TYPE_CHECKING:
@@ -31,6 +32,9 @@ def setup_orq_client(api_key: str) -> 'Orq':
     """
     Setup and return an Orq client instance.
 
+    Thin alias for ``common.orq_client.resolve_orq_client``; kept because callers
+    and tests patch this name.
+
     Args:
         api_key: Orq API key for authentication
 
@@ -38,21 +42,10 @@ def setup_orq_client(api_key: str) -> 'Orq':
         Orq client instance
 
     Raises:
-        ModuleNotFoundError: If orq_ai_sdk is not installed
-        Exception: If client setup fails
+        ImportError: If orq_ai_sdk is not installed
+        ValueError: If no API key is available
     """
-    try:
-        # lazy import for orq integration
-        from orq_ai_sdk import Orq
-
-        server_url = os.environ.get('ORQ_BASE_URL', 'https://my.orq.ai')
-        return Orq(api_key=api_key, server_url=server_url)
-    except ModuleNotFoundError as e:
-        raise Exception(
-            'orq_ai_sdk is not installed. Install with: uv add orq-ai-sdk (or: python -m pip install orq-ai-sdk)'
-        ) from e
-    except Exception as e:
-        raise Exception(f'Error setting up Orq client: {e}')
+    return resolve_orq_client(api_key)
 
 
 async def fetch_dataset_batches(

--- a/src/evaluatorq/redteam/adaptive/attack_generator.py
+++ b/src/evaluatorq/redteam/adaptive/attack_generator.py
@@ -227,6 +227,6 @@ async def adapt_prompt_to_tools(
 
     except (APIConnectionError, APIStatusError):
         raise
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error(f'Tool adaptation failed, using generic prompt without tool-specific targeting: {e}')
         return base_prompt

--- a/src/evaluatorq/redteam/adaptive/blackbox_classifier.py
+++ b/src/evaluatorq/redteam/adaptive/blackbox_classifier.py
@@ -242,7 +242,7 @@ async def _run_probes(agent_target: AgentTarget) -> tuple[list[Message], set[str
             response = await (target if target is not None else agent_target).respond(convo)
         except (APIConnectionError, APIStatusError):
             raise
-        except Exception as e:  # one flaky turn must not abort classification
+        except Exception as e:  # one flaky turn must not abort classification  # noqa: BLE001
             logger.warning('Blackbox probe ({}) failed: {}', group, e)
             # Drop the unanswered user turn so it does not pollute the judge
             # transcript with a question that has no paired reply.
@@ -300,7 +300,7 @@ async def _run_probes(agent_target: AgentTarget) -> tuple[list[Message], set[str
                     maybe_coro = closer()
                     if inspect.isawaitable(maybe_coro):
                         await maybe_coro
-                except Exception as close_err:  # cleanup must not mask the probe result
+                except Exception as close_err:  # cleanup must not mask the probe result  # noqa: BLE001
                     logger.debug('Failed to close recall probe target: {}', close_err)
     unprobed_groups = {group for group, n in answered_by_group.items() if n == 0}
     if not (write_ok and recall_ok):
@@ -415,7 +415,7 @@ async def classify_agent_capabilities_blackbox(
         inference = await _judge_transcript(transcript, llm_client, model, cfg)
     except (APIConnectionError, APIStatusError):
         raise
-    except Exception as e:  # degrade to a coverage-gap signal, mirror white-box
+    except Exception as e:  # degrade to a coverage-gap signal, mirror white-box  # noqa: BLE001
         logger.error('Blackbox judge call failed, strategies will be included optimistically: {}', e)
         return BlackboxAgentCapabilities(capabilities={}, classification_failed=True)
 

--- a/src/evaluatorq/redteam/adaptive/capability_classifier.py
+++ b/src/evaluatorq/redteam/adaptive/capability_classifier.py
@@ -256,7 +256,7 @@ async def _infer_resource_capabilities(
             return parsed
     except (APIConnectionError, APIStatusError):
         raise
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         # is_multi_agent defaults False here, so multi-agent-only attacks (ASI07/08) are
         # suppressed for this target. Say so explicitly: a coverage gap caused by an
         # inference error must be distinguishable from a confident single-agent result.
@@ -333,6 +333,6 @@ async def _classify_tools(
 
     except (APIConnectionError, APIStatusError):
         raise
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error(f'Tool classification failed, strategies will be included optimistically: {e}')
         return {}, False

--- a/src/evaluatorq/redteam/adaptive/objective_generator.py
+++ b/src/evaluatorq/redteam/adaptive/objective_generator.py
@@ -248,7 +248,7 @@ async def _call_llm_for_objectives_single(
             )
             return []
         raise
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error(f'Objective generation failed for {log_label!r} ({type(e).__name__}): {e}')
         return []
 

--- a/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -174,7 +174,7 @@ class ProgressDisplay:
             if task_id is not None:
                 try:
                     self._progress.remove_task(task_id)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     logger.debug('Failed to update progress display', exc_info=True)
                 self._bar_task_ids.discard(task_id)
             self._finished += 1
@@ -529,7 +529,7 @@ class MultiTurnOrchestrator:
                     logger.debug(f'Tool-chaining: capping {len(valid_steps)} steps to max_turns={max_turns}')
                     valid_steps = valid_steps[:max_turns]
                 return format_plan_for_prompt(valid_steps), planner_usage
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             # repr-style detail: str(asyncio.TimeoutError()) is '' on 3.10+, so log
             # the type to keep timeouts/cancellations identifiable in the fallback.
             logger.warning(
@@ -611,7 +611,7 @@ class MultiTurnOrchestrator:
                     _progress_label(strategy.category, strategy.name),
                     max_turns,
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 logger.debug('Failed to update progress display', exc_info=True)
 
         try:
@@ -742,7 +742,7 @@ class MultiTurnOrchestrator:
                             error_turn = turn + 1
                             break
                         continue
-                    except Exception as e:
+                    except Exception as e:  # noqa: BLE001
                         # A provider can block the attacker prompt at the moderation layer
                         # and raise (e.g. Azure → HTTP 400 code='content_filter') instead
                         # of returning finish_reason='content_filter'. Classify that as a

--- a/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -642,7 +642,7 @@ def create_dynamic_evaluator(
         elif isinstance(raw_output, dict):
             try:
                 output = AttackOutput.model_validate(raw_output)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 inputs = getattr(data, 'inputs', {}) or {}
                 logger.error(
                     'Failed to parse job output as AttackOutput '
@@ -797,7 +797,7 @@ async def cleanup_memory_entities(
         msg = f'Memory cleanup timed out after {cleanup_timeout_s:.0f}s for {len(entity_ids)} entities'
         logger.warning(msg)
         return msg
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         msg = f'Memory cleanup failed: {e}'
         logger.warning(msg)
         return msg

--- a/src/evaluatorq/redteam/adaptive/strategy_planner.py
+++ b/src/evaluatorq/redteam/adaptive/strategy_planner.py
@@ -170,7 +170,7 @@ async def plan_strategies_for_vulnerabilities(
                             pipeline_config=cfg,
                         )
                     return vuln, generated, None
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     logger.error(
                         f'Strategy generation failed for {vuln.value}, no strategies will be tested for this vulnerability: {e}'
                     )

--- a/src/evaluatorq/redteam/backends/orq.py
+++ b/src/evaluatorq/redteam/backends/orq.py
@@ -118,7 +118,7 @@ async def _orq_cleanup_memory(orq_client: Any, ctx: AgentContext, entity_ids: li
                     memory_entity_id=entity_id,
                 )
                 logger.debug(f'Deleted memory entity {entity_id} from store {ms.key}')
-            except Exception as e:  # noqa: PERF203
+            except Exception as e:  # noqa: BLE001, PERF203
                 if extract_status_code(e) == 404:
                     continue
                 logger.warning(f'Failed to cleanup memory entity {entity_id} from {ms.key}: {e}')
@@ -544,7 +544,7 @@ class ORQAgentTarget(AgentTarget):
                 name=getattr(kb, 'key', None),
                 description=getattr(kb, 'description', None) or None,
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning(f'Failed to enrich knowledge base {kb_id}: {e} — attack strategies will use limited context')
             return KnowledgeBaseInfo(id=kb_id)
 
@@ -560,7 +560,7 @@ class ORQAgentTarget(AgentTarget):
                 key=getattr(ms, 'key', ms_key),
                 description=getattr(ms, 'description', None) or None,
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning(f'Failed to enrich memory store {ms_key}: {e} — attack strategies will use limited context')
             return MemoryStoreInfo(id=ms_key)
 
@@ -597,7 +597,7 @@ class ORQAgentTarget(AgentTarget):
                 # SDK returns parameters/schema as a Pydantic model; ToolInfo wants a plain dict.
                 if raw_params is not None:
                     parameters = raw_params.model_dump() if hasattr(raw_params, 'model_dump') else raw_params
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.warning(f'Failed to enrich tool {tool_id}: {e} — attack strategies will use limited context')
         return ToolInfo(name=name, description=description, parameters=parameters, action_type=action_type)
 

--- a/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from evaluatorq import DataPoint, EvaluationResult
 from evaluatorq.common.judge import JudgeError, build_eval_replacements, run_judge
 from evaluatorq.common.jury import Prediction, VerdictKind, _panel_composition_messages, append_jury_summary, run_jury
+from evaluatorq.common.orq_client import resolve_orq_client
 from evaluatorq.common.output_adapters import output_error_text, output_to_messages
 from evaluatorq.common.tracing import set_span_attrs
 from evaluatorq.contracts import JURY_RAW_OUTPUT_KEY
@@ -415,15 +416,6 @@ def _validate_platform_datapoint(inputs: dict[str, Any]) -> None:
 
 def _fetch_all_datapoints(dataset_id: str) -> list[DataPoint]:
     """Fetch all datapoints from an ORQ dataset, handling pagination."""
-    try:
-        from orq_ai_sdk import Orq
-    except ImportError as e:
-        msg = (
-            'Fetching datasets from the ORQ platform requires the orq-ai-sdk package. '
-            'Install it with: uv add "evaluatorq[orq]" (or: python -m pip install "evaluatorq[orq]")'
-        )
-        raise ImportError(msg) from e
-
     orq_api_key = os.environ.get('ORQ_API_KEY')
     if not orq_api_key:
         msg = (
@@ -431,7 +423,7 @@ def _fetch_all_datapoints(dataset_id: str) -> list[DataPoint]:
             'Alternatively, pass a local file path as the dataset argument.'
         )
         raise ValueError(msg)
-    client = Orq(api_key=orq_api_key)
+    client = resolve_orq_client(orq_api_key)
     all_datapoints: list[DataPoint] = []
     skipped = 0
     cursor: str | None = None

--- a/src/evaluatorq/redteam/runtime/jobs.py
+++ b/src/evaluatorq/redteam/runtime/jobs.py
@@ -11,6 +11,7 @@ from evaluatorq import DataPoint, Job, job
 from evaluatorq.common.llm_call import apply_pipeline_metadata, execute_chat_completion
 from evaluatorq.common.llm_client import client_routes_through_orq
 from evaluatorq.common.messages import coerce_content_text
+from evaluatorq.common.orq_client import resolve_orq_client
 from evaluatorq.common.thread_context import build_static_thread_id, conversation_thread, thread_body_param
 from evaluatorq.common.tracing import record_llm_response, set_span_attrs, truncate_for_span
 from evaluatorq.redteam.adaptive.orchestrator import _get_active_progress
@@ -73,19 +74,10 @@ def create_model_job(
     if deployment_key:
         safe_key = _sanitize_job_name(deployment_key)
 
-        try:
-            from orq_ai_sdk import Orq
-        except ImportError as e:
-            msg = (
-                'Deployment jobs require the orq-ai-sdk package. '
-                'Install it with: uv add "evaluatorq[orq]" (or: python -m pip install "evaluatorq[orq]")'
-            )
-            raise ImportError(msg) from e
-
         api_key = os.environ.get('ORQ_API_KEY')
         if not api_key:
             raise CredentialError('ORQ_API_KEY environment variable is not set')
-        deployment_client = Orq(api_key=api_key)
+        deployment_client = resolve_orq_client(api_key)
 
         @job(f'redteam:static:{safe_key}')
         async def deployment_job(data: DataPoint, _row: int) -> dict[str, Any]:

--- a/tests/test_reuse_guardrails.py
+++ b/tests/test_reuse_guardrails.py
@@ -1,0 +1,167 @@
+"""Mechanical guardrails for the reuse table in CLAUDE.md.
+
+Prose conventions get skipped; a failing test does not. Each rule below names the
+canonical helper in its failure message. When one fires, route the call through
+the helper — do not append your file to the allowlist. The allowlists are a
+freeze on the sites that predate the rule and are expected to shrink.
+
+Detection is AST-based, not regex: a docstring or comment mentioning a call is
+not a call, and `x = client.chat.completions` followed by `x.create(...)` should
+not be a way around the rule by accident.
+"""
+
+from __future__ import annotations
+
+import ast
+from functools import cache
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / 'src' / 'evaluatorq'
+
+# Attribute suffixes that mean "an LLM API call happened here".
+LLM_CALL_SUFFIXES = (
+    'chat.completions.create',
+    'chat.completions.parse',
+    'responses.create',
+    'responses.parse',
+)
+# Callables that construct an SDK client, by SDK.
+OPENAI_CLIENT_NAMES = frozenset({'OpenAI', 'AsyncOpenAI', 'AzureOpenAI', 'AsyncAzureOpenAI'})
+ORQ_CLIENT_NAMES = frozenset({'Orq', 'AsyncOrq'})
+SPAN_NAMES = frozenset({'get_tracer', 'start_span', 'start_as_current_span'})
+
+
+def _dotted(node: ast.expr) -> str:
+    """Best-effort dotted name for a call target (``a.b.c`` -> ``'a.b.c'``)."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return '.'.join(reversed(parts))
+
+
+def _calls(source: str) -> list[tuple[int, str]]:
+    """Return ``(lineno, dotted_name)`` for every call in ``source``."""
+    return [
+        (node.lineno, _dotted(node.func))
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+    ]
+
+
+@cache
+def _src_calls() -> tuple[tuple[str, int, str], ...]:
+    """Every ``(relative_path, lineno, dotted_name)`` call in the package, parsed once."""
+    return tuple(
+        (path.relative_to(SRC).as_posix(), lineno, name)
+        for path in sorted(SRC.rglob('*.py'))
+        for lineno, name in _calls(path.read_text(encoding='utf-8'))
+    )
+
+
+def _hits(predicate: object, *, allow: frozenset[str] | set[str] | None = None) -> list[str]:
+    """Return ``path:line`` for every call matching ``predicate`` outside ``allow``."""
+    assert callable(predicate)
+    allowed = allow or ()
+    return [f'{rel}:{lineno}' for rel, lineno, name in _src_calls() if rel not in allowed and predicate(name)]
+
+
+def _is_llm_call(name: str) -> bool:
+    return any(name == suffix or name.endswith('.' + suffix) for suffix in LLM_CALL_SUFFIXES)
+
+
+def _tail(name: str) -> str:
+    return name.rsplit('.', 1)[-1]
+
+
+# Call sites that predate common.llm_call. Shrink, never grow — the length
+# assertion below exists so growing it is a deliberate, visible edit.
+LLM_CALL_ALLOW = frozenset({
+    'common/llm_call.py',  # canonical
+    'common/structured_output.py',  # canonical for schema output
+    'openresponses/target.py',  # Responses API transport
+    'redteam/backends/openai.py',  # backend transport
+    'redteam/backends/orq.py',  # backend transport
+    'redteam/adaptive/blackbox_classifier.py',
+    'redteam/adaptive/tool_chaining.py',
+    'simulation/agents/base.py',
+    'simulation/generators/first_message_generator.py',
+    'common/reports/executive_summary.py',
+})
+
+
+def test_llm_call_allowlist_does_not_grow() -> None:
+    assert len(LLM_CALL_ALLOW) == 10, (
+        'LLM_CALL_ALLOW changed size. Removing an entry (good) means lowering this '
+        'number; adding one means a new direct call site slipped in — route it '
+        'through evaluatorq.common.llm_call instead.'
+    )
+
+
+def test_llm_calls_go_through_the_shared_helper() -> None:
+    extra = _hits(_is_llm_call, allow=LLM_CALL_ALLOW)
+    assert not extra, (
+        'Direct LLM API call outside the shared path: '
+        + ', '.join(extra)
+        + '. Use evaluatorq.common.llm_call.execute_chat_completion / execute_chat_parse '
+        '(or common.structured_output for schema output) — they own span recording, '
+        'trace-header injection, token usage and the reserved-key guard.'
+    )
+
+
+def test_openai_clients_come_from_llm_client() -> None:
+    extra = _hits(lambda name: _tail(name) in OPENAI_CLIENT_NAMES, allow={'common/llm_client.py'})
+    assert not extra, (
+        'OpenAI client constructed outside common/llm_client.py: '
+        + ', '.join(extra)
+        + '. Use resolve_llm_client() — it owns env-var precedence, base-URL '
+        'resolution and max_retries.'
+    )
+
+
+def test_orq_clients_come_from_orq_client() -> None:
+    extra = _hits(lambda name: _tail(name) in ORQ_CLIENT_NAMES, allow={'common/orq_client.py'})
+    assert not extra, (
+        'Orq SDK client constructed outside common/orq_client.py: '
+        + ', '.join(extra)
+        + '. Use resolve_orq_client() — it owns the lazy import, the install hint, '
+        'the ORQ_API_KEY check and the ORQ_BASE_URL default.'
+    )
+
+
+def test_spans_are_opened_only_in_tracing_modules() -> None:
+    extra = [
+        hit
+        for hit in _hits(lambda name: _tail(name) in SPAN_NAMES)
+        if not (hit.startswith('tracing/') or Path(hit.split(':')[0]).name == 'tracing.py')
+    ]
+    assert not extra, (
+        'Span created outside a tracing module: '
+        + ', '.join(extra)
+        + '. Use evaluatorq.common.tracing.with_llm_span, or add a thin wrapper in your '
+        "surface's tracing.py that delegates to it — span naming stays one vocabulary."
+    )
+
+
+@pytest.mark.parametrize(
+    ('source', 'predicate', 'expected'),
+    [
+        ('await client.chat.completions.create(**params)', _is_llm_call, True),
+        ('client.beta.chat.completions.parse(**params)', _is_llm_call, True),
+        ('await self._client.responses.create(**kwargs)', _is_llm_call, True),
+        ('"""Prose about client.chat.completions.create."""', _is_llm_call, False),
+        ('# client.chat.completions.create(...)', _is_llm_call, False),
+        ('client = AsyncOpenAI(api_key=key)', lambda n: _tail(n) in OPENAI_CLIENT_NAMES, True),
+        ('client = openai.AzureOpenAI(api_key=key)', lambda n: _tail(n) in OPENAI_CLIENT_NAMES, True),
+        ('client = Orq(api_key=key)', lambda n: _tail(n) in ORQ_CLIENT_NAMES, True),
+        ('with tracer.start_as_current_span("x"):\n    pass', lambda n: _tail(n) in SPAN_NAMES, True),
+    ],
+)
+def test_detection_actually_fires(source: str, predicate: object, expected: bool) -> None:
+    """A guardrail nobody proved can fail is a guardrail that silently no-ops."""
+    assert callable(predicate)
+    assert any(predicate(name) for _, name in _calls(source)) is expected


### PR DESCRIPTION
## Why

Coding agents kept reinventing components that already exist in `common/`. The diagnosis: `CLAUDE.md` answered *"what files exist"* — which the filesystem answers for free, and answered wrongly (the tree listed 8 files under `common/`; there are 30). It never answered *"I need to call an LLM, what do I use"*. And nothing was enforced, so the prose was optional.

Patterns were mined from 40 merged PRs' inline review comments and 600 commits, not invented.

## What changed

**1. `CLAUDE.md`: tree → reuse table.** ~130 lines of directory listing replaced by a package map plus a *"Need X? Use Y. Do not reinvent."* table, one row per shared helper, plus house rules distilled from recurring review findings, plus a "Keeping this file true" loop (a convention learned in review lands here in the same PR, with its mechanical check, and something stale gets deleted).

**2. `tests/test_reuse_guardrails.py`: the mechanical half.** Four rules, AST-based rather than regex — LLM call sites, OpenAI client construction, Orq client construction, span creation. Each names its canonical helper on failure. Each is itself tested against a synthetic violation, because a guardrail nobody proved can fail is one that silently no-ops.

**3. `BLE001` enabled repo-wide with a debt register.** A blind `except Exception` around an LLM call swallows programming errors and returns degradation instead — in PR #96 a `TypeError` from a kwarg collision made *every* evaluation return `passed=None`, silently. New code is covered; the 91 pre-existing violations are baselined (34 files in `per-file-ignores`, 18 inline `noqa`) and tracked in RES-1298. Also bans `tenacity`/`backoff` (one retry layer, not two) and `requests` (httpx is already a runtime dep).

**4. `common/orq_client.resolve_orq_client`.** Five sites each had their own copy of lazy-import → install hint → `ORQ_API_KEY` → `ORQ_BASE_URL`. Two had drifted and never passed `server_url`, so **a self-hosted `ORQ_BASE_URL` was silently ignored** on the red-team job runner and the OWASP dataset fetcher. That is the `fix:` in this PR.

**5. Canonical docstrings** on `judge`, `extract_json`, `sanitize`, `messages`, `output_adapters` (which had no module docstring at all) and `run_manifest` — so the rule reaches an agent that opens the file without reading `CLAUDE.md`.

## Two false claims corrected

`CLAUDE.md` said extras are imported lazily inside functions; `redteam/ui/dashboard.py`, `dashboard/app.py` and the langchain integrations all import at module scope. And `retry.py`'s retry-multiplication used numbers matching no constant in this repo (`MAX_RETRY_ATTEMPTS` is 5, so it's 15 requests).

## Notes for review

- This went through an adversarial multi-critic review before landing; the decisions, including the rejected findings, are recorded on [RES-1298](https://linear.app/orqai/issue/RES-1298).
- Scoping BLE001 to two directories via nested `.ruff.toml` was tried and **does not work** — ruff resolves config from the invocation root, so `ruff check src` ignores them silently. Worth knowing before someone tries it again.
- `CLAUDE.md` is 258 lines and states a ~200-line ceiling. Deliberately deferred, not overlooked.

All four CI checks pass locally: `ruff check src`, `ruff format --check src`, `basedpyright` (0 errors, 0 warnings), `pytest -m 'not integration'` (4188 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)