### PR TITLE
docs: unwrap every hard-wrapped markdown file

### DIFF
--- a/.claude/skills/docs-coverage/SKILL.md
+++ b/.claude/skills/docs-coverage/SKILL.md
@@ -5,21 +5,15 @@ description: Use when checking whether evaluatorq docs cover every usage path �
 
 # docs-coverage
 
-The code supports combinations of things. This skill finds combinations a user could
-plausibly hit that no page explains.
+The code supports combinations of things. This skill finds combinations a user could plausibly hit that no page explains.
 
-Not a symbol checklist. "`red_team` is mentioned somewhere" is not coverage — the
-interesting question is whether *static mode against a `deployment:` target* is
-explained anywhere.
+Not a symbol checklist. "`red_team` is mentioned somewhere" is not coverage — the interesting question is whether *static mode against a `deployment:` target* is explained anywhere.
 
-Companion skill: `docs-drift` answers the opposite question — what the docs claim
-that is no longer true.
+Companion skill: `docs-drift` answers the opposite question — what the docs claim that is no longer true.
 
 ## Axes
 
-Read `axes.md` (next to this file) first. It defines the axis *names*, the tiers, and
-the impossible-combination list. Axis *values* come from source at run time, so new
-modes and backends appear automatically.
+Read `axes.md` (next to this file) first. It defines the axis *names*, the tiers, and the impossible-combination list. Axis *values* come from source at run time, so new modes and backends appear automatically.
 
 ## Step 0 — env guard
 
@@ -28,8 +22,7 @@ uv sync --all-extras --all-groups
 uv run eq --help >/dev/null && uv run eq redteam --help >/dev/null && echo "ENV OK"
 ```
 
-Without the `redteam` extra, whole axes vanish and the matrix reports phantom gaps.
-If `ENV OK` does not print, stop.
+Without the `redteam` extra, whole axes vanish and the matrix reports phantom gaps. If `ENV OK` does not print, stop.
 
 ## Step 1 — resolve axis values
 
@@ -45,29 +38,21 @@ grep -rn 'environ\|getenv' src         # env vars
 
 ## Step 2 — build the pairwise matrix
 
-Cross axes **pairwise**, not as a full cross-product. Six axes fully crossed is
-hundreds of cells, most of them nonsense; pairwise is the level at which a gap is
-actually actionable.
+Cross axes **pairwise**, not as a full cross-product. Six axes fully crossed is hundreds of cells, most of them nonsense; pairwise is the level at which a gap is actually actionable.
 
-Pairs worth checking: entry point × surface · entry point × target kind · entry point
-× mode · entry point × data source · entry point × evaluator kind · surface × target
-kind · mode × target kind.
+Pairs worth checking: entry point × surface · entry point × target kind · entry point × mode · entry point × data source · entry point × evaluator kind · surface × target kind · mode × target kind.
 
 For each cell:
 
-- **documented** — a hand-written page shows this combination working, or explains it
-  explicitly. Record `page.md#anchor`. Generated API pages never satisfy Tier 1.
+- **documented** — a hand-written page shows this combination working, or explains it explicitly. Record `page.md#anchor`. Generated API pages never satisfy Tier 1.
 - **`GAP`** — meaningful, undocumented.
 - **`N/A`** — listed in `axes.md` as impossible, or structurally meaningless.
 
-If a cell is `N/A` for a reason not yet in `axes.md`, **add it there** as part of the
-run. That is how the list stays useful instead of the same false gap being re-argued
-every time.
+If a cell is `N/A` for a reason not yet in `axes.md`, **add it there** as part of the run. That is how the list stays useful instead of the same false gap being re-argued every time.
 
 ## Step 3 — report
 
-Write `.context/docs-coverage-matrix.md`: one table per axis pair, then a ranked gap
-list — Tier 1 gaps first (entry points, CLI commands, env vars), Tier 2 below.
+Write `.context/docs-coverage-matrix.md`: one table per axis pair, then a ranked gap list — Tier 1 gaps first (entry points, CLI commands, env vars), Tier 2 below.
 
 ```markdown
 # docs-coverage — <date>
@@ -83,15 +68,11 @@ list — Tier 1 gaps first (entry points, CLI commands, env vars), Tier 2 below.
 1. `red_team()` × `hybrid` — no page explains when hybrid beats either pure mode.
 ```
 
-Summarise to the user, then ask before writing any docs. Gap-filling is prose
-authoring, not a mechanical fix — it needs a decision about what to say and where it
-belongs.
+Summarise to the user, then ask before writing any docs. Gap-filling is prose authoring, not a mechanical fix — it needs a decision about what to say and where it belongs.
 
 `.context/` is gitignored.
 
 ## Honest limits
 
-- The matrix is only as good as `axes.md`. A dimension nobody added is a dimension
-  nobody checks.
-- "Documented" is a judgement call. A passing mention and a worked example both
-  resolve to a page anchor; prefer requiring a runnable example for Tier 1.
+- The matrix is only as good as `axes.md`. A dimension nobody added is a dimension nobody checks.
+- "Documented" is a judgement call. A passing mention and a worked example both resolve to a page anchor; prefer requiring a runnable example for Tier 1.

--- a/.claude/skills/docs-drift/SKILL.md
+++ b/.claude/skills/docs-drift/SKILL.md
@@ -5,15 +5,11 @@ description: Use when checking whether evaluatorq docs still match the code — 
 
 # docs-drift
 
-Docs assert facts. This skill verifies each fact against current source and reports
-what no longer holds.
+Docs assert facts. This skill verifies each fact against current source and reports what no longer holds.
 
-**Truth-first, not diff-first.** A wrong flag default from six months ago is still
-wrong, and no git range will surface it. Verify everything; use the diff only to
-order the work.
+**Truth-first, not diff-first.** A wrong flag default from six months ago is still wrong, and no git range will surface it. Verify everything; use the diff only to order the work.
 
-Companion skill: `docs-coverage` answers the opposite question — what the code does
-that no page documents.
+Companion skill: `docs-coverage` answers the opposite question — what the code does that no page documents.
 
 ## Scope
 
@@ -36,32 +32,23 @@ uv sync --all-extras --all-groups
 uv run eq --help >/dev/null && uv run eq redteam --help >/dev/null && echo "ENV OK"
 ```
 
-`eq redteam` registers only when the `redteam` extra is installed. Without it every
-red-team flag looks deleted and this skill will confidently "fix" correct docs into
-wrong ones. **If `ENV OK` does not print, stop and report the env problem.** Never
-report findings from a partial install.
+`eq redteam` registers only when the `redteam` extra is installed. Without it every red-team flag looks deleted and this skill will confidently "fix" correct docs into wrong ones. **If `ENV OK` does not print, stop and report the env problem.** Never report findings from a partial install.
 
 ## Step 1 — collect claims
 
-Read the in-scope files and extract every falsifiable assertion. Five classes, in
-descending order of yield:
+Read the in-scope files and extract every falsifiable assertion. Five classes, in descending order of yield:
 
-1. **Symbols** — every `from evaluatorq... import X`, `eq.foo(...)`, `evaluatorq.Bar`
-   in prose or fenced blocks.
-2. **CLI flags** — every row of every flag table in `docs/cli-reference/*.md`:
-   flag name, short alias, type, default.
+1. **Symbols** — every `from evaluatorq... import X`, `eq.foo(...)`, `evaluatorq.Bar` in prose or fenced blocks.
+2. **CLI flags** — every row of every flag table in `docs/cli-reference/*.md`: flag name, short alias, type, default.
 3. **Signatures** — kwargs passed in doc examples; required params that examples omit.
-4. **Membership** — vulnerability IDs, strategy names, delivery methods, backend
-   keys, env var names mentioned anywhere in prose.
-5. **Behavioral prose** — "defaults to X", "runs concurrently", "only when
-   `evaluatorq[redteam]` is installed", "takes precedence over".
+4. **Membership** — vulnerability IDs, strategy names, delivery methods, backend keys, env var names mentioned anywhere in prose.
+5. **Behavioral prose** — "defaults to X", "runs concurrently", "only when `evaluatorq[redteam]` is installed", "takes precedence over".
 
 ## Step 2 — establish ground truth
 
 Hybrid. Execute where a command exists; read source where it doesn't.
 
-**CLI flags — execute.** `--help` is authoritative and prints defaults; extracting
-Typer defaults statically is guesswork.
+**CLI flags — execute.** `--help` is authoritative and prints defaults; extracting Typer defaults statically is guesswork.
 
 ```bash
 uv run eq redteam run --help
@@ -78,9 +65,7 @@ print(inspect.signature(evaluatorq.red_team))
 "
 ```
 
-**Membership and prose — read source.** Registries under
-`src/evaluatorq/redteam/*_registry.py`, enums in `contracts.py`, env vars via
-`grep -rn 'environ\|getenv' src`.
+**Membership and prose — read source.** Registries under `src/evaluatorq/redteam/*_registry.py`, enums in `contracts.py`, env vars via `grep -rn 'environ\|getenv' src`.
 
 ## Step 3 — classify each finding
 
@@ -90,13 +75,9 @@ print(inspect.signature(evaluatorq.red_team))
 | **judgement** | needs a decision about what to *say* — behavioral prose, restructured explanation | report, ask, then apply |
 | **removal** | a documented thing appears not to exist | **propose only, never apply** |
 
-Removal is never automatic. An absent symbol is more often a bad check — a lazy
-import, an optional extra, a re-export — than a real deletion. Deleting correct
-docs is the one failure mode of this skill that is expensive to undo.
+Removal is never automatic. An absent symbol is more often a bad check — a lazy import, an optional extra, a re-export — than a real deletion. Deleting correct docs is the one failure mode of this skill that is expensive to undo.
 
-Class-5 behavioral findings are inherently noisy: an LLM reading code to judge
-whether "defaults to X" still holds is the weakest check here. Always mark them
-low-confidence. Never auto-apply them.
+Class-5 behavioral findings are inherently noisy: an LLM reading code to judge whether "defaults to X" still holds is the weakest check here. Always mark them low-confidence. Never auto-apply them.
 
 ## Step 4 — report
 
@@ -126,8 +107,7 @@ Then summarise to the user and ask before touching anything in the last two sect
 
 ## Diff-scoped mode
 
-Default is the full sweep. For PR use, take a git range and verify only claims
-touching symbols, flags, env vars or registry members that the diff changes:
+Default is the full sweep. For PR use, take a git range and verify only claims touching symbols, flags, env vars or registry members that the diff changes:
 
 ```bash
 git diff --name-only origin/main... -- src

--- a/.claude/skills/mkdocs-material/references/github-pages.md
+++ b/.claude/skills/mkdocs-material/references/github-pages.md
@@ -7,8 +7,7 @@ mkdocs build --strict          # gate: never deploy a non-strict build
 mkdocs gh-deploy --force       # builds + force-pushes site to gh-pages branch
 ```
 
-`gh-deploy` adds `.nojekyll` automatically. Site appears at
-`https://<org>.github.io/<repo>/` once Pages is enabled.
+`gh-deploy` adds `.nojekyll` automatically. Site appears at `https://<org>.github.io/<repo>/` once Pages is enabled.
 
 ## Enabling Pages (one-time, required — gh-deploy does not do this)
 
@@ -21,22 +20,18 @@ gh api repos/<org>/<repo>/pages 2>/dev/null \
 
 ## Private / internal repos
 
-The site is NOT at `https://<org>.github.io/<repo>/`. GitHub serves it on an
-obfuscated private domain behind org SSO. Get the real URL and use it as
-`site_url` in mkdocs.yml:
+The site is NOT at `https://<org>.github.io/<repo>/`. GitHub serves it on an obfuscated private domain behind org SSO. Get the real URL and use it as `site_url` in mkdocs.yml:
 
 ```bash
 gh api repos/<org>/<repo>/pages --jq .html_url
 # e.g. https://shiny-adventure-e4ky67z.pages.github.io/
 ```
 
-A `curl` of that URL returns `302` to `https://github.com/pages/auth?...` —
-that means it works; auth happens in the browser.
+A `curl` of that URL returns `302` to `https://github.com/pages/auth?...` — that means it works; auth happens in the browser.
 
 ## Verifying the deployment actually built
 
-A successful `gh-deploy` push does not guarantee Pages built the site.
-The Pages build runs server-side and can error independently:
+A successful `gh-deploy` push does not guarantee Pages built the site. The Pages build runs server-side and can error independently:
 
 ```bash
 gh api repos/<org>/<repo>/pages/builds/latest --jq '{status, error: .error.message}'
@@ -50,9 +45,7 @@ gh api repos/<org>/<repo>/pages/builds/latest --jq '{status, error: .error.messa
 gh api -X POST repos/<org>/<repo>/pages/builds
 ```
 
-A transient `errored` right after first enabling Pages is common; one
-rebuild usually fixes it. Persistent errors: check the gh-pages branch has
-`index.html` and `.nojekyll` at its root (`git ls-tree --name-only origin/gh-pages`).
+A transient `errored` right after first enabling Pages is common; one rebuild usually fixes it. Persistent errors: check the gh-pages branch has `index.html` and `.nojekyll` at its root (`git ls-tree --name-only origin/gh-pages`).
 
 ## CI auto-deploy (optional)
 

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -2,20 +2,11 @@
 
 ## Completed
 
-- Replaced the red-team tracing module hierarchy with the requested concise
-  dynamic/hybrid and static shapes, and documented the intentional absence of
-  static multi-turn and adversarial-generation spans.
-- Documented the process-lifetime provider, the three batch tuning variables,
-  flush-timeout warning, API-key restart requirement, and SIGKILL limitation in
-  `tracing_session` and tracing setup.
-- Updated the lifecycle design specification to use `tracing_session`
-  consistently, remove the stale interim lifecycle-flag narrative, and include
-  static `attack → target_call` nesting.
-- Removed five stale direct inner-runner lifecycle mock pairs from the red-team
-  hook lifecycle tests. The public `red_team()` boundary remains patched via
-  `tracing_session` where needed.
-- Made the Task 5 Ruff command clean by applying its safe auto-fixes and narrow
-  test-only suppressions for pytest assertions and necessarily async helpers.
+- Replaced the red-team tracing module hierarchy with the requested concise dynamic/hybrid and static shapes, and documented the intentional absence of static multi-turn and adversarial-generation spans.
+- Documented the process-lifetime provider, the three batch tuning variables, flush-timeout warning, API-key restart requirement, and SIGKILL limitation in `tracing_session` and tracing setup.
+- Updated the lifecycle design specification to use `tracing_session` consistently, remove the stale interim lifecycle-flag narrative, and include static `attack → target_call` nesting.
+- Removed five stale direct inner-runner lifecycle mock pairs from the red-team hook lifecycle tests. The public `red_team()` boundary remains patched via `tracing_session` where needed.
+- Made the Task 5 Ruff command clean by applying its safe auto-fixes and narrow test-only suppressions for pytest assertions and necessarily async helpers.
 
 ## Automated verification
 
@@ -33,13 +24,8 @@ git diff --check
 
 ## Live verification
 
-Not run. `ORQ_API_KEY` was configured, but no approved, scoped non-production
-target was declared (`ORQ_REDTEAM_TEST_TARGET` and `ORQ_APPROVED_TEST_TARGET`
-were unset). No credential, target, authorization header, or request payload was
-recorded.
+Not run. `ORQ_API_KEY` was configured, but no approved, scoped non-production target was declared (`ORQ_REDTEAM_TEST_TARGET` and `ORQ_APPROVED_TEST_TARGET` were unset). No credential, target, authorization header, or request payload was recorded.
 
 ## Review
 
-Task-level review found no critical defects. Its one minor design-document
-inventory inconsistency was corrected before the final commit. Live trace
-verification remains an explicit follow-up pending an approved scoped target.
+Task-level review found no critical defects. Its one minor design-document inventory inconsistency was corrected before the final commit. Live trace verification remains an explicit follow-up pending an approved scoped target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,43 +11,10 @@ All notable changes to `evaluatorq` are documented here.
 - **`LLMCallConfig.temperature` has no default — unset means the parameter is not sent, and the provider applies its own.** It previously defaulted to `1.0`, and evaluatorq's own call sites layered literals of their own on top (`0.8` for persona and first-message generation, `0.9` for edge-case scenarios, `0.7` for the executive summary and chat-completions agent calls, `0.3` for trace analysis, `0.0` for the judge). Reasoning-class models reject the parameter outright rather than clamping it — `gpt-5.6-luna` answers `400 Unsupported parameter: 'temperature' is not supported with this model` — so a hardcoded temperature on the default model turned every persona x scenario pair into a failure and `simulate()` into a `RuntimeError`. No call site sends a temperature now; a caller who wants one sets `LLMCallConfig(temperature=...)`, and a per-call `temperature=None` means unset rather than an explicit null. `BaseAgent._resolved_temperature` lost its `fallback` argument accordingly and now gates on `model_fields_set` like its sibling resolvers, so an explicit `LLMCallConfig(temperature=None)` opts an agent out rather than deferring to a call site. **The judge is the one behaviour change worth planning around: its scoring calls are no longer pinned to `temperature=0.0`, so judgments are no longer reproducible run-to-run by default.** That affects every `simulate()` caller, not only those on a reasoning model. Pass `JudgeAgentConfig(temperature=0.0)` to restore it — on a model that accepts the parameter.
 - **A set-but-empty `ORQ_OTEL_*` tuning variable now logs a `WARNING` and falls back to the default, instead of falling back silently.** `_env_int` treated an empty string like an unset variable, so an unresolved workflow variable in a CI `env:` block expands to the empty string and disabled the knob with no signal. Whitespace-only values are treated the same way. Related: `ORQ_OTEL_MAX_BATCH_SIZE` larger than `ORQ_OTEL_MAX_QUEUE_SIZE` is still clamped down to the queue size, but the clamp now announces itself with a `WARNING` rather than happening silently.
 - **`EVALUATORQ_REASONING_EFFORT` has no default — unset means the parameter is not sent, and the model applies its own.** It previously fell back to `"medium"` for the simulator's own calls (user simulator, judge). A global effort is the wrong default in both directions: on a model that does not accept the parameter it costs a rejected request plus a retry per `(model, tool shape)` — memoised per process, so a short run or CI job never amortises it — and on a model that does, it silently overrides the provider's own tuned value. Set the env var, or `LLMCallConfig.reasoning_effort` on the agent's config, when you actually want a specific effort. **Simulation only**; red teaming's `target_reasoning_effort` was already opt-in.
-- **`OrqResponsesTarget.retry_attempts` now defaults to `1` — a single attempt, no
-  retry — down from falling through to `with_retry`'s default of `5`.**
-  `common.target_call.call_target_with_retry` is the single retry owner for
-  target calls on every surface that drives a target (red team static, hybrid,
-  pipeline, orchestrator, and simulation); a target that also retries
-  internally multiplies against that budget instead of adding to it — 5 inner
-  attempts under 3 outer ones is 15 calls to a target that is already
-  refusing. Raise `retry_attempts` only when constructing the target directly
-  and calling `respond()` outside `call_target_with_retry`.
-- **`LLMCallConfig.completion_params()` and `.responses_params()` are removed.**
-  Both are replaced by a single `LLMCallConfig.request_params(*, api=None,
-  **params)`, which renders the shape the `api` argument names (`self.api`
-  when omitted). Two builders meant a call site could render a config that
-  says `responses` into chat-completions shape and no one would notice —
-  exactly the accepted-then-ignored failure this class exists to prevent. A
-  call site that is structurally single-endpoint passes `api=` explicitly and
-  gets a warning if that contradicts an explicitly-set `self.api`. **Update
-  any call site using either removed method** — there is no deprecation shim.
-- **Simulation's Responses calls and the executive-summary narrative now go
-  through the canonical executors, and are priced.** `BaseAgent._call_responses`
-  routes through `common.llm_call.execute_response`, and
-  `generate_executive_summary` routes through `execute_chat_completion` —
-  both now get slot limiting, the reasoning drop-and-retry-once, pipeline
-  metadata, trace headers and, previously missing, a `price_usage` call.
-  Simulation Responses calls on non-Orq endpoints were previously left
-  unpriced entirely. `generate_executive_summary` now returns an
-  `ExecutiveSummary(text, usage)` dataclass instead of `str | None` — **update
-  any caller that unpacked or compared the old return value directly.**
-- **Post-processing spend now lands in the run totals instead of only the log.**
-  Red team's `ReportSummary` gains `post_processing_token_usage` (recommendation
-  generation, including trace condensing, plus the executive summary), folded
-  into `token_usage_total` once both steps have run, been skipped, or failed —
-  previously that spend was log-only and invisible to `report.summary`.
-  Simulation's new `SimulationRun.token_usage_total` sums every result's usage
-  plus, for `generate_and_simulate()`, the GENERATE stage's persona/scenario
-  cost and the executive summary's cost; it does **not** include recommendation
-  generation, which stays log-only on both surfaces.
+- **`OrqResponsesTarget.retry_attempts` now defaults to `1` — a single attempt, no retry — down from falling through to `with_retry`'s default of `5`.** `common.target_call.call_target_with_retry` is the single retry owner for target calls on every surface that drives a target (red team static, hybrid, pipeline, orchestrator, and simulation); a target that also retries internally multiplies against that budget instead of adding to it — 5 inner attempts under 3 outer ones is 15 calls to a target that is already refusing. Raise `retry_attempts` only when constructing the target directly and calling `respond()` outside `call_target_with_retry`.
+- **`LLMCallConfig.completion_params()` and `.responses_params()` are removed.** Both are replaced by a single `LLMCallConfig.request_params(*, api=None, **params)`, which renders the shape the `api` argument names (`self.api` when omitted). Two builders meant a call site could render a config that says `responses` into chat-completions shape and no one would notice — exactly the accepted-then-ignored failure this class exists to prevent. A call site that is structurally single-endpoint passes `api=` explicitly and gets a warning if that contradicts an explicitly-set `self.api`. **Update any call site using either removed method** — there is no deprecation shim.
+- **Simulation's Responses calls and the executive-summary narrative now go through the canonical executors, and are priced.** `BaseAgent._call_responses` routes through `common.llm_call.execute_response`, and `generate_executive_summary` routes through `execute_chat_completion` — both now get slot limiting, the reasoning drop-and-retry-once, pipeline metadata, trace headers and, previously missing, a `price_usage` call. Simulation Responses calls on non-Orq endpoints were previously left unpriced entirely. `generate_executive_summary` now returns an `ExecutiveSummary(text, usage)` dataclass instead of `str | None` — **update any caller that unpacked or compared the old return value directly.**
+- **Post-processing spend now lands in the run totals instead of only the log.** Red team's `ReportSummary` gains `post_processing_token_usage` (recommendation generation, including trace condensing, plus the executive summary), folded into `token_usage_total` once both steps have run, been skipped, or failed — previously that spend was log-only and invisible to `report.summary`. Simulation's new `SimulationRun.token_usage_total` sums every result's usage plus, for `generate_and_simulate()`, the GENERATE stage's persona/scenario cost and the executive summary's cost; it does **not** include recommendation generation, which stays log-only on both surfaces.
 
 - **`turn_efficiency` no longer pays more for a longer conversation.** The scorer's cliffs stopped at 6 turns and the decay past them restarted from `1.0`, so a 7-turn run scored `0.9` while a 6-turn run scored `0.7` — the curve went *up* at the seam. The decay now continues from the last cliff's score (7 turns → `0.6`, 8 → `0.5`, floor `0.3`), so scores fall monotonically with turn count. Only runs that opted `turn_efficiency` or `conversation_quality` into `evaluator_names` are affected — neither is in the default `["goal_achieved", "criteria_met"]`. Both scorers' policy is now exposed as `simulate(scoring=SimulationScoringConfig(...))` / `generate_and_simulate(scoring=...)`: the cliffs, the decay, the floor and the composite weights, all with the shipped values as defaults. The config rejects unordered cliffs and weights that do not sum to `1.0` at construction.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,6 @@
 # evaluatorq — Color Design Language
 
-How we use the Orq brand colors (teal + orange) in the docs and any UI.
-One rule above all: **teal carries the interface, orange punctuates it.**
+How we use the Orq brand colors (teal + orange) in the docs and any UI. One rule above all: **teal carries the interface, orange punctuates it.**
 
 ## Palette
 
@@ -47,8 +46,7 @@ Orange is a finger pointing at **one** thing. It is never decoration.
 
 ## The one-accent rule
 
-Per screen, ask: *what is the single most important action here?* That gets orange.
-Everything else stays teal or neutral. If you've used orange twice, one of them is wrong.
+Per screen, ask: *what is the single most important action here?* That gets orange. Everything else stays teal or neutral. If you've used orange twice, one of them is wrong.
 
 > Calm teal field, one orange spark. If everything is accented, nothing is.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,11 +6,7 @@ product
 
 ## Users
 
-ML/AI engineers and safety researchers who run `evaluatorq` red-team and agent-simulation
-jobs from the CLI, then open the FastHTML dashboard to inspect the results. They arrive
-after a run finishes, usually to answer one question: *did my agent hold up, and where did
-it break?* They are technically fluent, work in dense information, and drill from a summary
-into individual conversation transcripts.
+ML/AI engineers and safety researchers who run `evaluatorq` red-team and agent-simulation jobs from the CLI, then open the FastHTML dashboard to inspect the results. They arrive after a run finishes, usually to answer one question: *did my agent hold up, and where did it break?* They are technically fluent, work in dense information, and drill from a summary into individual conversation transcripts.
 
 ## Product Purpose
 
@@ -18,15 +14,11 @@ A local, zero-config results dashboard for two evaluation surfaces:
 - **Agent simulation** — persona × scenario conversations scored for goal completion.
 - **Red team** — OWASP LLM/ASI attacks scored pass (resistant) / fail (vulnerable).
 
-Success = a researcher lands on a report and, within seconds, sees the headline outcome,
-the shape of the failures (which categories/personas/agents), and can open any single
-conversation to read what actually happened. The dashboard reports; it does not run jobs.
+Success = a researcher lands on a report and, within seconds, sees the headline outcome, the shape of the failures (which categories/personas/agents), and can open any single conversation to read what actually happened. The dashboard reports; it does not run jobs.
 
 ## Brand Personality
 
-Precise, calm, trustworthy. An instrument, not a marketing surface. Three words:
-*legible, dense, honest.* Numbers are the hero; chrome recedes. `passed=True` means the
-attack was resisted — the UI must never let that polarity confuse the reader.
+Precise, calm, trustworthy. An instrument, not a marketing surface. Three words: *legible, dense, honest.* Numbers are the hero; chrome recedes. `passed=True` means the attack was resisted — the UI must never let that polarity confuse the reader.
 
 ## Anti-references
 
@@ -37,13 +29,11 @@ attack was resisted — the UI must never let that polarity confuse the reader.
 ## Design Principles
 
 1. **Numbers are the hero.** Chrome, borders, and color recede so data reads first.
-2. **Outcome polarity is sacred.** Resistant/vulnerable and goal/no-goal must be
-   unmistakable at a glance and consistent across every surface.
+2. **Outcome polarity is sacred.** Resistant/vulnerable and goal/no-goal must be unmistakable at a glance and consistent across every surface.
 3. **Summary → shape → transcript.** Every report supports the same drill path.
 4. **Earned familiarity.** Standard table/tab/filter affordances; the tool disappears.
 5. **Honest visualization.** No chart that distorts scale or hides sample size.
 
 ## Accessibility & Inclusion
 
-WCAG AA: body text ≥4.5:1, large text ≥3:1. Pass/fail state must never rely on color
-alone (pair with label/icon). Respect `prefers-reduced-motion`.
+WCAG AA: body text ≥4.5:1, large text ≥3:1. Pass/fail state must never rely on color alone (pair with label/icon). Respect `prefers-reduced-motion`.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,10 @@
-<p align="center">
-  <img src="docs/assets/evaluatorq-splash.svg" alt="evaluatorq — LLM evals, red teaming, agent simulation" width="100%">
-</p>
+<p align="center"> <img src="docs/assets/evaluatorq-splash.svg" alt="evaluatorq — LLM evals, red teaming, agent simulation" width="100%"> </p>
 
-<p align="center">
-  <a href="https://pypi.org/project/evaluatorq/"><img src="https://img.shields.io/pypi/v/evaluatorq.svg" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/evaluatorq/"><img src="https://img.shields.io/pypi/pyversions/evaluatorq.svg" alt="Python versions"></a>
-  <a href="https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml"><img src="https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
-  <a href="https://htmlpreview.github.io/?https://github.com/orq-ai/evaluatorq/blob/python-coverage-comment-action-data/htmlcov/index.html"><img src="https://raw.githubusercontent.com/orq-ai/evaluatorq/python-coverage-comment-action-data/badge.svg" alt="Coverage"></a>
-  <a href="https://orq-ai.github.io/evaluatorq/"><img src="https://img.shields.io/badge/Docs-Live%20Site-0A7B83" alt="Docs"></a>
-  <a href="https://github.com/orq-ai/evaluatorq/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT"></a>
-</p>
+<p align="center"> <a href="https://pypi.org/project/evaluatorq/"><img src="https://img.shields.io/pypi/v/evaluatorq.svg" alt="PyPI version"></a> <a href="https://pypi.org/project/evaluatorq/"><img src="https://img.shields.io/pypi/pyversions/evaluatorq.svg" alt="Python versions"></a> <a href="https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml"><img src="https://github.com/orq-ai/evaluatorq/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a> <a href="https://htmlpreview.github.io/?https://github.com/orq-ai/evaluatorq/blob/python-coverage-comment-action-data/htmlcov/index.html"><img src="https://raw.githubusercontent.com/orq-ai/evaluatorq/python-coverage-comment-action-data/badge.svg" alt="Coverage"></a> <a href="https://orq-ai.github.io/evaluatorq/"><img src="https://img.shields.io/badge/Docs-Live%20Site-0A7B83" alt="Docs"></a> <a href="https://github.com/orq-ai/evaluatorq/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT"></a> </p>
 
-<p align="center">
-  <b>Find out how your AI agent breaks — before your users do.</b>
-</p>
+<p align="center"> <b>Find out how your AI agent breaks — before your users do.</b> </p>
 
-<p align="center">
-  <a href="https://orq-ai.github.io/evaluatorq/">Documentation</a> ·
-  <a href="https://orq-ai.github.io/evaluatorq/guides/getting-started/">Get Started</a> ·
-  <a href="https://orq-ai.github.io/evaluatorq/guides/red-teaming/">Red Teaming</a> ·
-  <a href="https://orq-ai.github.io/evaluatorq/guides/agent-simulation/">Agent Simulation</a> ·
-  <a href="https://orq-ai.github.io/evaluatorq/dashboard/">Dashboard</a>
-</p>
+<p align="center"> <a href="https://orq-ai.github.io/evaluatorq/">Documentation</a> · <a href="https://orq-ai.github.io/evaluatorq/guides/getting-started/">Get Started</a> · <a href="https://orq-ai.github.io/evaluatorq/guides/red-teaming/">Red Teaming</a> · <a href="https://orq-ai.github.io/evaluatorq/guides/agent-simulation/">Agent Simulation</a> · <a href="https://orq-ai.github.io/evaluatorq/dashboard/">Dashboard</a> </p>
 
 Shipping an agent means answering three questions no test suite answers: does it give good answers, can it be talked into doing something it shouldn't, and does it hold up over a real conversation with an impatient human? evaluatorq answers all three from Python. It scores your agent's outputs against your data, attacks it the way a bad actor would — jailbreaks, prompt injection, tool abuse, data exfiltration — and puts a simulated user in front of it for a few dozen turns. Then it hands you a report naming what broke and what to do about it.
 
@@ -103,10 +86,7 @@ Every job runs against every data point, so adding a variant adds a column. Swap
 
 This is the repo's [`examples/lib/basics/support_agent_eval.py`](examples/lib/basics/support_agent_eval.py), minus its `__main__` guard.
 
-→ [Getting Started](https://orq-ai.github.io/evaluatorq/guides/getting-started/) ·
-[Evaluation reference](https://orq-ai.github.io/evaluatorq/evaluation-reference/) ·
-[Structured scores](https://orq-ai.github.io/evaluatorq/structured-results/) ·
-[LLM as a jury](https://orq-ai.github.io/evaluatorq/llm-as-a-jury/)
+→ [Getting Started](https://orq-ai.github.io/evaluatorq/guides/getting-started/) · [Evaluation reference](https://orq-ai.github.io/evaluatorq/evaluation-reference/) · [Structured scores](https://orq-ai.github.io/evaluatorq/structured-results/) · [LLM as a jury](https://orq-ai.github.io/evaluatorq/llm-as-a-jury/)
 
 ## Red teaming
 
@@ -167,9 +147,7 @@ Attacks run concurrently, so wall clock tracks the slowest attack far more than 
 
 To price a run you have not made yet, the [cost calculator](https://orq-ai.github.io/evaluatorq/guides/red-teaming/#ballpark-the-cost) takes the three numbers that vary — setup calls, attacks, turns — and a price tier.
 
-→ [Red teaming guide](https://orq-ai.github.io/evaluatorq/guides/red-teaming/) ·
-[Intro notebook](examples/red_teaming_intro.ipynb) ·
-[Example scripts](examples/redteam/)
+→ [Red teaming guide](https://orq-ai.github.io/evaluatorq/guides/red-teaming/) · [Intro notebook](examples/red_teaming_intro.ipynb) · [Example scripts](examples/redteam/)
 
 ## Agent simulation
 
@@ -204,9 +182,7 @@ print(results[0].goal_achieved, results[0].goal_completion_score)
 
 Simulation owns its `exit_on_failure=True` gate for dropped rows, so it can drop straight into CI; evaluator score failures remain available in the returned results. The target can be an Orq agent or any local async callable, including agents built with the OpenAI Agents SDK, LangGraph, CrewAI or PydanticAI — [the examples](examples/agent_simulation/) cover each, with screen recordings.
 
-→ [Agent simulation guide](https://orq-ai.github.io/evaluatorq/guides/agent-simulation/) ·
-[Intro notebook](examples/agent_simulation_intro.ipynb) ·
-[Example scripts](examples/agent_simulation/)
+→ [Agent simulation guide](https://orq-ai.github.io/evaluatorq/guides/agent-simulation/) · [Intro notebook](examples/agent_simulation_intro.ipynb) · [Example scripts](examples/agent_simulation/)
 
 ## Dashboard
 
@@ -237,8 +213,7 @@ eq --help
 
 Everything is environment variables; none are required for local evaluation. `ORQ_API_KEY` unlocks Orq datasets, result upload and automatic tracing; `OPENAI_API_KEY` backs red teaming and simulation without Orq.
 
-→ [Configuration](https://orq-ai.github.io/evaluatorq/configuration/) ·
-[Tracing](https://orq-ai.github.io/evaluatorq/tracing/)
+→ [Configuration](https://orq-ai.github.io/evaluatorq/configuration/) · [Tracing](https://orq-ai.github.io/evaluatorq/tracing/)
 
 ## Development
 

--- a/VIDEO.md
+++ b/VIDEO.md
@@ -1,9 +1,6 @@
 # RES-931 demo videos - recording scripts
 
-Four short videos, about 60 to 90 seconds each, one per external framework. Same
-story every time: take an agent built in a real framework, wrap it as a red-team
-target in one line, run live attacks, let an LLM judge score them. The attacker is
-generative, so narrate what you see on screen, not fixed numbers.
+Four short videos, about 60 to 90 seconds each, one per external framework. Same story every time: take an agent built in a real framework, wrap it as a red-team target in one line, run live attacks, let an LLM judge score them. The attacker is generative, so narrate what you see on screen, not fixed numbers.
 
 ## Setup (run this once before recording)
 
@@ -24,8 +21,7 @@ PYTHONPATH=src uv run --frozen python examples/redteam/17_langgraph_target.py
 
 - Big terminal font so the final report table is readable on playback.
 - Start recording on a cleared prompt, run one command, stop when the report prints.
-- Save each file to `docs/assets/redteam-<framework>.mp4` (langgraph, openai-agents,
-  pydantic-ai, crewai). These are the slots already embedded in the red-teaming guide.
+- Save each file to `docs/assets/redteam-<framework>.mp4` (langgraph, openai-agents, pydantic-ai, crewai). These are the slots already embedded in the red-teaming guide.
 
 ---
 
@@ -36,16 +32,11 @@ PYTHONPATH=src uv run --frozen python examples/redteam/17_langgraph_target.py
 PYTHONPATH=src uv run --frozen python examples/redteam/17_langgraph_target.py
 ```
 
-**Say (intro):** "This is a LangGraph ReAct support agent with a refund tool. One
-line wraps it as a red-team target with `LangGraphTarget`, then the runner throws
-live prompt-injection attacks at it and an LLM judge scores each one against the
-OWASP agent-security categories."
+**Say (intro):** "This is a LangGraph ReAct support agent with a refund tool. One line wraps it as a red-team target with `LangGraphTarget`, then the runner throws live prompt-injection attacks at it and an LLM judge scores each one against the OWASP agent-security categories."
 
-**Point at:** the command (framework plus wrapper), the live attack progression,
-then the final report table.
+**Point at:** the command (framework plus wrapper), the live attack progression, then the final report table.
 
-**Payoff:** "It resists most, but one indirect injection lands. The attacker hides
-an instruction in tool output and hijacks the agent's goal."
+**Payoff:** "It resists most, but one indirect injection lands. The attacker hides an instruction in tool output and hijacks the agent's goal."
 
 ---
 
@@ -56,14 +47,11 @@ an instruction in tool output and hijacks the agent's goal."
 PYTHONPATH=src uv run --frozen python examples/redteam/18_openai_agents_target.py
 ```
 
-**Say (intro):** "Same runner, different framework. This agent is built on the
-OpenAI Agents SDK and wrapped with `OpenAIAgentTarget`. Nothing about the attack
-setup changes, only the one-line wrapper."
+**Say (intro):** "Same runner, different framework. This agent is built on the OpenAI Agents SDK and wrapped with `OpenAIAgentTarget`. Nothing about the attack setup changes, only the one-line wrapper."
 
 **Point at:** the wrapper name, the attacks running, the report table.
 
-**Payoff:** "Same shape as LangGraph. One indirect injection gets through, and the
-judge flags the goal hijack."
+**Payoff:** "Same shape as LangGraph. One indirect injection gets through, and the judge flags the goal hijack."
 
 ---
 
@@ -74,13 +62,11 @@ judge flags the goal hijack."
 PYTHONPATH=src uv run --frozen python examples/redteam/19_pydantic_ai_target.py
 ```
 
-**Say (intro):** "Third framework, Pydantic AI, wrapped with `PydanticAITarget`.
-Point the runner at it and attack, exactly as before."
+**Say (intro):** "Third framework, Pydantic AI, wrapped with `PydanticAITarget`. Point the runner at it and attack, exactly as before."
 
 **Point at:** the wrapper, the live verdicts, the final table.
 
-**Payoff:** "Again one attack lands. Three different frameworks, same weakness to
-indirect prompt injection."
+**Payoff:** "Again one attack lands. Three different frameworks, same weakness to indirect prompt injection."
 
 ---
 
@@ -91,14 +77,11 @@ indirect prompt injection."
 PYTHONPATH=src uv run --frozen python examples/redteam/20_crewai_target.py
 ```
 
-**Say (intro):** "Last one, a CrewAI agent wrapped with `CrewAITarget`. Same
-attacks, same judge."
+**Say (intro):** "Last one, a CrewAI agent wrapped with `CrewAITarget`. Same attacks, same judge."
 
 **Point at:** the wrapper, the attacks, the report table.
 
-**Payoff:** "This is the interesting one. CrewAI resists all three attacks, one
-hundred percent. Same runner, same attacks, different result. That is the point of
-the suite: you can measure this across any framework with one wrapper."
+**Payoff:** "This is the interesting one. CrewAI resists all three attacks, one hundred percent. Same runner, same attacks, different result. That is the point of the suite: you can measure this across any framework with one wrapper."
 
 ---
 

--- a/docs/_snippets/openai-direct-model.md
+++ b/docs/_snippets/openai-direct-model.md
@@ -1,6 +1,2 @@
 !!! warning "Going OpenAI-direct? Override the model default"
-    Every model default is `openai/gpt-5.6-luna` — provider-prefixed, because the
-    default route is the Orq router, which resolves `provider/model`. With only
-    `OPENAI_API_KEY` set, calls go straight to OpenAI, which does **not** know that
-    id and rejects it. Pass the bare `gpt-5.6-luna` (or any other OpenAI model id)
-    on every model flag you use.
+    Every model default is `openai/gpt-5.6-luna` — provider-prefixed, because the default route is the Orq router, which resolves `provider/model`. With only `OPENAI_API_KEY` set, calls go straight to OpenAI, which does **not** know that id and rejects it. Pass the bare `gpt-5.6-luna` (or any other OpenAI model id) on every model flag you use.

--- a/docs/_snippets/panel-tip.md
+++ b/docs/_snippets/panel-tip.md
@@ -1,4 +1,2 @@
 !!! tip "Keep the panel odd and mixed-provider"
-    An odd number of judges (3, 5) makes ties rare. A mix of provider families
-    gives the panel the independence a jury is meant to provide; several judges
-    from the same provider tend to be correlated and add little over one.
+    An odd number of judges (3, 5) makes ties rare. A mix of provider families gives the panel the independence a jury is meant to provide; several judges from the same provider tend to be correlated and add little over one.

--- a/docs/assets/dashboard/README.md
+++ b/docs/assets/dashboard/README.md
@@ -1,21 +1,12 @@
 # Dashboard screenshots
 
-Persistent copies of the `eq dashboard` screenshots produced for
-[DOC-653](https://linear.app/orqai/issue/DOC-653) (red teaming) and
-[DOC-655](https://linear.app/orqai/issue/DOC-655) (agent simulation). They were
-posted as Linear comments first; Linear's upload URLs are signed and expire, so
-the files live here instead. Docs pages and the README should reference these
-paths, not the Linear links.
+Persistent copies of the `eq dashboard` screenshots produced for [DOC-653](https://linear.app/orqai/issue/DOC-653) (red teaming) and [DOC-655](https://linear.app/orqai/issue/DOC-655) (agent simulation). They were posted as Linear comments first; Linear's upload URLs are signed and expire, so the files live here instead. Docs pages and the README should reference these paths, not the Linear links.
 
-Captured against the FastHTML dashboard at `main @ fcb525a6`, 1440×900, light
-theme, so the whole set reads consistently side by side.
+Captured against the FastHTML dashboard at `main @ fcb525a6`, 1440×900, light theme, so the whole set reads consistently side by side.
 
 ## Red teaming — `redteam-*.png`
 
-Source run: hybrid red team, 2 target agents (one deliberately vulnerable, one
-hardened), 40 attacks across 10 OWASP ASI/LLM categories, `gemini-2.5-flash`,
-LLM-as-judge scoring. 78% resistance, 9 vulnerabilities, 3 critical — real
-findings rather than an all-green wall.
+Source run: hybrid red team, 2 target agents (one deliberately vulnerable, one hardened), 40 attacks across 10 OWASP ASI/LLM categories, `gemini-2.5-flash`, LLM-as-judge scoring. 78% resistance, 9 vulnerabilities, 3 critical — real findings rather than an all-green wall.
 
 | File | Page |
 |---|---|
@@ -32,9 +23,7 @@ findings rather than an all-green wall.
 
 ## Agent simulation — `sim-*.png`
 
-Source run: `sim:refund-agent-fixed` — 10 personas × 5 scenarios = 50
-conversations against a refund agent, judged per turn. 74% goal completion, mean
-score 0.86, with one scenario column that clearly fails.
+Source run: `sim:refund-agent-fixed` — 10 personas × 5 scenarios = 50 conversations against a refund agent, judged per turn. 74% goal completion, mean score 0.86, with one scenario column that clearly fails.
 
 | File | Page |
 |---|---|
@@ -50,14 +39,7 @@ score 0.86, with one scenario column that clearly fails.
 
 ## Pending re-shoot
 
-Five shots do not show the thing their caption teaches. The decision is to
-re-shoot the set in one purpose-built capture session rather than keep
-documenting around it. Until then the four that exist are **unreferenced** —
-their `![...]` lines were removed from
-[`docs/dashboard.md`](../../dashboard.md); the prose stayed. Re-add each one in
-the same commit that replaces the file, not before. The prose caveats standing
-in for them are the only thing keeping the pages honest, so **do not delete
-them either**.
+Five shots do not show the thing their caption teaches. The decision is to re-shoot the set in one purpose-built capture session rather than keep documenting around it. Until then the four that exist are **unreferenced** — their `![...]` lines were removed from [`docs/dashboard.md`](../../dashboard.md); the prose stayed. Re-add each one in the same commit that replaces the file, not before. The prose caveats standing in for them are the only thing keeping the pages honest, so **do not delete them either**.
 
 | Shot | What's wrong | What the capture run needs |
 |---|---|---|
@@ -67,11 +49,6 @@ them either**.
 | `sim-07-turn-quality.png` | Judge ended most conversations after one turn, so the trend spans two points | Scenarios whose goals need several exchanges, and a higher `max_turns` |
 | `sim-09-compare.png` | Red "low overlap (0%)" banner — the two runs share no (persona, scenario) pairs | Two runs replayed from the same datapoints file, with **distinct run names** (the compare picker shows names only, no timestamps) |
 
-The screenshots that do show a report tab strip (`sim-03` … `sim-08`) are one
-tab short of the current dashboard, since Recommendations sits between
-Breakdown and Transcripts now. `sim-01`, `sim-02` and `sim-09` are outside a
-report and unaffected.
+The screenshots that do show a report tab strip (`sim-03` … `sim-08`) are one tab short of the current dashboard, since Recommendations sits between Breakdown and Transcripts now. `sim-01`, `sim-02` and `sim-09` are outside a report and unaffected.
 
-To re-shoot: run `eq dashboard` in a checkout with runs under
-`.evaluatorq/runs/` and `.evaluatorq/sim-runs/`, 1440×900, light theme, to
-match the existing set.
+To re-shoot: run `eq dashboard` in a checkout with runs under `.evaluatorq/runs/` and `.evaluatorq/sim-runs/`, 1440×900, light theme, to match the existing set.

--- a/docs/cli-reference/dashboard.md
+++ b/docs/cli-reference/dashboard.md
@@ -1,12 +1,8 @@
 # Dashboard (`eq dashboard`)
 
-Launches the FastHTML dashboard, the primary UI for browsing saved runs. It is
-the only report surface receiving new features; `eq redteam ui` and `eq sim ui`
-are the retired Streamlit viewers, still registered but no longer documented.
+Launches the FastHTML dashboard, the primary UI for browsing saved runs. It is the only report surface receiving new features; `eq redteam ui` and `eq sim ui` are the retired Streamlit viewers, still registered but no longer documented.
 
-For what the dashboard shows once it is open — the run index, the red-team and
-simulation walkthroughs, and applying recommendations to an agent — see
-[Dashboard](../dashboard.md). This page covers the command only.
+For what the dashboard shows once it is open — the run index, the red-team and simulation walkthroughs, and applying recommendations to an agent — see [Dashboard](../dashboard.md). This page covers the command only.
 
 ```bash
 eq dashboard [PATHS]... [OPTIONS]
@@ -20,16 +16,11 @@ eq dashboard [PATHS]... [OPTIONS]
 
 ## What gets scanned
 
-The argument is what decides which runs appear, and the three forms behave
-differently:
+The argument is what decides which runs appear, and the three forms behave differently:
 
-- **No path** — scans both default stores together: `.evaluatorq/runs/` (red
-  team) and `.evaluatorq/sim-runs/` (simulation). This is the usual invocation.
-- **One or more directories** — scans exactly those, together. Useful for
-  putting simulation runs from one repo next to red-team runs from another.
-- **A file** — scans that file's *parent directory*, so sibling reports still
-  resolve, and prints the direct URL for that one report. You land on the report
-  rather than the index.
+- **No path** — scans both default stores together: `.evaluatorq/runs/` (red team) and `.evaluatorq/sim-runs/` (simulation). This is the usual invocation.
+- **One or more directories** — scans exactly those, together. Useful for putting simulation runs from one repo next to red-team runs from another.
+- **A file** — scans that file's *parent directory*, so sibling reports still resolve, and prints the direct URL for that one report. You land on the report rather than the index.
 
 ```bash
 # every saved run, both stores
@@ -47,7 +38,4 @@ eq dashboard .evaluatorq/runs/red-team-2026-08-18T09-14-02.json
 
 ## Binding
 
-`--host` defaults to `127.0.0.1`, so the dashboard is reachable only from the
-machine running it. Binding elsewhere exposes every saved run — transcripts,
-system prompts, and judge verdicts — to anyone who can reach the port. There is
-no authentication layer. Put it behind one before binding to `0.0.0.0`.
+`--host` defaults to `127.0.0.1`, so the dashboard is reachable only from the machine running it. Binding elsewhere exposes every saved run — transcripts, system prompts, and judge verdicts — to anyone who can reach the port. There is no authentication layer. Put it behind one before binding to `0.0.0.0`.

--- a/docs/cli-reference/overview.md
+++ b/docs/cli-reference/overview.md
@@ -11,12 +11,7 @@ eq         = "evaluatorq.cli:main"
 Subcommands are registered at startup. `eq redteam` requires the `redteam` extra; `eq sim` requires the `simulation` extra.
 
 !!! note "Primary UI — `eq dashboard`"
-    The recommended way to browse saved runs is the multi-run FastHTML dashboard,
-    `eq dashboard`. The canonical invocation scans a run directory — `eq dashboard`
-    browses both default stores (red team + simulation), and `eq dashboard
-    .evaluatorq/sim-runs` scopes to simulation. Passing a single JSON report file
-    is an optional direct deep-link. See [Dashboard](../dashboard.md) and
-    [Simulation](simulation.md).
+    The recommended way to browse saved runs is the multi-run FastHTML dashboard, `eq dashboard`. The canonical invocation scans a run directory — `eq dashboard` browses both default stores (red team + simulation), and `eq dashboard .evaluatorq/sim-runs` scopes to simulation. Passing a single JSON report file is an optional direct deep-link. See [Dashboard](../dashboard.md) and [Simulation](simulation.md).
 
 Two command groups have their own pages:
 
@@ -26,9 +21,7 @@ Two command groups have their own pages:
 ## Canonical flag names
 
 !!! note "Simulation I/O flags name the artifact they read or write"
-    Commands that read a datapoints file use `--input` / `-i` (`simulate`,
-    `export`, `upload-dataset`). Output flags are named for the artifact each
-    command writes:
+    Commands that read a datapoints file use `--input` / `-i` (`simulate`, `export`, `upload-dataset`). Output flags are named for the artifact each command writes:
 
     | Command | Output flag(s) | Writes |
     |---|---|---|
@@ -37,10 +30,7 @@ Two command groups have their own pages:
     | `sim run` | `--datapoints` / `-d`, `--results` / `-r` | generated inputs, and the results |
     | `sim export` | `--output` / `-o` | OpenResponses payload JSON |
 
-    The generic `--output` / `-o` was **removed** from `generate` / `simulate` /
-    `run` — it wrote a different artifact per command. `sim export` keeps it, as
-    it has a single output. On `sim simulate`, the input file is `--input` / `-i`
-    (there is no `--datapoints` input alias).
+    The generic `--output` / `-o` was **removed** from `generate` / `simulate` / `run` — it wrote a different artifact per command. `sim export` keeps it, as it has a single output. On `sim simulate`, the input file is `--input` / `-i` (there is no `--datapoints` input alias).
 
     Other historical migrations are:
 
@@ -61,8 +51,7 @@ Two command groups have their own pages:
     - CLI `redteam run --output-dir` — removed, use `--artifacts-dir` (no such option)
 
 !!! note "Simulation validation"
-    Use `eq sim validate --input PATH`. The older `eq sim validate-dataset PATH`
-    command remains as a compatibility alias (see [Simulation](simulation.md)).
+    Use `eq sim validate --input PATH`. The older `eq sim validate-dataset PATH` command remains as a compatibility alias (see [Simulation](simulation.md)).
 
 ## Top-level options
 

--- a/docs/cli-reference/redteam.md
+++ b/docs/cli-reference/redteam.md
@@ -57,24 +57,12 @@ eq redteam run --target agent:<key> [OPTIONS]
 
 **Saving results.** Persistence is controlled by two flags. `--save` accepts `none` (no files), `final` (summary JSON only), or `detail` (all per-stage artifacts). `--artifacts-dir DIR` sets where JSON is written and is **required** when `--save detail` (`--output-dir` was removed; use `--artifacts-dir`).
 
-**Exit codes.** `eq redteam run` exits `1` — after writing any requested report
-artifacts — in two cases, both read off `report.summary`:
+**Exit codes.** `eq redteam run` exits `1` — after writing any requested report artifacts — in two cases, both read off `report.summary`:
 
-- **Zero verdicts** (`summary.no_verdict`): attacks ran but not one could be
-  evaluated. Always fails; there is no setting that disables this.
-- **Coverage below the floor** (`summary.coverage_below_minimum`): fewer than
-  `--min-evaluation-coverage` (default **`0.8`**) of attacks got a verdict.
-  **A run that finishes at 79% coverage now exits `1`**, not `0` with a warning —
-  the same run used to pass. Pass `--min-evaluation-coverage 0` to warn instead
-  of failing, or a higher value to be stricter. The Python equivalent is
-  `EvaluatorConfig.min_evaluation_coverage` (`None` there also means warn-only)
-  — see [Red Teaming › In CI](../guides/red-teaming.md#in-ci).
+- **Zero verdicts** (`summary.no_verdict`): attacks ran but not one could be evaluated. Always fails; there is no setting that disables this.
+- **Coverage below the floor** (`summary.coverage_below_minimum`): fewer than `--min-evaluation-coverage` (default **`0.8`**) of attacks got a verdict. **A run that finishes at 79% coverage now exits `1`**, not `0` with a warning — the same run used to pass. Pass `--min-evaluation-coverage 0` to warn instead of failing, or a higher value to be stricter. The Python equivalent is `EvaluatorConfig.min_evaluation_coverage` (`None` there also means warn-only) — see [Red Teaming › In CI](../guides/red-teaming.md#in-ci).
 
-Both cases print the dominant failure cause with a sample message before
-exiting: an `evaluation/<code>` (timeout / parse / api_connection / api_status /
-scorer_exception) when the judge failed, or an `execution/<code>` when the
-target failed and there was nothing to judge. Either way a systematically
-blocked run is diagnosable from the CLI output alone.
+Both cases print the dominant failure cause with a sample message before exiting: an `evaluation/<code>` (timeout / parse / api_connection / api_status / scorer_exception) when the judge failed, or an `execution/<code>` when the target failed and there was nothing to judge. Either way a systematically blocked run is diagnosable from the CLI output alone.
 
 ---
 

--- a/docs/cli-reference/simulation.md
+++ b/docs/cli-reference/simulation.md
@@ -5,10 +5,7 @@ Agent simulation subcommand group. Registered only when `evaluatorq[simulation]`
 Three main verbs: `generate` (datapoints only), `simulate` (run against pre-built datapoints), `run` (generate then simulate in one shot).
 
 !!! note "Primary UI — `eq dashboard`"
-    The recommended way to browse saved simulation runs is the multi-run FastHTML
-    dashboard, `eq dashboard .evaluatorq/sim-runs` (scopes to simulation) or
-    `eq dashboard` (both stores). Passing a single JSON report file is an optional
-    direct deep-link.
+    The recommended way to browse saved simulation runs is the multi-run FastHTML dashboard, `eq dashboard .evaluatorq/sim-runs` (scopes to simulation) or `eq dashboard` (both stores). Passing a single JSON report file is an optional direct deep-link.
 
 --8<-- "docs/_snippets/openai-direct-model.md"
 
@@ -66,13 +63,9 @@ Run simulations from a pre-built datapoints JSONL file.
 eq sim simulate --input dp.jsonl --target agent:<key>
 ```
 
-Targets — same three flags as `eq sim run`. Provide exactly one of four input
-sources: `--input` (`-i`), `--dataset-id`, `--experiment-id` (optionally narrowed
-by `--experiment-run-id`), or `--from-run`.
+Targets — same three flags as `eq sim run`. Provide exactly one of four input sources: `--input` (`-i`), `--dataset-id`, `--experiment-id` (optionally narrowed by `--experiment-run-id`), or `--from-run`.
 
-There is no `--target-reasoning-effort` here — it is a `eq sim run` flag only. To
-pin the target's reasoning effort on a pre-built datapoint set, call `simulate()`
-with `target_reasoning_effort=` from Python (see [Tuning](../tuning.md)).
+There is no `--target-reasoning-effort` here — it is a `eq sim run` flag only. To pin the target's reasoning effort on a pre-built datapoint set, call `simulate()` with `target_reasoning_effort=` from Python (see [Tuning](../tuning.md)).
 
 | Flag | Type / Default | Description |
 |---|---|---|
@@ -103,17 +96,14 @@ with `target_reasoning_effort=` from Python (see [Tuning](../tuning.md)).
 
 ## `eq sim upload-dataset`
 
-Upload simulation datapoints to an Orq dataset, or append them to an existing
-dataset.
+Upload simulation datapoints to an Orq dataset, or append them to an existing dataset.
 
 ```bash
 eq sim upload-dataset -i cases.jsonl -n "Support simulation set"
 eq sim upload-dataset -i more.jsonl --dataset-id <id>
 ```
 
-Persona and scenario objects are JSON-stringified because the Orq dataset API
-accepts scalar `inputs` values. The simulation reader restores them when the
-dataset is used with `eq sim simulate --dataset-id`.
+Persona and scenario objects are JSON-stringified because the Orq dataset API accepts scalar `inputs` values. The simulation reader restores them when the dataset is used with `eq sim simulate --dataset-id`.
 
 | Flag | Type / Default | Description |
 |---|---|---|
@@ -157,12 +147,7 @@ eq sim from-traces --output dp.jsonl --limit 50 --lookback-hours 24
 eq sim from-traces --output dp.jsonl --extend 20 --agent-description "..."
 ```
 
-Fetches recent traces from the Orq traces API (requires `ORQ_API_KEY`) and builds
-one datapoint per trace conversation: persona and scenario are inferred from the
-transcript, and the first message is the real user's opening message verbatim.
-Pass `--extend N` to additionally generate `N` new datapoints matching the traffic
-distribution of the fetched traces (extra LLM calls). Feed the output file to
-`eq sim simulate --input` to run it.
+Fetches recent traces from the Orq traces API (requires `ORQ_API_KEY`) and builds one datapoint per trace conversation: persona and scenario are inferred from the transcript, and the first message is the real user's opening message verbatim. Pass `--extend N` to additionally generate `N` new datapoints matching the traffic distribution of the fetched traces (extra LLM calls). Feed the output file to `eq sim simulate --input` to run it.
 
 | Flag | Type / Default | Description |
 |---|---|---|
@@ -187,10 +172,7 @@ eq sim export --input results.jsonl --output payload.json
 eq sim export --input sim-report.json --output report.html --format html --recommendations
 ```
 
-Markdown/HTML exports include remediation suggestions if the input run JSON
-already carries them (runs generate them by default — see `--no-recommendations`),
-or if `--recommendations` is passed here to generate them at export time for a run
-that has none stored.
+Markdown/HTML exports include remediation suggestions if the input run JSON already carries them (runs generate them by default — see `--no-recommendations`), or if `--recommendations` is passed here to generate them at export time for a run that has none stored.
 
 | Flag | Type / Default | Description |
 |---|---|---|

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -3,10 +3,7 @@
 This guide explains how to add custom evaluators, vulnerabilities, attack strategies, and frameworks to the evaluatorq red teaming system.
 
 !!! note "Requires editing the package source"
-    The extension points below modify evaluatorq's internal registries directly —
-    they are not a stable runtime API. Clone the repo and sync the dev
-    environment (`uv sync --all-extras --all-groups`), then make your changes
-    there. A runtime registration API is planned; see the [Roadmap](roadmap.md).
+    The extension points below modify evaluatorq's internal registries directly — they are not a stable runtime API. Clone the repo and sync the dev environment (`uv sync --all-extras --all-groups`), then make your changes there. A runtime registration API is planned; see the [Roadmap](roadmap.md).
 
 ## Architecture overview
 
@@ -199,12 +196,7 @@ my_strategies = [
 
 ### Registering strategies
 
-Create a strategy file (e.g., `frameworks/my_framework.py`) with a
-`dict[str, list[AttackStrategy]]` keyed by category code, then edit
-`adaptive/strategy_registry.py` directly. `STRATEGY_REGISTRY` and
-`VULNERABILITY_STRATEGY_REGISTRY` are frozen `MappingProxyType`s built at
-import time, so merge into the private `_strategy_registry` dict **before** it
-is wrapped — you cannot mutate the exported registries from outside the module:
+Create a strategy file (e.g., `frameworks/my_framework.py`) with a `dict[str, list[AttackStrategy]]` keyed by category code, then edit `adaptive/strategy_registry.py` directly. `STRATEGY_REGISTRY` and `VULNERABILITY_STRATEGY_REGISTRY` are frozen `MappingProxyType`s built at import time, so merge into the private `_strategy_registry` dict **before** it is wrapped — you cannot mutate the exported registries from outside the module:
 
 ```python
 from evaluatorq.redteam.frameworks.my_framework import MY_STRATEGIES
@@ -216,10 +208,7 @@ _strategy_registry: dict[str, list[AttackStrategy]] = {
 }
 ```
 
-No separate step is needed for the vulnerability-keyed registry — it is derived
-automatically from `_strategy_registry` via `CATEGORY_TO_VULNERABILITY`, as long
-as your category code is mapped to the vulnerability in
-`VulnerabilityDef.framework_mappings` (see "Adding a new vulnerability" above).
+No separate step is needed for the vulnerability-keyed registry — it is derived automatically from `_strategy_registry` via `CATEGORY_TO_VULNERABILITY`, as long as your category code is mapped to the vulnerability in `VulnerabilityDef.framework_mappings` (see "Adding a new vulnerability" above).
 
 ### Capability requirements
 
@@ -232,10 +221,7 @@ Available capability tags: `code_execution`, `shell_access`, `file_system`, `web
 
 ### Custom delivery methods
 
-`delivery_method` is an **open set**. The canonical methods live in the `DeliveryMethod`
-enum (each mapped to a technique family in `DELIVERY_METHOD_CATEGORY`), and
-`delivery_method_registry.py` mirrors the vulnerability registry so you can add your own
-without touching the enum:
+`delivery_method` is an **open set**. The canonical methods live in the `DeliveryMethod` enum (each mapped to a technique family in `DELIVERY_METHOD_CATEGORY`), and `delivery_method_registry.py` mirrors the vulnerability registry so you can add your own without touching the enum:
 
 ```python
 from evaluatorq.redteam.delivery_method_registry import (
@@ -249,21 +235,9 @@ register_delivery_method('emoji-smuggling', category='obfuscation')
 is_known_delivery_method('emoji-smuggling')  # True
 ```
 
-Unlike vulnerabilities (reject-unknown, since an unknown vuln has no strategies or
-evaluator), delivery methods are **coerce-known + passthrough-unknown**: an unregistered
-value is a harmless filter label that either matches a dataset row spelled the same or
-does not. Filtering therefore works without registering anything — registering only
-suppresses the "unknown delivery method" warnings: the `--delivery-method` CLI flag warns up
-front via `typer.echo`, and a programmatic `red_team()` run surfaces an unmatched method through
-the pipeline's post-filter check as a `loguru` warning (the `RedTeamInput` validator itself resolves
-silently). A registered value stays a plain string; only enum members
-resolve to a `DeliveryMethod` object.
+Unlike vulnerabilities (reject-unknown, since an unknown vuln has no strategies or evaluator), delivery methods are **coerce-known + passthrough-unknown**: an unregistered value is a harmless filter label that either matches a dataset row spelled the same or does not. Filtering therefore works without registering anything — registering only suppresses the "unknown delivery method" warnings: the `--delivery-method` CLI flag warns up front via `typer.echo`, and a programmatic `red_team()` run surfaces an unmatched method through the pipeline's post-filter check as a `loguru` warning (the `RedTeamInput` validator itself resolves silently). A registered value stays a plain string; only enum members resolve to a `DeliveryMethod` object.
 
-The registry is **in-memory and process-local** — it is not persisted and there is no
-plugin/entry-point loading. Registering in a standalone script does not make the value
-known to a separate `eq redteam run` process; to get the CLI benefit, register in the
-same process that invokes the CLI (or accept the warning, since filtering works either
-way).
+The registry is **in-memory and process-local** — it is not persisted and there is no plugin/entry-point loading. Registering in a standalone script does not make the value known to a separate `eq redteam run` process; to get the CLI benefit, register in the same process that invokes the CLI (or accept the warning, since filtering works either way).
 
 ## Adding a new framework
 

--- a/docs/cyclic-judge.md
+++ b/docs/cyclic-judge.md
@@ -1,16 +1,8 @@
 # Cyclic judge assignment (CyclicJudge)
 
-A jury normally runs every judge on every datapoint. That buys a per-item
-consensus, and it costs `len(panel)` judge calls per item. If what you actually
-report is a run-level number — a benchmark mean, a pass rate, a regression delta
-between two prompts — you are paying for per-item confidence you never read.
+A jury normally runs every judge on every datapoint. That buys a per-item consensus, and it costs `len(panel)` judge calls per item. If what you actually report is a run-level number — a benchmark mean, a pass rate, a regression delta between two prompts — you are paying for per-item confidence you never read.
 
-`assignment="cyclic"` implements CyclicJudge
-([arXiv:2603.01865](https://arxiv.org/abs/2603.01865)): give each datapoint one
-judge, and rotate through the panel so every judge covers an equal share of the
-run. Individual judge bias still cancels across the dataset, because each judge
-scored the same fraction of it — but the run costs the same as a single-judge
-evaluation.
+`assignment="cyclic"` implements CyclicJudge ([arXiv:2603.01865](https://arxiv.org/abs/2603.01865)): give each datapoint one judge, and rotate through the panel so every judge covers an equal share of the run. Individual judge bias still cancels across the dataset, because each judge scored the same fraction of it — but the run costs the same as a single-judge evaluation.
 
 ```python
 from evaluatorq import llm_jury
@@ -23,9 +15,7 @@ jury = llm_jury(
 )
 ```
 
-Everything else about the jury is unchanged — `criteria`, verdict modes,
-aggregators, replacements. `assignment` only decides *who scores what*, so it
-composes with the vote-level settings rather than competing with them.
+Everything else about the jury is unchanged — `criteria`, verdict modes, aggregators, replacements. `assignment` only decides *who scores what*, so it composes with the vote-level settings rather than competing with them.
 
 ## Which to pick
 
@@ -37,60 +27,37 @@ composes with the vote-level settings rather than competing with them.
 | Run-level score | panel mean | panel mean, in expectation |
 | Use it for | reviewing individual rows, gating a release on one verdict | benchmark means, pass rates, A/B deltas over many rows |
 
-The rule of thumb: **if you would act on a single row's verdict, use `"all"`.**
-If you would only ever act on the aggregate, `"cyclic"` gets you the same
-aggregate for a third of the money on a three-judge panel.
+The rule of thumb: **if you would act on a single row's verdict, use `"all"`.** If you would only ever act on the aggregate, `"cyclic"` gets you the same aggregate for a third of the money on a three-judge panel.
 
-Cyclic does not remove bias the whole panel shares. It cancels the offsets
-*between* your judges; if every judge in the panel is lenient about the same
-thing, so is the rotation. That still comes down to picking a diverse panel.
+Cyclic does not remove bias the whole panel shares. It cancels the offsets *between* your judges; if every judge in the panel is lenient about the same thing, so is the rotation. That still comes down to picking a diverse panel.
 
 ## How items are assigned
 
-Inside `evaluatorq()` the assignment is keyed on the **dataset row**: datapoint
-`i` goes to judge `i % len(panel)`. Datapoint 0 gets judge 0, datapoint 1 gets
-judge 1, wrapping around.
+Inside `evaluatorq()` the assignment is keyed on the **dataset row**: datapoint `i` goes to judge `i % len(panel)`. Datapoint 0 gets judge 0, datapoint 1 gets judge 1, wrapping around.
 
-Keying on the row rather than on call order matters. The runner evaluates
-datapoints concurrently, so "the next judge in the rotation" would otherwise mean
-"whichever judge call happened to arrive first" — non-reproducible between two
-identical runs. Because the key is the row:
+Keying on the row rather than on call order matters. The runner evaluates datapoints concurrently, so "the next judge in the rotation" would otherwise mean "whichever judge call happened to arrive first" — non-reproducible between two identical runs. Because the key is the row:
 
 - the mapping is identical at `datapoint_parallelism=1` and `datapoint_parallelism=32`,
 - re-running the same dataset assigns the same judges again,
 - reusing one `llm_jury(...)` object across several runs does not shift it.
 
-In a multi-job run every job sees the same row index, so datapoint `i` is scored
-by the same judge under each job. That is deliberate: when you compare job A
-against job B, judge identity is not a confound.
+In a multi-job run every job sees the same row index, so datapoint `i` is scored by the same judge under each job. That is deliberate: when you compare job A against job B, judge identity is not a confound.
 
 !!! note "Shuffle first if row order is meaningful"
 
-    Rotation over a dataset sorted by category lines judge 0 up with category 0.
-    Shuffle before evaluating so the cycle cannot align with a latent grouping —
-    this is the paper's own caveat.
+    Rotation over a dataset sorted by category lines judge 0 up with category 0. Shuffle before evaluating so the cycle cannot align with a latent grouping — this is the paper's own caveat.
 
 ### The arrival-order fallback
 
-Calling a scorer directly, outside `evaluatorq()`, provides no row index. Those
-calls fall back to a cursor that lives on the evaluator object and hands out
-judges in arrival order. There, only the equal-share balance is guaranteed, not
-which judge sees which item, and a reused evaluator continues the rotation where
-the previous run left off.
+Calling a scorer directly, outside `evaluatorq()`, provides no row index. Those calls fall back to a cursor that lives on the evaluator object and hands out judges in arrival order. There, only the equal-share balance is guaranteed, not which judge sees which item, and a reused evaluator continues the rotation where the previous run left off.
 
-`PairwiseComparator.compare` has no dataset row at all, so it is always
-arrival-ordered. See [Pairwise judging](pairwise-judging.md).
+`PairwiseComparator.compare` has no dataset row at all, so it is always arrival-ordered. See [Pairwise judging](pairwise-judging.md).
 
 ## Auditing the rotation
 
-Under `assignment="cyclic"`, every result carries the full jury record —
-per-judge votes, model IDs, verdicts — under `raw_output["jury"]`. It is the only
-record of which judge scored which item, so it is what you reach for to check the
-rotation actually balanced, or to find a judge that has gone off the rails.
+Under `assignment="cyclic"`, every result carries the full jury record — per-judge votes, model IDs, verdicts — under `raw_output["jury"]`. It is the only record of which judge scored which item, so it is what you reach for to check the rotation actually balanced, or to find a judge that has gone off the rails.
 
-This is cyclic-only. Under `"all"` the panel itself is the record, so the payload
-would be redundant: `raw_output` stays `None` and results keep the shape they had
-before cyclic existed.
+This is cyclic-only. Under `"all"` the panel itself is the record, so the payload would be redundant: `raw_output` stays `None` and results keep the shape they had before cyclic existed.
 
 ```python
 from collections import Counter
@@ -107,48 +74,29 @@ for result in results:
 print(shares)  # each judge should hold roughly 1/len(panel) of the run
 ```
 
-For pairwise runs, `build_report` already rolls per-judge rates up for you into
-`PairwiseReport.per_judge`.
+For pairwise runs, `build_report` already rolls per-judge rates up for you into `PairwiseReport.per_judge`.
 
 ## What changes per item
 
-- **`stats` and `raw_agreement` are `None`.** One vote has no cross-judge
-  agreement to report, and emitting `1.0` / `std=0.0` would be indistinguishable
-  from a genuinely unanimous panel. Summaries render `raw agreement n/a`.
-- **`repetitions` still applies to the assigned judge.** `repetitions=3` means
-  three calls to *one* judge, smoothing that judge's own call noise — never three
-  judges. It multiplies the cost accordingly.
-- **Rotation runs over the deduplicated panel.** `judges=["a", "a", "b"]` gives
-  `a` two votes per item under `"all"`, but an equal share under `"cyclic"`.
-  Listing a judge twice to up-weight it only works under `"all"`.
+- **`stats` and `raw_agreement` are `None`.** One vote has no cross-judge agreement to report, and emitting `1.0` / `std=0.0` would be indistinguishable from a genuinely unanimous panel. Summaries render `raw agreement n/a`.
+- **`repetitions` still applies to the assigned judge.** `repetitions=3` means three calls to *one* judge, smoothing that judge's own call noise — never three judges. It multiplies the cost accordingly.
+- **Rotation runs over the deduplicated panel.** `judges=["a", "a", "b"]` gives `a` two votes per item under `"all"`, but an equal share under `"cyclic"`. Listing a judge twice to up-weight it only works under `"all"`.
 
 ## Failures
 
-`min_successful_judges` must stay `1` — only one judge runs per item, so a higher
-floor could never be met, and passing one raises `ValueError`.
+`min_successful_judges` must stay `1` — only one judge runs per item, so a higher floor could never be met, and passing one raises `ValueError`.
 
 When the assigned judge fails mechanically:
 
 - If `replacement_judges` is set, a stand-in is promoted and casts a real vote.
-- Otherwise the item comes back **inconclusive**. The rest of the run still has
-  redundancy, since other items are scored by other judges, so one item's outage
-  does not kill the run.
-- The exception is a single-model cyclic panel with no stand-ins. There is no
-  redundancy left to fall back on, so the error propagates loudly rather than
-  quietly marking every item inconclusive.
+- Otherwise the item comes back **inconclusive**. The rest of the run still has redundancy, since other items are scored by other judges, so one item's outage does not kill the run.
+- The exception is a single-model cyclic panel with no stand-ins. There is no redundancy left to fall back on, so the error propagates loudly rather than quietly marking every item inconclusive.
 
-One caveat worth knowing: a judge that is *systematically* broken — a bad key for
-one provider, a prompt its API rejects — shows up under cyclic as scattered
-inconclusive items across `1/len(panel)` of the run, rather than as the loud
-collapse in agreement you would see under `"all"`. Check the share counts from
-the audit snippet above if a run comes back with more inconclusive rows than you
-expect.
+One caveat worth knowing: a judge that is *systematically* broken — a bad key for one provider, a prompt its API rejects — shows up under cyclic as scattered inconclusive items across `1/len(panel)` of the run, rather than as the loud collapse in agreement you would see under `"all"`. Check the share counts from the audit snippet above if a run comes back with more inconclusive rows than you expect.
 
 ## Full example
 
-[Cyclic Jury](examples/lib/basics/cyclic_jury.md) scores one dataset twice with
-the same three-judge panel — once with `"all"`, once with `"cyclic"` — and prints
-the item-to-judge mapping and total judge calls for each.
+[Cyclic Jury](examples/lib/basics/cyclic_jury.md) scores one dataset twice with the same three-judge panel — once with `"all"`, once with `"cyclic"` — and prints the item-to-judge mapping and total judge calls for each.
 
 ## See also
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,23 +1,15 @@
 # Dashboard
 
 !!! note "Primary UI — FastHTML `eq dashboard`"
-    The combined `eq dashboard` documented here is the primary way to browse
-    saved runs. Its canonical invocation scans a run directory and opens the
-    multi-run FastHTML UI — `eq dashboard` (no path) browses both default stores,
-    and `eq dashboard .evaluatorq/sim-runs` scopes to simulation. Passing a single
-    JSON report file is an optional direct deep-link to that report.
+    The combined `eq dashboard` documented here is the primary way to browse saved runs. Its canonical invocation scans a run directory and opens the multi-run FastHTML UI — `eq dashboard` (no path) browses both default stores, and `eq dashboard .evaluatorq/sim-runs` scopes to simulation. Passing a single JSON report file is an optional direct deep-link to that report.
 
-evaluatorq ships a built-in web dashboard for browsing red team and simulation
-reports.  It is powered by **FastHTML** (a lightweight Python web framework)
-and served locally via **uvicorn**.  There is no external service dependency —
-everything runs on your machine.
+evaluatorq ships a built-in web dashboard for browsing red team and simulation reports.  It is powered by **FastHTML** (a lightweight Python web framework) and served locally via **uvicorn**.  There is no external service dependency — everything runs on your machine.
 
 ![The evaluatorq combined dashboard — stat band, runs by type, attack-resistance, findings by severity, token usage, and recent runs.](assets/dashboard-index.png){ .dashboard-shot }
 
 ## Install
 
-The dashboard is an optional extra (it pulls in `python-fasthtml` and
-`uvicorn`):
+The dashboard is an optional extra (it pulls in `python-fasthtml` and `uvicorn`):
 
 ```bash
 uv add "evaluatorq[dashboard]"
@@ -25,14 +17,11 @@ uv add "evaluatorq[dashboard]"
 uv add "evaluatorq[redteam,dashboard]"
 ```
 
-Prefer pip? Use `python -m pip install "evaluatorq[dashboard]"`, which installs
-into the interpreter you just named rather than whichever `pip` happens to be
-first on your `PATH`.
+Prefer pip? Use `python -m pip install "evaluatorq[dashboard]"`, which installs into the interpreter you just named rather than whichever `pip` happens to be first on your `PATH`.
 
 ## Launch
 
-Launch it with `eq dashboard` (the `evaluatorq` and `eq` entry points are
-interchangeable):
+Launch it with `eq dashboard` (the `evaluatorq` and `eq` entry points are interchangeable):
 
 ```bash
 # Canonical — browse both default stores at once (red team + simulation)
@@ -61,29 +50,19 @@ ORQ_WORKSPACE=orq-research eq dashboard
 | `eq dashboard <dir>` | Only that directory (e.g. `eq dashboard .evaluatorq/sim-runs`) |
 | `eq dashboard <file>.json` | Optional direct deep-link; prints that report's direct URL so you land straight on it |
 
-With no `PATH` the server prints the local URL to open. Pointing at a directory
-(`eq dashboard .evaluatorq/sim-runs`) scopes the UI to that store. Passing a
-single JSON report file is an optional direct deep-link that prints that
-report's direct URL.
+With no `PATH` the server prints the local URL to open. Pointing at a directory (`eq dashboard .evaluatorq/sim-runs`) scopes the UI to that store. Passing a single JSON report file is an optional direct deep-link that prints that report's direct URL.
 
 ### Orq trace links
 
-Set `ORQ_WORKSPACE` when launching the dashboard to show **View Traces** links
-for conversations and runs. Its value is the workspace slug in the Orq UI URL;
-for example, `https://my.orq.ai/orq-research/traces` uses
-`ORQ_WORKSPACE=orq-research`. It is configured explicitly and is not derived
-from `ORQ_API_KEY`. If it is unset, trace-link buttons are hidden.
+Set `ORQ_WORKSPACE` when launching the dashboard to show **View Traces** links for conversations and runs. Its value is the workspace slug in the Orq UI URL; for example, `https://my.orq.ai/orq-research/traces` uses `ORQ_WORKSPACE=orq-research`. It is configured explicitly and is not derived from `ORQ_API_KEY`. If it is unset, trace-link buttons are hidden.
 
-`ORQ_WORKSPACE_SLUG` remains supported as an alias. For a self-hosted or
-staging Orq UI, set `ORQ_UI_BASE_URL` as well; otherwise the dashboard uses
-`ORQ_BASE_URL`, then `https://my.orq.ai`.
+`ORQ_WORKSPACE_SLUG` remains supported as an alias. For a self-hosted or staging Orq UI, set `ORQ_UI_BASE_URL` as well; otherwise the dashboard uses `ORQ_BASE_URL`, then `https://my.orq.ai`.
 
 ---
 
 ## What the dashboard browses
 
-The dashboard auto-discovers JSON report files in the configured root
-directories:
+The dashboard auto-discovers JSON report files in the configured root directories:
 
 | Default store | Written by |
 |---|---|
@@ -91,8 +70,7 @@ directories:
 | `.evaluatorq/sim-runs/*.json` | `eq sim run` (auto-saves unless `--no-save`); `simulate()` only when called with `save=True` |
 | `.evaluatorq/pairwise-runs/*.json` | `PairwiseRun.save()` (see [Pairwise Judging](pairwise-judging.md#saving-a-run-and-viewing-it-in-the-dashboard)) |
 
-Each report gets a stable URL for the lifetime of its file, so links you share
-keep working.
+Each report gets a stable URL for the lifetime of its file, so links you share keep working.
 
 ### Supported surfaces
 
@@ -102,43 +80,23 @@ keep working.
 | Simulation | `"mode"` key present (`mode` wins over `pipeline`) |
 | Pairwise | `"judging"` key present |
 
-Files that cannot be parsed (invalid JSON) are silently skipped.  Files that
-parse but fail model validation appear in the index as **broken cards** with an
-error badge; their detail page shows a non-fatal error message instead of a
-traceback.
+Files that cannot be parsed (invalid JSON) are silently skipped.  Files that parse but fail model validation appear in the index as **broken cards** with an error badge; their detail page shows a non-fatal error message instead of a traceback.
 
 ---
 
 ## Landing
 
-`GET /` opens the combined dashboard: a stat band (total runs, per-surface
-counts, attack resistance), runs-by-type and attack-resistance breakdowns,
-findings by severity, token usage, and a **recent runs** list across both
-stores.  The left sidebar switches surface — **Red Team** and **Agent Sim**
-open filtered run lists at `?surface=…`, sorted by creation time (newest
-first).  Each run row drills into its report view; reports whose JSON is only
-partially valid surface an error badge instead of a traceback.  The **export**
-action on a report downloads the standalone self-contained HTML for offline
-sharing.
+`GET /` opens the combined dashboard: a stat band (total runs, per-surface counts, attack resistance), runs-by-type and attack-resistance breakdowns, findings by severity, token usage, and a **recent runs** list across both stores.  The left sidebar switches surface — **Red Team** and **Agent Sim** open filtered run lists at `?surface=…`, sorted by creation time (newest first).  Each run row drills into its report view; reports whose JSON is only partially valid surface an error badge instead of a traceback.  The **export** action on a report downloads the standalone self-contained HTML for offline sharing.
 
 ### How attack resistance is counted
 
-Resistance is **attack-weighted**: the rate is resisted attacks over *evaluated*
-attacks, not over every attack attempted.  An attack only counts as evaluated
-once a judge returned a verdict — an attack whose target call failed, or whose
-judge crashed, timed out or was skipped, is excluded from both sides of the
-ratio rather than counted as resisted.  So a run headlined `100 attacks` can
-show a rate measured over 60; the Score tooltip names both numbers.
+Resistance is **attack-weighted**: the rate is resisted attacks over *evaluated* attacks, not over every attack attempted.  An attack only counts as evaluated once a judge returned a verdict — an attack whose target call failed, or whose judge crashed, timed out or was skipped, is excluded from both sides of the ratio rather than counted as resisted.  So a run headlined `100 attacks` can show a rate measured over 60; the Score tooltip names both numbers.
 
-For older reports, the dashboard derives missing summary values from the stored
-per-attack results. If that produces a different rate from the exported report,
-the Score cell is marked with `*` and its tooltip explains the difference.
+For older reports, the dashboard derives missing summary values from the stored per-attack results. If that produces a different rate from the exported report, the Score cell is marked with `*` and its tooltip explains the difference.
 
 !!! note "Rates use evaluated attacks"
 
-    Attacks without a judge verdict are excluded from resistance rates. If an
-    older exported report uses a different denominator, the Score tooltip marks
-    the difference; re-export the report to refresh it under the current rule.
+    Attacks without a judge verdict are excluded from resistance rates. If an older exported report uses a different denominator, the Score tooltip marks the difference; re-export the report to refresh it under the current rule.
 
 ---
 
@@ -160,11 +118,7 @@ Both surfaces expose dimension filters in a sidebar:
 
 ### Simulation filters
 
-The sim rail exposes chip toggles, `<details>` dropdowns, and range
-controls, rendered directly in the sidebar wherever they always apply and
-tucked behind a **More filters** expander (`filter-dd-more`, reusing the
-same open-state persistence as the red team rail) when they may be
-unavailable for a given run:
+The sim rail exposes chip toggles, `<details>` dropdowns, and range controls, rendered directly in the sidebar wherever they always apply and tucked behind a **More filters** expander (`filter-dd-more`, reusing the same open-state persistence as the red team rail) when they may be unavailable for a given run:
 
 | Control | Kind | Direction | Notes |
 |---|---|---|---|
@@ -178,18 +132,9 @@ unavailable for a given run:
 | `min_total_tokens` *(More)* | range | floor (`≥`) | raw `token_usage.total_tokens`, step `1`, max = the run's actual highest token count; hidden when the run recorded zero tokens |
 | per-turn metric thresholds *(More)* | range | floor for hallucination risk (`≥`), ceiling for response quality / tone appropriateness / factual accuracy (`≤`) | step `0.05`, range `0..1`; each control is rendered **only when that metric was actually scored somewhere in the run** — unavailable metrics are hidden, not shown disabled |
 
-Every range control renders its default bound numerically (`≤`/`≥ value`) —
-when unset it shows the no-op end of the range, so it always reads as a number,
-never "all". Min-turns additionally shows the run's max turns beside the
-readout. Metric thresholds compare
-against a result's **worst scored turn** (`max()` for hallucination risk,
-`min()` for the quality metrics); a result with **no scored turns for that
-metric stays visible** regardless of the threshold, so unscored results are
-never silently dropped from the filtered view.
+Every range control renders its default bound numerically (`≤`/`≥ value`) — when unset it shows the no-op end of the range, so it always reads as a number, never "all". Min-turns additionally shows the run's max turns beside the readout. Metric thresholds compare against a result's **worst scored turn** (`max()` for hallucination risk, `min()` for the quality metrics); a result with **no scored turns for that metric stays visible** regardless of the threshold, so unscored results are never silently dropped from the filtered view.
 
-Filters are applied via HTMX (no page reload).  The report body, summary
-aggregates, and download links all update in-place to reflect the active
-filter state.
+Filters are applied via HTMX (no page reload).  The report body, summary aggregates, and download links all update in-place to reflect the active filter state.
 
 ![A red team report filtered by the sidebar dimension filters.](assets/dashboard-redteam-filtered.png){ .dashboard-shot }
 
@@ -197,85 +142,46 @@ filter state.
 
 ## Interactive views (red team)
 
-The red team surface exposes four dashboard-only interactive panels alongside
-the static report body:
+The red team surface exposes four dashboard-only interactive panels alongside the static report body:
 
-1. **Interactive breakdown** — pick a group-by and stack-by dimension (7 × 7
-   combinations); attack-success rate recomputed per (group, stack) cell.
-2. **Agent heatmap** — select the pivot dimension (vulnerability / category /
-   technique / severity) for the agent × dimension ASR heatmap.
-3. **Conversation viewer** — drill into the full message-by-message transcript
-   for any individual attack (system / user / assistant / tool messages plus
-   evaluator explanation).
-4. **Disagreement viewer** — for multi-agent runs, select any agent pair and
-   page through attacks where their results differ (side-by-side transcripts).
+1. **Interactive breakdown** — pick a group-by and stack-by dimension (7 × 7 combinations); attack-success rate recomputed per (group, stack) cell.
+2. **Agent heatmap** — select the pivot dimension (vulnerability / category / technique / severity) for the agent × dimension ASR heatmap.
+3. **Conversation viewer** — drill into the full message-by-message transcript for any individual attack (system / user / assistant / tool messages plus evaluator explanation).
+4. **Disagreement viewer** — for multi-agent runs, select any agent pair and page through attacks where their results differ (side-by-side transcripts).
 
 ### Apply recommendations to the agent
 
-On a single-agent run that produced recommendations, **Focus areas** and
-**Recommendations** can preview suggested instruction changes as a diff. Nothing
-is written until you confirm. Applying a recommendation creates a new minor
-agent version and marks the recommendation as applied on the run.
+On a single-agent run that produced recommendations, **Focus areas** and **Recommendations** can preview suggested instruction changes as a diff. Nothing is written until you confirm. Applying a recommendation creates a new minor agent version and marks the recommendation as applied on the run.
 
-Write-back requires an **Orq agent**, `ORQ_API_KEY`, and the `orq` extra
-(`orq-ai-sdk`). Multi-agent red-team runs never offer the action. Everything
-else does: the button renders whenever a single target produced
-recommendations, and the target-type check happens at preview time, not at
-render time — so on a run against a plain model, deployment or callback the
-**Apply…** button appears and then fails with an error naming the missing
-agent. Treat the button as "recommendations exist", not "this run is
-writable". The same flow is available programmatically through the red-team and
-simulation apply helpers.
+Write-back requires an **Orq agent**, `ORQ_API_KEY`, and the `orq` extra (`orq-ai-sdk`). Multi-agent red-team runs never offer the action. Everything else does: the button renders whenever a single target produced recommendations, and the target-type check happens at preview time, not at render time — so on a run against a plain model, deployment or callback the **Apply…** button appears and then fails with an error naming the missing agent. Treat the button as "recommendations exist", not "this run is writable". The same flow is available programmatically through the red-team and simulation apply helpers.
 
 ### Simulation transcript viewer
 
-Simulation reports expose a conversation transcript panel: select any
-conversation entry from the run to see the full multi-turn exchange between the
-simulated user and the target agent.
+Simulation reports expose a conversation transcript panel: select any conversation entry from the run to see the full multi-turn exchange between the simulated user and the target agent.
 
 ![The dashboard conversation transcript viewer, message by message.](assets/dashboard-transcript.png){ .dashboard-shot }
 
 ### Pairwise comparison view
 
-Pairwise runs render three sections: the consensus win rate for each side, a
-per-judge table (win rates, tie rate, position bias), and the comparison list.
+Pairwise runs render three sections: the consensus win rate for each side, a per-judge table (win rates, tie rate, position bias), and the comparison list.
 
 ![A pairwise run: consensus win rates per side, the per-judge table, and the comparison list.](assets/dashboard-pairwise.png){ .dashboard-shot }
 
-Each comparison row expands to the two responses side by side with every
-judge's vote and rationale.  Rows where the judges split, or where the panel
-could not decide, are marked; those are the ones worth opening.
+Each comparison row expands to the two responses side by side with every judge's vote and rationale.  Rows where the judges split, or where the panel could not decide, are marked; those are the ones worth opening.
 
 ![Two expanded comparisons: a split panel and one the panel could not decide.](assets/dashboard-pairwise-comparison.png){ .dashboard-shot }
 
-The judge table flags a judge whose position bias reaches 0.15.  A judge that
-contradicts itself across the two orderings has no real preference, so its
-votes are noise.  The column reads `n/a` rather than `0.00` wherever nothing
-was flippable, since there was no measurement to make.
+The judge table flags a judge whose position bias reaches 0.15.  A judge that contradicts itself across the two orderings has no real preference, so its votes are noise.  The column reads `n/a` rather than `0.00` wherever nothing was flippable, since there was no measurement to make.
 
-Whether swapping happened is read from the votes rather than from the saved
-`swap` flag.  A vote is only marked complete when both orderings landed, so the
-data settles it and a run saved with the default `swap=True` but executed
-single-ordering is labelled `on (never observed)` instead of a bare `on`.  The
-distinction carries into the `n/a` tooltips: when no judge in the run completed
-a pair that is a run-level fact, and the table says so rather than blaming each
-judge in turn.
+Whether swapping happened is read from the votes rather than from the saved `swap` flag.  A vote is only marked complete when both orderings landed, so the data settles it and a run saved with the default `swap=True` but executed single-ordering is labelled `on (never observed)` instead of a bare `on`.  The distinction carries into the `n/a` tooltips: when no judge in the run completed a pair that is a run-level fact, and the table says so rather than blaming each judge in turn.
 
-In the run lists, a pairwise run scores as its **decided rate** — the share of
-comparisons the panel could call, or `1 - inconclusive_rate`.  Mean inter-judge
-agreement reads like the more natural choice but is a modal vote share, so it
-is quantized by panel size: against the shared `≥ 0.80` threshold it silently
-means "unanimous" for three judges and "four of five" for five, and it is
-undefined for a single-judge run.  Every surface's Score column names its own
-metric on hover.
+In the run lists, a pairwise run scores as its **decided rate** — the share of comparisons the panel could call, or `1 - inconclusive_rate`.  Mean inter-judge agreement reads like the more natural choice but is a modal vote share, so it is quantized by panel size: against the shared `≥ 0.80` threshold it silently means "unanimous" for three judges and "four of five" for five, and it is undefined for a single-judge run.  Every surface's Score column names its own metric on hover.
 
 ### Additional red team charts
 
-Beyond the four panels above, the red team surface recomputes several charts
-live that the static exported report does not carry:
+Beyond the four panels above, the red team surface recomputes several charts live that the static exported report does not carry:
 
-- **Cumulative discovery curve** — vulnerabilities found as a function of
-  conversation turn depth.
+- **Cumulative discovery curve** — vulnerabilities found as a function of conversation turn depth.
 - **Attack-failure treemap** — vulnerability → technique, sized by attack count.
 - **Token histograms** — prompt and completion token distributions per attack.
 - **Vulnerability × severity** — a cross-join stacked bar.
@@ -284,10 +190,7 @@ live that the static exported report does not carry:
 
 ## Reading a red-team run
 
-Runs are saved to `.evaluatorq/runs/<name>_<timestamp>.json` by default
-(`--save none` skips the file; `--save detail` also keeps per-stage artifacts
-in `--artifacts-dir`), and `eq dashboard` browses those files locally — no
-external service:
+Runs are saved to `.evaluatorq/runs/<name>_<timestamp>.json` by default (`--save none` skips the file; `--save detail` also keeps per-stage artifacts in `--artifacts-dir`), and `eq dashboard` browses those files locally — no external service:
 
 ```bash
 uv add "evaluatorq[dashboard]"
@@ -296,124 +199,55 @@ eq dashboard                                              # browse every saved r
 eq dashboard .evaluatorq/runs/red-team_<timestamp>.json   # deep-link to one report
 ```
 
-What follows walks the dashboard the way you'd read a finished run: land, pick
-the run, then work down the report tabs from headline to evidence. The
-screenshots come from one example run — a hybrid run against two deliberately
-contrasting targets — so your own numbers will differ. [Filters](#filters),
-[trace links](#orq-trace-links) and [downloads](#downloads) are documented
-above. For the red-team concepts behind these numbers, see the
-[Red Teaming guide](guides/red-teaming.md).
+What follows walks the dashboard the way you'd read a finished run: land, pick the run, then work down the report tabs from headline to evidence. The screenshots come from one example run — a hybrid run against two deliberately contrasting targets — so your own numbers will differ. [Filters](#filters), [trace links](#orq-trace-links) and [downloads](#downloads) are documented above. For the red-team concepts behind these numbers, see the [Red Teaming guide](guides/red-teaming.md).
 
 ### 1. Landing — what has been run at all { #rt-landing }
 
-`eq dashboard` opens on a cross-surface overview: jobs run, spend, tokens, the
-red team / agent sim split, and findings by severity across every stored run.
-Use it to confirm the run you expect actually landed, then pick a surface from
-the left rail.
+`eq dashboard` opens on a cross-surface overview: jobs run, spend, tokens, the red team / agent sim split, and findings by severity across every stored run. Use it to confirm the run you expect actually landed, then pick a surface from the left rail.
 
-It is a triage screen, not a scoreboard: the severity bars aggregate *every*
-stored run, including throwaway smoke runs, so a red bar here doesn't mean the
-system you care about is broken. Go to the surface, find the run, and read its
-numbers there.
+It is a triage screen, not a scoreboard: the severity bars aggregate *every* stored run, including throwaway smoke runs, so a red bar here doesn't mean the system you care about is broken. Go to the surface, find the run, and read its numbers there.
 
-An empty landing page — zeros across the stat band, no runs in either rail —
-means the dashboard found no report files, not that the runs failed. Check you
-launched it from the directory holding `.evaluatorq/`, and that the run was
-saved at all — `red_team()` saves by default, but `--save none` (CLI) or
-`save=SaveMode.NONE` writes nothing.
+An empty landing page — zeros across the stat band, no runs in either rail — means the dashboard found no report files, not that the runs failed. Check you launched it from the directory holding `.evaluatorq/`, and that the run was saved at all — `red_team()` saves by default, but `--save none` (CLI) or `save=SaveMode.NONE` writes nothing.
 
 ![The dashboard landing page: jobs run, spend, tokens, run mix, and findings by severity across all stored runs.](assets/dashboard/redteam-01-landing.png){ .dashboard-shot }
 
 ### 2. Red Team — pick a run { #rt-run-list }
 
-**Red Team** lists every red-team job, newest first, with the target or targets
-it attacked and how many attack cases it ran. The `SCORE` column is the
-resistance rate (higher is better), not the attack success rate — the stat band
-above totals attacks, ASR and critical findings across those runs, so the two
-directions sit on the same screen.
+**Red Team** lists every red-team job, newest first, with the target or targets it attacked and how many attack cases it ran. The `SCORE` column is the resistance rate (higher is better), not the attack success rate — the stat band above totals attacks, ASR and critical findings across those runs, so the two directions sit on the same screen.
 
-`STATUS` is the run's lifecycle, not a verdict: **success** for a finished run,
-**running** for one still in flight (the dashboard reads the run manifest, so a
-long run appears here before it has a report), and **error** for one that died
-part-way. Open an **error** run anyway — the attacks that completed before the
-failure are still in it, and the numbers are computed over those alone, so
-treat its resistance rate as a partial sample.
+`STATUS` is the run's lifecycle, not a verdict: **success** for a finished run, **running** for one still in flight (the dashboard reads the run manifest, so a long run appears here before it has a report), and **error** for one that died part-way. Open an **error** run anyway — the attacks that completed before the failure are still in it, and the numbers are computed over those alone, so treat its resistance rate as a partial sample.
 
 ![The Red Team run list: target, status, score and case count per job.](assets/dashboard/redteam-02-run-list.png){ .dashboard-shot }
 
 ### 3. Overview — the headline { #rt-overview }
 
-Opening a run lands on **Overview**: a written executive summary, the five
-headline numbers (attacks run, vulnerabilities, attack success rate, resistance
-rate, critical findings), the resistant/vulnerable split, the severity
-distribution, and per-agent attack success with the weakest agent first.
+Opening a run lands on **Overview**: a written executive summary, the five headline numbers (attacks run, vulnerabilities, attack success rate, resistance rate, critical findings), the resistant/vulnerable split, the severity distribution, and per-agent attack success with the weakest agent first.
 
-Resistance rate and ASR are complements: 78% resistant is 22% ASR. There is no
-universal pass mark — take the first run as your baseline, fix what
-[Focus areas](#rt-focus-areas) puts on top, and turn the
-number you reach into a [CI gate](guides/red-teaming.md#in-ci) so the next run can only improve on
-it.
+Resistance rate and ASR are complements: 78% resistant is 22% ASR. There is no universal pass mark — take the first run as your baseline, fix what [Focus areas](#rt-focus-areas) puts on top, and turn the number you reach into a [CI gate](guides/red-teaming.md#in-ci) so the next run can only improve on it.
 
-Both numbers cover only the categories this run actually attacked. The example
-run touched 10 of the 19 framework categories, so its resistance rate says
-nothing about the other 9 — [Config](#rt-config) lists
-which were skipped, and it is worth reading before quoting the headline
-anywhere.
+Both numbers cover only the categories this run actually attacked. The example run touched 10 of the 19 framework categories, so its resistance rate says nothing about the other 9 — [Config](#rt-config) lists which were skipped, and it is worth reading before quoting the headline anywhere.
 
-Filters sit in the right rail on every tab — outcome, severity, minimum turns,
-category, agent, attack technique, delivery method and vulnerability — and the
-whole page, downloads included, respects them.
+Filters sit in the right rail on every tab — outcome, severity, minimum turns, category, agent, attack technique, delivery method and vulnerability — and the whole page, downloads included, respects them.
 
 ![Overview: executive summary, headline metrics, outcome donut, severity split and per-agent attack success.](assets/dashboard/redteam-03-overview.png){ .dashboard-shot }
 
 ### 4. Agents — which target broke { #rt-agents }
 
-For a run with more than one target, **Agents** puts each one's ASR, model,
-discovered tools, skills and knowledge side by side, so a hardened target and an
-unhardened one are directly comparable. On a single-agent run — the usual first
-run — the tab still renders, as one row: the same capability inventory, no
-comparison. Skip it and read Focus areas instead.
+For a run with more than one target, **Agents** puts each one's ASR, model, discovered tools, skills and knowledge side by side, so a hardened target and an unhardened one are directly comparable. On a single-agent run — the usual first run — the tab still renders, as one row: the same capability inventory, no comparison. Skip it and read Focus areas instead.
 
-A dash in the tools, skills or knowledge column means nothing was discovered for
-that target, not that the agent has none. For custom targets, provide
-`agent_context=` if you want evaluatorq to use the capabilities you know about.
-Treat a broad attack set as unknown capability coverage, not evidence that the
-agent supports every tool or skill.
+A dash in the tools, skills or knowledge column means nothing was discovered for that target, not that the agent has none. For custom targets, provide `agent_context=` if you want evaluatorq to use the capabilities you know about. Treat a broad attack set as unknown capability coverage, not evidence that the agent supports every tool or skill.
 
 ![Agents: per-agent ASR, model, and the tools, skills and knowledge discovered for each target.](assets/dashboard/redteam-04-agents.png){ .dashboard-shot }
 
 ### 5. Focus areas — what to fix first { #rt-focus-areas }
 
-**Focus areas** ranks fixes by `risk = success rate × avg severity` and attaches
-a recommended remediation to each. Severity is the numeric weight shown on
-[Config](#rt-config) (critical is the heaviest), so a
-vulnerability that fails often *and* fails badly floats to the top. Start at P1
-and work down; re-run the same categories afterwards and compare the two runs
-in the run list to confirm the fix landed.
+**Focus areas** ranks fixes by `risk = success rate × avg severity` and attaches a recommended remediation to each. Severity is the numeric weight shown on [Config](#rt-config) (critical is the heaviest), so a vulnerability that fails often *and* fails badly floats to the top. Start at P1 and work down; re-run the same categories afterwards and compare the two runs in the run list to confirm the fix landed.
 
-When the run has recommendations and exactly one tested agent, each one also
-gets an **Apply…** button: it previews the merged instructions as a diff, and
-nothing is written until you confirm. Multi-agent runs never get the button.
-The button does *not* check the target type, though — on a run against a plain
-model, deployment or callback it appears and then fails at preview with an
-error naming the missing agent.
-[Apply recommendations to the agent](#apply-recommendations-to-the-agent)
-covers the requirements. The
-[`14_recommendations_and_artifacts.py` cookbook](examples/redteam/14_recommendations_and_artifacts.md)
-shows the corresponding Python configuration.
+When the run has recommendations and exactly one tested agent, each one also gets an **Apply…** button: it previews the merged instructions as a diff, and nothing is written until you confirm. Multi-agent runs never get the button. The button does *not* check the target type, though — on a run against a plain model, deployment or callback it appears and then fails at preview with an error naming the missing agent. [Apply recommendations to the agent](#apply-recommendations-to-the-agent) covers the requirements. The [`14_recommendations_and_artifacts.py` cookbook](examples/redteam/14_recommendations_and_artifacts.md) shows the corresponding Python configuration.
 
 ### 6. Breakdowns — where the weakness sits { #rt-breakdowns }
 
-**Breakdowns** gives attack success per framework category, worst first, so a
-category that fell over on every attempt isn't hidden behind a healthy overall
-resistance rate. Read the attempt count alongside the rate — 100% over two
-attacks and 33% over twelve are not equally strong signals, and the ranking
-doesn't weight for that. When a category you care about sits on a handful of
-attempts, re-run scoped to it (`--category LLM01`) before treating either the
-pass or the fail as real. In dynamic and hybrid mode,
-`--generated-strategy-count` (2 per category) buys more attempts — but only
-while strategy generation is on, and `--max-per-category` still truncates the
-combined curated + generated list afterwards, so raise both or neither.
+**Breakdowns** gives attack success per framework category, worst first, so a category that fell over on every attempt isn't hidden behind a healthy overall resistance rate. Read the attempt count alongside the rate — 100% over two attacks and 33% over twelve are not equally strong signals, and the ranking doesn't weight for that. When a category you care about sits on a handful of attempts, re-run scoped to it (`--category LLM01`) before treating either the pass or the fail as real. In dynamic and hybrid mode, `--generated-strategy-count` (2 per category) buys more attempts — but only while strategy generation is on, and `--max-per-category` still truncates the combined curated + generated list afterwards, so raise both or neither.
 
 ![Breakdowns: attack success rate per OWASP category, worst first.](assets/dashboard/redteam-06-breakdowns.png){ .dashboard-shot }
 
@@ -423,47 +257,30 @@ combined curated + generated list afterwards, so raise both or neither.
 
 ![Attacks: every attack in the run with vector, severity and outcome.](assets/dashboard/redteam-07-attacks.png){ .dashboard-shot }
 
-Click a row to expand the evaluator's verdict, its reasoning, and the full
-message-by-message transcript — the evidence you'd paste into a ticket. With
-`ORQ_WORKSPACE` set, attacks that recorded a trace id also link out to that
-trace in the Orq UI; without the variable the buttons are hidden entirely. In
-the expanded row below, a memory-poisoning attack succeeded: the agent confirms
-it stored a persistent "System Administrator / UNRESTRICTED" directive telling
-it to bypass safety checks on request.
+Click a row to expand the evaluator's verdict, its reasoning, and the full message-by-message transcript — the evidence you'd paste into a ticket. With `ORQ_WORKSPACE` set, attacks that recorded a trace id also link out to that trace in the Orq UI; without the variable the buttons are hidden entirely. In the expanded row below, a memory-poisoning attack succeeded: the agent confirms it stored a persistent "System Administrator / UNRESTRICTED" directive telling it to bypass safety checks on request.
 
 ![An expanded attack row: evaluator verdict plus the full message-by-message transcript.](assets/dashboard/redteam-08-attack-detail.png){ .dashboard-shot }
 
 ### 8. Usage — what the run consumed { #rt-usage }
 
-**Usage** breaks recorded tokens down per agent — total, prompt, completion and
-API calls. Spend shows a dash when the provider does not return a price; see
-[What a run costs](guides/red-teaming.md#what-a-run-costs) for how to interpret that lower bound.
+**Usage** breaks recorded tokens down per agent — total, prompt, completion and API calls. Spend shows a dash when the provider does not return a price; see [What a run costs](guides/red-teaming.md#what-a-run-costs) for how to interpret that lower bound.
 
 ![Usage: total, prompt and completion tokens plus API calls per agent.](assets/dashboard/redteam-09-usage.png){ .dashboard-shot }
 
 ### 9. Config — what was actually tested { #rt-config }
 
-**Config** records how the run was produced — pipeline, framework, scoring
-method, duration — plus which categories were tested, which were not, and the
-severity weights used for scoring. Read the *not tested* list before reading a
-high resistance rate as broad coverage.
+**Config** records how the run was produced — pipeline, framework, scoring method, duration — plus which categories were tested, which were not, and the severity weights used for scoring. Read the *not tested* list before reading a high resistance rate as broad coverage.
 
 ![Config: run configuration, methodology, tested and untested categories, and severity weights.](assets/dashboard/redteam-10-config.png){ .dashboard-shot }
 
 !!! tip "Exports respect the filters"
-    **Export** downloads the run as standalone HTML, Markdown, CSV or JSON —
-    the tabular formats carry only the rows your filters left visible, so
-    filter first, then export. Formats per surface:
-    [Downloads](#downloads).
+    **Export** downloads the run as standalone HTML, Markdown, CSV or JSON — the tabular formats carry only the rows your filters left visible, so filter first, then export. Formats per surface: [Downloads](#downloads).
 
 ---
 
 ## Reading a simulation run
 
-Runs are saved to `.evaluatorq/sim-runs/<name>_<timestamp>.json` — automatically
-by `eq sim run` (unless you pass `--no-save`), and by `simulate()` when called
-with `save=True`. `eq dashboard` browses those files locally, no external
-service:
+Runs are saved to `.evaluatorq/sim-runs/<name>_<timestamp>.json` — automatically by `eq sim run` (unless you pass `--no-save`), and by `simulate()` when called with `save=True`. `eq dashboard` browses those files locally, no external service:
 
 ```bash
 uv add "evaluatorq[dashboard]"
@@ -473,151 +290,72 @@ eq dashboard .evaluatorq/sim-runs  # scope to simulation runs
 ```
 
 !!! warning "The Python examples above don't save by default"
-    `simulate()` and `generate_and_simulate()` default to `save=False`, so a
-    script copy-pasted from earlier on this page leaves the dashboard empty.
-    Pass `save=True`, or drive the run from the CLI (`eq sim run`), which saves
-    unless you pass `--no-save`.
+    `simulate()` and `generate_and_simulate()` default to `save=False`, so a script copy-pasted from earlier on this page leaves the dashboard empty. Pass `save=True`, or drive the run from the CLI (`eq sim run`), which saves unless you pass `--no-save`.
 
-What follows walks the dashboard the way you'd read a finished run: land, pick
-the run, then work down the report tabs from headline to transcript. The
-screenshots come from one example run — 10 personas × 5 scenarios against a
-refund agent — so your own numbers will differ. [Filters](#filters),
-[trace links](#orq-trace-links) and [downloads](#downloads) are documented
-above. For the simulation concepts behind these numbers, see the
-[Agent Simulation guide](guides/agent-simulation.md).
+What follows walks the dashboard the way you'd read a finished run: land, pick the run, then work down the report tabs from headline to transcript. The screenshots come from one example run — 10 personas × 5 scenarios against a refund agent — so your own numbers will differ. [Filters](#filters), [trace links](#orq-trace-links) and [downloads](#downloads) are documented above. For the simulation concepts behind these numbers, see the [Agent Simulation guide](guides/agent-simulation.md).
 
 ### 1. Landing — what has been run at all { #sim-landing }
 
-`eq dashboard` opens on a cross-surface overview: jobs run, spend, tokens and
-the red team / agent sim split across every stored run. Agent simulation sits
-next to red teaming in the left rail.
+`eq dashboard` opens on a cross-surface overview: jobs run, spend, tokens and the red team / agent sim split across every stored run. Agent simulation sits next to red teaming in the left rail.
 
-Zeros everywhere and an empty rail mean no report files were found, not that
-the run failed — the usual cause is the `save=False` default in the warning
-above. Launch `eq dashboard` from the directory holding `.evaluatorq/`.
+Zeros everywhere and an empty rail mean no report files were found, not that the run failed — the usual cause is the `save=False` default in the warning above. Launch `eq dashboard` from the directory holding `.evaluatorq/`.
 
 ![The dashboard landing page: jobs run, spend, tokens and run mix across all stored runs.](assets/dashboard/sim-01-landing.png){ .dashboard-shot }
 
 ### 2. Agent Sim — pick a run { #sim-run-list }
 
-**Agent Sim** lists every simulation job with its target, goal-completion score,
-conversation count and cost. The picker above the list selects two runs to
-compare — see [Compare](#sim-compare).
+**Agent Sim** lists every simulation job with its target, goal-completion score, conversation count and cost. The picker above the list selects two runs to compare — see [Compare](#sim-compare).
 
 ![The Agent Sim run list: simulations run, goal completion, average turns and cost per simulation.](assets/dashboard/sim-02-run-list.png){ .dashboard-shot }
 
 ### 3. Overview — the headline { #sim-overview }
 
-Opening a run lands on **Overview**: a written summary naming the best and worst
-persona × scenario pair, the run's counts (personas, scenarios, conversations,
-average score, average turns, errors), the achieved/not-achieved split, and the
-four per-turn quality metrics — response quality, hallucination risk, tone
-appropriateness, factual accuracy.
+Opening a run lands on **Overview**: a written summary naming the best and worst persona × scenario pair, the run's counts (personas, scenarios, conversations, average score, average turns, errors), the achieved/not-achieved split, and the four per-turn quality metrics — response quality, hallucination risk, tone appropriateness, factual accuracy.
 
-Those four are scored by the judge on every turn regardless of what you passed
-in `evaluator_names`, which is why they appear even though the Config tab lists
-only `goal_achieved` and `criteria_met`. All four run 0–1; higher is better for
-three of them, and *lower* is better for hallucination risk. Factual accuracy is
-only meaningful when the scenario supplies ground truth — without it the judge
-has nothing to check the response against.
+Those four are scored by the judge on every turn regardless of what you passed in `evaluator_names`, which is why they appear even though the Config tab lists only `goal_achieved` and `criteria_met`. All four run 0–1; higher is better for three of them, and *lower* is better for hallucination risk. Factual accuracy is only meaningful when the scenario supplies ground truth — without it the judge has nothing to check the response against.
 
-Two numbers on this screen are easy to conflate. The **pass rate** is the share
-of conversations where the judge set `goal_achieved` — the donut. **Average
-score** is the mean `goal_completion_score`, the judge's 0–1 rating of *how
-fully* the goal was met, so a run can average 0.7 while passing half its
-conversations.
+Two numbers on this screen are easy to conflate. The **pass rate** is the share of conversations where the judge set `goal_achieved` — the donut. **Average score** is the mean `goal_completion_score`, the judge's 0–1 rating of *how fully* the goal was met, so a run can average 0.7 while passing half its conversations.
 
-The **CONFIDENCE** badge is a band on the pass rate, not a statistical
-confidence: ≥ 80% of goals achieved reads HIGH, ≥ 50% MEDIUM, below that LOW.
-It carries no sample-size meaning at all — three conversations that all pass
-still read HIGH. A LOW badge says the run went badly, not that you need more
-data.
+The **CONFIDENCE** badge is a band on the pass rate, not a statistical confidence: ≥ 80% of goals achieved reads HIGH, ≥ 50% MEDIUM, below that LOW. It carries no sample-size meaning at all — three conversations that all pass still read HIGH. A LOW badge says the run went badly, not that you need more data.
 
-Filters sit in the right rail on every tab — goal outcome, rule violations, who
-terminated the conversation, persona, scenario, and score/turn thresholds — and
-the whole page respects them. "Terminated by" takes four values: `judge` (the
-judge decided the conversation was done), `max_turns` (the turn cap hit first),
-`error`, and `timeout`. A run dominated by `max_turns` means the cap, not the
-agent, decided where the conversations ended.
+Filters sit in the right rail on every tab — goal outcome, rule violations, who terminated the conversation, persona, scenario, and score/turn thresholds — and the whole page respects them. "Terminated by" takes four values: `judge` (the judge decided the conversation was done), `max_turns` (the turn cap hit first), `error`, and `timeout`. A run dominated by `max_turns` means the cap, not the agent, decided where the conversations ended.
 
 ![Overview: executive summary, run counts, outcome donut and the four average quality metrics.](assets/dashboard/sim-03-overview.png){ .dashboard-shot }
 
 ### 4. Breakdown — which persona × scenario pair fails { #sim-breakdown }
 
-**Breakdown** is the persona × scenario heatmap, usually the fastest read in the
-report. Here every persona clears the straightforward refund paths at 100%,
-while one column — *Never Received Claim With Unverified Evidence* — lands
-between 20% and 90% for every one of them. A column that's weak across personas
-points at the scenario; a row that's weak across scenarios points at the
-persona; a single cold cell (*Cautious Low-Tech Senior* × *Duplicate Refund
-Attempt*, 0%) points at that pairing specifically.
+**Breakdown** is the persona × scenario heatmap, usually the fastest read in the report. Here every persona clears the straightforward refund paths at 100%, while one column — *Never Received Claim With Unverified Evidence* — lands between 20% and 90% for every one of them. A column that's weak across personas points at the scenario; a row that's weak across scenarios points at the persona; a single cold cell (*Cautious Low-Tech Senior* × *Duplicate Refund Attempt*, 0%) points at that pairing specifically.
 
 ![Breakdown: goal completion per persona and scenario. One column scores far below the rest across nearly every persona.](assets/dashboard/sim-04-breakdown-heatmap.png){ .dashboard-shot }
 
 ### 5. Recommendations — what to change { #sim-recommendations }
 
-**Recommendations** turns the failures into suggested edits, one card per
-suggestion, with the persona, scenario and triggers that produced it. For a run
-that targeted an Orq agent, each suggestion can be applied to the agent's
-instructions from here: preview the merge as a diff, confirm, and the write
-lands as a new minor agent version. Runs against a plain model, a deployment or
-a callback have no instructions to write back to, so their suggestions render
-as plain bullets. A framework-wrapped agent (LangGraph, Pydantic AI, CrewAI,
-OpenAI Agents) is *not* an Orq agent but still gets the button, which then
-fails at preview — see
-[Apply recommendations to the agent](#apply-recommendations-to-the-agent)
-for the full contract. The tab carries a count badge, and it disappears
-entirely when a run generated no recommendations — as does **Turn quality**
-when a run recorded no per-turn metrics. A missing tab here is a property of
-the run, not a broken page.
+**Recommendations** turns the failures into suggested edits, one card per suggestion, with the persona, scenario and triggers that produced it. For a run that targeted an Orq agent, each suggestion can be applied to the agent's instructions from here: preview the merge as a diff, confirm, and the write lands as a new minor agent version. Runs against a plain model, a deployment or a callback have no instructions to write back to, so their suggestions render as plain bullets. A framework-wrapped agent (LangGraph, Pydantic AI, CrewAI, OpenAI Agents) is *not* an Orq agent but still gets the button, which then fails at preview — see [Apply recommendations to the agent](#apply-recommendations-to-the-agent) for the full contract. The tab carries a count badge, and it disappears entirely when a run generated no recommendations — as does **Turn quality** when a run recorded no per-turn metrics. A missing tab here is a property of the run, not a broken page.
 
 ### 6. Transcripts — the conversations { #sim-transcripts }
 
-**Transcripts** lists every conversation with persona, scenario, turn count,
-score, who ended it, and whether the goal was met. Sort by score to put the
-failures on top, and raise the page size (5 / 10 / 25) before scanning a large
-run. The **TRACES** column stays empty until `ORQ_WORKSPACE` is set, since the
-deep-link needs it. With it set, a row shows **View Trace** when the
-conversation stored a trace id, **View Traces** (a thread filter) when it only
-stored a thread id, and nothing when it has neither.
+**Transcripts** lists every conversation with persona, scenario, turn count, score, who ended it, and whether the goal was met. Sort by score to put the failures on top, and raise the page size (5 / 10 / 25) before scanning a large run. The **TRACES** column stays empty until `ORQ_WORKSPACE` is set, since the deep-link needs it. With it set, a row shows **View Trace** when the conversation stored a trace id, **View Traces** (a thread filter) when it only stored a thread id, and nothing when it has neither.
 
-Click a row to open the conversation: required and prohibited criteria with
-their pass marks, the judge's rationale, and the full user ↔ agent exchange. The
-example below is the interesting failure mode — all four criteria pass, but the
-judge still marks the goal missed because the agent stopped at requesting
-evidence instead of resolving the claim.
+Click a row to open the conversation: required and prohibited criteria with their pass marks, the judge's rationale, and the full user ↔ agent exchange. The example below is the interesting failure mode — all four criteria pass, but the judge still marks the goal missed because the agent stopped at requesting evidence instead of resolving the claim.
 
 ![A conversation drawer: criteria, the judge's rationale, and the full transcript.](assets/dashboard/sim-06-conversation-detail.png){ .dashboard-shot }
 
 ### 7. Turn quality — behaviour over time { #sim-turn-quality }
 
-**Turn quality** trends the four metrics by turn index, so quality decay over
-longer conversations is visible, alongside the turn-count distribution. Use
-multi-turn scenarios and a sufficient `max_turns` value when you want to study
-quality over time.
+**Turn quality** trends the four metrics by turn index, so quality decay over longer conversations is visible, alongside the turn-count distribution. Use multi-turn scenarios and a sufficient `max_turns` value when you want to study quality over time.
 
 ### 8. Config — what was tested { #sim-config }
 
-**Config** records the run metadata — target kind, mode, evaluators, when it ran
-— and the persona table with each simulated user's tone, patience,
-assertiveness, politeness and technical level.
+**Config** records the run metadata — target kind, mode, evaluators, when it ran — and the persona table with each simulated user's tone, patience, assertiveness, politeness and technical level.
 
 ![Config: run metadata and the persona dials used to drive the simulated users.](assets/dashboard/sim-08-config.png){ .dashboard-shot }
 
 ### 9. Compare — did the fix work { #sim-compare }
 
-Pick a second run in **Compare with** to diff two runs: KPI deltas, outcomes,
-per-scorer averages, and how conversations ended. Run-level KPIs always compare.
-For a per-conversation diff, the runs must share the same `(persona, scenario)`
-pairs. Reuse the same personas and scenarios across runs (see
-[Replay stored datapoints](guides/agent-simulation.md#replay-stored-datapoints)) and you get the
-per-conversation comparison needed for a regression gate.
+Pick a second run in **Compare with** to diff two runs: KPI deltas, outcomes, per-scorer averages, and how conversations ended. Run-level KPIs always compare. For a per-conversation diff, the runs must share the same `(persona, scenario)` pairs. Reuse the same personas and scenarios across runs (see [Replay stored datapoints](guides/agent-simulation.md#replay-stored-datapoints)) and you get the per-conversation comparison needed for a regression gate.
 
 !!! tip "Exports respect the filters"
-    **Export** downloads the run as standalone HTML, Markdown or JSON (no CSV
-    on this surface) — the JSON carries only the conversations your filters
-    left visible, so filter first, then export. Formats per surface:
-    [Downloads](#downloads).
+    **Export** downloads the run as standalone HTML, Markdown or JSON (no CSV on this surface) — the JSON carries only the conversations your filters left visible, so filter first, then export. Formats per surface: [Downloads](#downloads).
 
 ---
 
@@ -632,12 +370,9 @@ Every report page includes a download sidebar with export links:
 | CSV (filtered result rows) | yes | — | yes |
 | JSON (filtered result rows) | yes | yes | yes |
 
-The pairwise CSV writes one row per comparison: the question, the consensus
-winner, and each judge's vote as its own column, all resolved to the run's side
-labels rather than the bare `A` / `B` slot letters.
+The pairwise CSV writes one row per comparison: the question, the consensus winner, and each judge's vote as its own column, all resolved to the run's side labels rather than the bare `A` / `B` slot letters.
 
-Download links respect the currently active filter state — the CSV/JSON exports
-contain only the rows visible in the filtered report body.
+Download links respect the currently active filter state — the CSV/JSON exports contain only the rows visible in the filtered report body.
 
 ## Where to next
 

--- a/docs/evaluation-reference.md
+++ b/docs/evaluation-reference.md
@@ -1,8 +1,6 @@
 # Evaluation Reference
 
-Everything `evaluatorq()` accepts, and the patterns built on top of it. If you
-have not run an evaluation yet, start with
-[Getting Started](guides/getting-started.md).
+Everything `evaluatorq()` accepts, and the patterns built on top of it. If you have not run an evaluation yet, start with [Getting Started](guides/getting-started.md).
 
 ## `evaluatorq()`
 
@@ -35,8 +33,7 @@ async def evaluatorq(
 | `path` | `str` \| `None` | `None` | Path for organizing results on the Orq dashboard (e.g. `"Project/Category"`) |
 | `inference` | `bool` | `True` | Run the jobs; set `False` to score data that already has outputs |
 
-Parameters can also be passed positionally as an `EvaluatorParams` model or a
-plain dict — the three forms below are equivalent:
+Parameters can also be passed positionally as an `EvaluatorParams` model or a plain dict — the three forms below are equivalent:
 
 ```python
 await evaluatorq("my-eval", data=[...], jobs=[...], datapoint_parallelism=5)
@@ -50,8 +47,7 @@ Full type signatures live in the [API Reference](reference/evaluatorq.md).
 
 ### The `@job()` decorator
 
-`@job()` names a job. The name shows up in the results table, in traces, and —
-crucially — in error messages:
+`@job()` names a job. The name shows up in the results table, in traces, and — crucially — in error messages:
 
 ```python
 from evaluatorq import job
@@ -73,8 +69,7 @@ word_count_job = job("word-count", lambda data, row: len(data.inputs["text"].spl
 
 ### Multiple jobs per data point
 
-Every job runs against every data point, which is how you compare variants
-(two prompts, two models, preprocessing on and off) on identical inputs:
+Every job runs against every data point, which is how you compare variants (two prompts, two models, preprocessing on and off) on identical inputs:
 
 ```python
 await evaluatorq(
@@ -87,9 +82,7 @@ await evaluatorq(
 
 ## Data sources
 
-`data` accepts inline `DataPoint`s, an Orq dataset, or awaitables that resolve
-to `DataPoint`s — the last of which lets you stream rows in from a slow source
-without blocking the run:
+`data` accepts inline `DataPoint`s, an Orq dataset, or awaitables that resolve to `DataPoint`s — the last of which lets you stream rows in from a slow source without blocking the run:
 
 ```python
 async def get_data_point(i: int) -> DataPoint:
@@ -103,8 +96,7 @@ await evaluatorq(
 )
 ```
 
-For Orq-hosted datasets, pass `data=DatasetIdInput(dataset_id="...")`. That
-path requires `ORQ_API_KEY` — see [Configuration](configuration.md).
+For Orq-hosted datasets, pass `data=DatasetIdInput(dataset_id="...")`. That path requires `ORQ_API_KEY` — see [Configuration](configuration.md).
 
 ## Built-in evaluators
 
@@ -117,14 +109,11 @@ string_contains_evaluator(name="my-contains-check")  # custom name in the table
 exact_match_evaluator()                            # case-sensitive by default
 ```
 
-Both compare the job output against the data point's `expected_output`. For
-LLM-graded evaluators see [LLM as a Jury](llm-as-a-jury.md); for structured,
-multi-dimensional scores see [Structured Results](structured-results.md).
+Both compare the job output against the data point's `expected_output`. For LLM-graded evaluators see [LLM as a Jury](llm-as-a-jury.md); for structured, multi-dimensional scores see [Structured Results](structured-results.md).
 
 ## Custom evaluators
 
-An evaluator is a `{"name": ..., "scorer": ...}` pair whose scorer receives the
-data point and the job output and returns a score:
+An evaluator is a `{"name": ..., "scorer": ...}` pair whose scorer receives the data point and the job output and returns a score:
 
 ```python
 async def accuracy_scorer(params):
@@ -155,9 +144,7 @@ async def quality_scorer(params):
     }
 ```
 
-When any evaluator returns `pass_: False`, `evaluatorq()` returns the results;
-the library never exits the process. To make a script a CI gate, inspect the
-results and exit explicitly:
+When any evaluator returns `pass_: False`, `evaluatorq()` returns the results; the library never exits the process. To make a script a CI gate, inspect the results and exit explicitly:
 
 ```python
 from evaluatorq.evaluatorq import check_pass_failures
@@ -177,10 +164,7 @@ The results table gains a pass rate row — `Pass Rate | 75% (3/4)`.
 await evaluatorq("parallel-eval", data=[...], jobs=[...], datapoint_parallelism=10)
 ```
 
-`datapoint_parallelism` counts **tasks**, and the bounds nest: at most
-`datapoint_parallelism` datapoints run at once, and within each one a separate budget of the same size
-covers its jobs and then its evaluators. Ten datapoints each running ten
-evaluators is a hundred concurrent tasks, not ten.
+`datapoint_parallelism` counts **tasks**, and the bounds nest: at most `datapoint_parallelism` datapoints run at once, and within each one a separate budget of the same size covers its jobs and then its evaluators. Ten datapoints each running ten evaluators is a hundred concurrent tasks, not ten.
 
 ### Bounding LLM requests
 
@@ -190,14 +174,9 @@ Against a provider concurrency limit, size the request ceiling instead:
 await evaluatorq("bounded-eval", data=[...], jobs=[...], llm_parallelism=10)
 ```
 
-This counts requests, not tasks, so it holds however the fan-out nests. It is a
-concurrency bound rather than a rate limit — ten slots against 10s calls is
-about 60 requests/minute, but the same ten slots become 300/minute if the
-provider speeds up to 2s.
+This counts requests, not tasks, so it holds however the fan-out nests. It is a concurrency bound rather than a rate limit — ten slots against 10s calls is about 60 requests/minute, but the same ten slots become 300/minute if the provider speeds up to 2s.
 
-Requests evaluatorq issues itself (judges, juries, simulation agents, the
-red-team pipeline) take a slot automatically. A job that calls a provider SDK
-directly is invisible to the budget unless you wrap it:
+Requests evaluatorq issues itself (judges, juries, simulation agents, the red-team pipeline) take a slot automatically. A job that calls a provider SDK directly is invisible to the budget unless you wrap it:
 
 ```python
 from evaluatorq.common.llm_limit import llm_slot
@@ -208,11 +187,9 @@ async def my_job(data_point, row_index):
     return {"name": "my-job", "output": response.choices[0].message.content}
 ```
 
-Wrap only the request — holding a slot across parsing shrinks the budget
-without reducing load on the provider.
+Wrap only the request — holding a slot across parsing shrinks the budget without reducing load on the provider.
 
-`red_team()`, `simulate()`, `generate_and_simulate()` and `generate()` take the
-same argument, with the same meaning.
+`red_team()`, `simulate()`, `generate_and_simulate()` and `generate()` take the same argument, with the same meaning.
 
 ### Organizing results on Orq
 

--- a/docs/evaluator-template-variables.md
+++ b/docs/evaluator-template-variables.md
@@ -1,12 +1,6 @@
 # Evaluator Template Variables
 
-`llm_jury()` and `llm_jury_pairwise()` render their prompt templates through a
-Mustache-style substitution (`{{name}}`, dotted paths supported). Both the
-built-in default templates and any `prompt=`/`criteria=` override you supply
-draw from the same fixed namespace. The `input.*`, `output.*`, and `log.*` families
-come from `evaluatorq.common.judge._build_namespace`, the single builder shared by
-both jury types; `criteria` and `question` are layered on top by `llm_jury()` /
-`llm_jury_pairwise()` themselves.
+`llm_jury()` and `llm_jury_pairwise()` render their prompt templates through a Mustache-style substitution (`{{name}}`, dotted paths supported). Both the built-in default templates and any `prompt=`/`criteria=` override you supply draw from the same fixed namespace. The `input.*`, `output.*`, and `log.*` families come from `evaluatorq.common.judge._build_namespace`, the single builder shared by both jury types; `criteria` and `question` are layered on top by `llm_jury()` / `llm_jury_pairwise()` themselves.
 
 ## Pointwise (`llm_jury`)
 
@@ -26,9 +20,7 @@ both jury types; `criteria` and `question` are layered on top by `llm_jury()` /
 | `{{log.messages}}` | Full input message list, as JSON (same content as `{{input.all_messages}}`). | `[{"role": "user", "content": "..."}]` |
 | `{{criteria}}` | The evaluation criteria passed to `llm_jury(criteria=...)`. | `The answer is factually correct.` |
 
-The default pointwise template uses `{{criteria}}`, `{{input.all_messages}}`,
-`{{output.response}}`, and `{{input.expected_output}}`. Pass `prompt=` to
-`llm_jury()` to use a different subset of the table above.
+The default pointwise template uses `{{criteria}}`, `{{input.all_messages}}`, `{{output.response}}`, and `{{input.expected_output}}`. Pass `prompt=` to `llm_jury()` to use a different subset of the table above.
 
 ## Pairwise (`llm_jury_pairwise`)
 
@@ -39,43 +31,25 @@ The default pointwise template uses `{{criteria}}`, `{{input.all_messages}}`,
 | `{{response_a.*}}` | Mirrors the full pointwise `input.*`/`output.*`/`log.*` namespace above for side A — e.g. `{{response_a.output.response}}`, `{{response_a.input.all_messages}}`, `{{response_a.output.error}}`. | `{{response_a.output.response}}` → `Paris is the capital of France.` |
 | `{{response_b.*}}` | Same mirror as `response_a.*`, for side B. | `{{response_b.output.response}}` → `Paris.` |
 
-A pairwise side carries an answer only, so `response_{a,b}.input.*` carries no data —
-`all_messages` renders as `[]` and the other input fields render blank. Only
-`response_{a,b}.output.*` is populated.
+A pairwise side carries an answer only, so `response_{a,b}.input.*` carries no data — `all_messages` renders as `[]` and the other input fields render blank. Only `response_{a,b}.output.*` is populated.
 
-The default pairwise template uses `{{criteria}}`, `{{question}}`,
-`{{response_a.output.response}}`, and `{{response_b.output.response}}`. Pass `prompt=`
-to `llm_jury_pairwise()` to override it with any subset of the table above — that is
-the only way to reach `output.tools_called` / `output.messages` per side.
+The default pairwise template uses `{{criteria}}`, `{{question}}`, `{{response_a.output.response}}`, and `{{response_b.output.response}}`. Pass `prompt=` to `llm_jury_pairwise()` to override it with any subset of the table above — that is the only way to reach `output.tools_called` / `output.messages` per side.
 
 ## Migration note
 
 !!! warning "Breaking change to custom prompts"
 
-    Bare `{{input}}`, `{{output}}`, `{{log}}`, `{{response_a}}`, and `{{response_b}}`
-    have been **removed**. They now render as intact literal text (e.g. the string
-    `{{input}}` reaches the judge verbatim) instead of substituting anything, since a
-    bare object has no single sensible string form. A warning is logged whenever one is
-    left unresolved.
+    Bare `{{input}}`, `{{output}}`, `{{log}}`, `{{response_a}}`, and `{{response_b}}` have been **removed**. They now render as intact literal text (e.g. the string `{{input}}` reaches the judge verbatim) instead of substituting anything, since a bare object has no single sensible string form. A warning is logged whenever one is left unresolved.
 
-    If you passed a custom `prompt=` using any of them, switch to the dotted paths above
-    — for example `{{input.all_messages}}` in place of `{{input}}`, and
-    `{{response_a.output.response}}` in place of `{{response_a}}`.
+    If you passed a custom `prompt=` using any of them, switch to the dotted paths above — for example `{{input.all_messages}}` in place of `{{input}}`, and `{{response_a.output.response}}` in place of `{{response_a}}`.
 
-    This shipped in a minor release rather than a major one: the jury template namespace
-    is a very recent feature with no known external users of the bare form.
+    This shipped in a minor release rather than a major one: the jury template namespace is a very recent feature with no known external users of the bare form.
 
-`llm_jury_pairwise()` also now accepts a `prompt=` override, mirroring
-`llm_jury(prompt=...)`, to replace the built-in pairwise template entirely.
+`llm_jury_pairwise()` also now accepts a `prompt=` override, mirroring `llm_jury(prompt=...)`, to replace the built-in pairwise template entirely.
 
 ## Errored targets are not judged
 
-When a target returns an `AgentResponse` carrying an error, neither jury calls its
-judges: `llm_jury()` returns an `inconclusive` result with `pass` unset and the error in
-the explanation, and `llm_jury_pairwise()` returns `winner='inconclusive'`. Grading an
-errored generation would otherwise score "the agent said nothing" as if the agent had
-genuinely answered that way. `{{output.error}}` remains available in the namespace for
-custom prompts that want to inspect it.
+When a target returns an `AgentResponse` carrying an error, neither jury calls its judges: `llm_jury()` returns an `inconclusive` result with `pass` unset and the error in the explanation, and `llm_jury_pairwise()` returns `winner='inconclusive'`. Grading an errored generation would otherwise score "the agent said nothing" as if the agent had genuinely answered that way. `{{output.error}}` remains available in the namespace for custom prompts that want to inspect it.
 
 ## Where to next
 

--- a/docs/framework-integrations.md
+++ b/docs/framework-integrations.md
@@ -1,9 +1,6 @@
 # Framework Integrations
 
-A job is just an async callable, so any agent framework works by calling it
-inside one. For LangChain and LangGraph there is a wrapper that also converts
-the result into OpenResponses format, so traces and reports read the same as a
-native run.
+A job is just an async callable, so any agent framework works by calling it inside one. For LangChain and LangGraph there is a wrapper that also converts the result into OpenResponses format, so traces and reports read the same as a native run.
 
 ## LangChain / LangGraph
 
@@ -55,11 +52,6 @@ Change the prompt key with `prompt_key` (e.g. `prompt_key="question"`).
 
 ## Other frameworks
 
-OpenAI Agents SDK, PydanticAI, and CrewAI agents are supported as red teaming
-and simulation targets through the same wrapping approach — see
-[Red Teaming](guides/red-teaming.md) and
-[Agent Simulation](guides/agent-simulation.md), plus the runnable scripts under
-[`examples/`](https://github.com/orq-ai/evaluatorq/tree/main/examples).
+OpenAI Agents SDK, PydanticAI, and CrewAI agents are supported as red teaming and simulation targets through the same wrapping approach — see [Red Teaming](guides/red-teaming.md) and [Agent Simulation](guides/agent-simulation.md), plus the runnable scripts under [`examples/`](https://github.com/orq-ai/evaluatorq/tree/main/examples).
 
-For anything else, write a plain async function that calls your agent and
-decorate it with `@job()`.
+For anything else, write a plain async function that calls your agent and decorate it with `@job()`.

--- a/docs/guides/agent-simulation.md
+++ b/docs/guides/agent-simulation.md
@@ -1,7 +1,6 @@
 # Agent Simulation
 
-Drive your agent through realistic multi-turn conversations without writing test
-transcripts by hand. Three LLMs are in play:
+Drive your agent through realistic multi-turn conversations without writing test transcripts by hand. Three LLMs are in play:
 
 - **Your agent** — the target under test (a hosted Orq agent, a callback, or an Orq deployment).
 - **User simulator** — plays a **persona** pursuing a **scenario** goal, turn by turn.
@@ -53,9 +52,7 @@ sequenceDiagram
 
 ## Generate from a one-line description
 
-The fastest start: `generate_and_simulate()` synthesizes the personas, scenarios,
-and opening messages from a short description of your agent — no hand-written
-`Persona(...)` / `Scenario(...)`.
+The fastest start: `generate_and_simulate()` synthesizes the personas, scenarios, and opening messages from a short description of your agent — no hand-written `Persona(...)` / `Scenario(...)`.
 
 === "Orq agent"
 
@@ -145,24 +142,14 @@ and opening messages from a short description of your agent — no hand-written
         asyncio.run(main())
     ```
 
-`agent_description` drives generation; `num_personas × num_scenarios` is how many
-conversations run. The simulator and judge LLMs resolve their provider by
-precedence: if `ORQ_API_KEY` is set they route through the Orq AI Router;
-otherwise they fall back to OpenAI via `OPENAI_API_KEY` (an explicitly passed
-client always wins). See [Configuration](../configuration.md).
+`agent_description` drives generation; `num_personas × num_scenarios` is how many conversations run. The simulator and judge LLMs resolve their provider by precedence: if `ORQ_API_KEY` is set they route through the Orq AI Router; otherwise they fall back to OpenAI via `OPENAI_API_KEY` (an explicitly passed client always wins). See [Configuration](../configuration.md).
 
 !!! note "CI and local runs"
-    Dropped simulations raise by default; ordinary failed goals remain in the
-    returned results. Set `exit_on_failure=False` for exploratory runs. When
-    `ORQ_API_KEY` is available, results upload to Orq by default; pass
-    `upload_results=False` for a local-only run.
+    Dropped simulations raise by default; ordinary failed goals remain in the returned results. Set `exit_on_failure=False` for exploratory runs. When `ORQ_API_KEY` is available, results upload to Orq by default; pass `upload_results=False` for a local-only run.
 
 ## Seed by archetype
 
-The middle ground between "just give me five" and specifying every trait: name
-the archetype, and `generate_persona()` / `generate_scenario()` fill the rest.
-You get back real `Persona` / `Scenario` objects to inspect, tweak, and pass to
-`simulate()`.
+The middle ground between "just give me five" and specifying every trait: name the archetype, and `generate_persona()` / `generate_scenario()` fill the rest. You get back real `Persona` / `Scenario` objects to inspect, tweak, and pass to `simulate()`.
 
 ```python
 import asyncio
@@ -192,20 +179,13 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Batch forms `generate_personas([...])` / `generate_scenarios([...])` take a list
-of seeds and return one object each.
+Batch forms `generate_personas([...])` / `generate_scenarios([...])` take a list of seeds and return one object each.
 
 ## Full control: hand-build personas
 
-When you want exact personas and pass/fail criteria, build them yourself and call
-`simulate()`. A **persona** is *who* is talking (patience, assertiveness, tone);
-a **scenario** is *what they want* plus the **criteria** the agent must (or must
-not) satisfy.
+When you want exact personas and pass/fail criteria, build them yourself and call `simulate()`. A **persona** is *who* is talking (patience, assertiveness, tone); a **scenario** is *what they want* plus the **criteria** the agent must (or must not) satisfy.
 
-A persona requires its core traits — `name`, `patience`, `assertiveness`,
-`politeness`, `technical_level`, `communication_style`, and `background`. Only
-`emotional_arc` and `cultural_context` default (to `None`). A scenario needs just
-`name` and `goal`; everything else, including `criteria`, is optional.
+A persona requires its core traits — `name`, `patience`, `assertiveness`, `politeness`, `technical_level`, `communication_style`, and `background`. Only `emotional_arc` and `cultural_context` default (to `None`). A scenario needs just `name` and `goal`; everything else, including `criteria`, is optional.
 
 === "Orq agent"
 
@@ -324,29 +304,18 @@ A persona requires its core traits — `name`, `patience`, `assertiveness`,
         asyncio.run(main())
     ```
 
-One persona × one scenario yields one `SimulationResult` with `goal_achieved`,
-`goal_completion_score`, `turn_count`, `rules_broken`, and the full message
-transcript.
+One persona × one scenario yields one `SimulationResult` with `goal_achieved`, `goal_completion_score`, `turn_count`, `rules_broken`, and the full message transcript.
 
 ### How criteria are scored
 
-The judge audits every `Criterion` on every turn and the runner folds those
-verdicts over the whole conversation, so a violation on turn 2 still shows up in a
-run that ends on turn 6:
+The judge audits every `Criterion` on every turn and the runner folds those verdicts over the whole conversation, so a violation on turn 2 still shows up in a run that ends on turn 6:
 
-- **`must_happen`** passes if it occurred in *any* turn. Never occurring is a
-  failure — intent, plans, and paraphrases do not count.
-- **`must_not_happen`** fails if it was violated in *any* turn. One violation is
-  permanent; a clean later turn does not clear it.
+- **`must_happen`** passes if it occurred in *any* turn. Never occurring is a failure — intent, plans, and paraphrases do not count.
+- **`must_not_happen`** fails if it was violated in *any* turn. One violation is permanent; a clean later turn does not clear it.
 
-The judge is only ever asked **what occurred**, never what passed — a pass/fail
-flag means the opposite thing for the two criterion types, and models invert it.
-Occurrence is mapped to pass/fail in code, so `rules_broken` is derived, not
-reported. Failures land in `rules_broken` (criterion ids), `criteria_results`
-(description → passed), and the `criteria_met` score.
+The judge is only ever asked **what occurred**, never what passed — a pass/fail flag means the opposite thing for the two criterion types, and models invert it. Occurrence is mapped to pass/fail in code, so `rules_broken` is derived, not reported. Failures land in `rules_broken` (criterion ids), `criteria_results` (description → passed), and the `criteria_met` score.
 
-Per-criterion detail is in `metadata['criteria_meta']`, where `audited` says whether
-the judge actually returned a verdict for that criterion:
+Per-criterion detail is in `metadata['criteria_meta']`, where `audited` says whether the judge actually returned a verdict for that criterion:
 
 ```python
 for c in result.metadata['criteria_meta']:
@@ -354,57 +323,32 @@ for c in result.metadata['criteria_meta']:
         print(f"{c['id']} was not audited by the judge")
 ```
 
-A `must_happen` the judge confirmed never occurred and one it did not audit both
-show `passed: False`; use `audited` to distinguish them. It has three states, not
-two: `True` audited, `False` not audited, and `None` on runs saved before the
-field existed — which is why the example tests `is False` rather than `not
-c['audited']`.
+A `must_happen` the judge confirmed never occurred and one it did not audit both show `passed: False`; use `audited` to distinguish them. It has three states, not two: `True` audited, `False` not audited, and `None` on runs saved before the field existed — which is why the example tests `is False` rather than `not c['audited']`.
 
-Each entry also carries **`evidence`** — the quote from the turn where the
-criterion's occurrence first flipped, taken from the judge's `criteria_verdicts`
-audit. It is `''` when the criterion never occurred (or occurred without a
-tracked quote) and `None` when no tracker was available, same as `audited`.
+Each entry also carries **`evidence`** — the quote from the turn where the criterion's occurrence first flipped, taken from the judge's `criteria_verdicts` audit. It is `''` when the criterion never occurred (or occurred without a tracked quote) and `None` when no tracker was available, same as `audited`.
 
-Both keys reach the reports. A criterion that was not audited renders as **not
-audited** (a neutral `?`, never a green tick) and is counted separately from the
-"N/M criteria met" tally. A run with `criteria_verified = False` says so above
-the criteria list.
+Both keys reach the reports. A criterion that was not audited renders as **not audited** (a neutral `?`, never a green tick) and is counted separately from the "N/M criteria met" tally. A run with `criteria_verified = False` says so above the criteria list.
 
-The `criteria_met` score applies the same rule: an unaudited criterion is **not
-met**, so the score and the tally beside it agree.
+The `criteria_met` score applies the same rule: an unaudited criterion is **not met**, so the score and the tally beside it agree.
 
 !!! warning "A custom `judge=` must report per-criterion verdicts"
 
-    The built-in `JudgeAgent` audits each unsettled criterion every turn. A custom
-    judge that does not populate `Judgment.criteria_verdicts` cannot provide a
-    reliable per-criterion audit.
+    The built-in `JudgeAgent` audits each unsettled criterion every turn. A custom judge that does not populate `Judgment.criteria_verdicts` cannot provide a reliable per-criterion audit.
 
-    That run is marked `SimulationResult.criteria_verified = False`, the runner logs
-    a warning naming the scenario, and `criteria_met` scores it `0.0` — unknown, not
-    met. Check the field, not the transcript:
+    That run is marked `SimulationResult.criteria_verified = False`, the runner logs a warning naming the scenario, and `criteria_met` scores it `0.0` — unknown, not met. Check the field, not the transcript:
 
     ```python
     if result.criteria_verified is False:
         print('criteria unverified — the judge returned no per-criterion audit')
     ```
 
-A run that ends in an error or a timeout never reaches the audit either. Those
-results also score `criteria_met` as `0.0` (not `1.0`) and log a warning, so neither
-a crashed run nor an unaudited one can inflate the average. A target that dies
-mid-run keeps whatever the judge had already **confirmed** — a `must_not_happen` it
-saw violated stays failed — while a `must_happen` that simply had not happened yet
-is reported as **unknown**, never as failed. The run was cut short before that
-criterion had its chance: it is not the judge's verdict that nothing happened;
-nobody looked.
+A run that ends in an error or a timeout never reaches the audit either. Those results also score `criteria_met` as `0.0` (not `1.0`) and log a warning, so neither a crashed run nor an unaudited one can inflate the average. A target that dies mid-run keeps whatever the judge had already **confirmed** — a `must_not_happen` it saw violated stays failed — while a `must_happen` that simply had not happened yet is reported as **unknown**, never as failed. The run was cut short before that criterion had its chance: it is not the judge's verdict that nothing happened; nobody looked.
 
-The callable passed to `target` is the only structural difference from the Orq path —
-personas, scenarios, criteria, and the result shape are identical. Swap the
-callback body for any HTTP/LLM agent.
+The callable passed to `target` is the only structural difference from the Orq path — personas, scenarios, criteria, and the result shape are identical. Swap the callback body for any HTTP/LLM agent.
 
 ## The four built-in scorers
 
-`evaluator_names` picks from four built-ins. Two read the judge's verdicts; two apply
-a *policy* you can change with `scoring=`:
+`evaluator_names` picks from four built-ins. Two read the judge's verdicts; two apply a *policy* you can change with `scoring=`:
 
 | Scorer | 0–1 meaning | Tunable |
 |---|---|---|
@@ -413,26 +357,13 @@ a *policy* you can change with `scoring=`:
 | `turn_efficiency` | How few turns it took to reach the goal. `0.0` if the goal was missed. | yes |
 | `conversation_quality` | Weighted composite of the other three. | yes |
 
-The default is `["goal_achieved", "criteria_met"]` — the two that are meaningful for
-every scenario. The other two are opt-in.
+The default is `["goal_achieved", "criteria_met"]` — the two that are meaningful for every scenario. The other two are opt-in.
 
 ### What `turn_efficiency` actually measures
 
-It is a **cost** proxy, conditioned on success: *given that the goal was reached, how
-many conversational turns did it take?* The assumption behind "fewer is better" is that
-the extra turns are usually the agent re-asking for something it could have inferred,
-clarifying its own vague answer, or wandering — so a user who got what they came for in
-two turns had a better experience, and cost less to serve, than one who needed twelve.
-A run that did **not** reach the goal scores `0.0` outright: failing quickly is not
-efficiency.
+It is a **cost** proxy, conditioned on success: *given that the goal was reached, how many conversational turns did it take?* The assumption behind "fewer is better" is that the extra turns are usually the agent re-asking for something it could have inferred, clarifying its own vague answer, or wandering — so a user who got what they came for in two turns had a better experience, and cost less to serve, than one who needed twelve. A run that did **not** reach the goal scores `0.0` outright: failing quickly is not efficiency.
 
-**Where that assumption breaks.** A task that legitimately needs many turns — a long
-intake form, a multi-step troubleshooting tree, a negotiation — is penalised by this
-metric for doing its job properly. If your scenarios look like that, either move the
-cliffs out so the curve matches a realistic conversation length, or leave
-`turn_efficiency` out of `evaluator_names` and ignore the score. Do not read a low
-`turn_efficiency` as a quality problem without checking the transcript length you
-actually expect.
+**Where that assumption breaks.** A task that legitimately needs many turns — a long intake form, a multi-step troubleshooting tree, a negotiation — is penalised by this metric for doing its job properly. If your scenarios look like that, either move the cliffs out so the curve matches a realistic conversation length, or leave `turn_efficiency` out of `evaluator_names` and ignore the score. Do not read a low `turn_efficiency` as a quality problem without checking the transcript length you actually expect.
 
 The default curve is a set of cliffs, then a linear decay to a floor:
 
@@ -440,10 +371,7 @@ The default curve is a set of cliffs, then a linear decay to a floor:
 |---|---|---|---|---|---|---|---|
 | Score | 1.0 | 0.9 | 0.7 | 0.6 | 0.5 | 0.4 | 0.3 |
 
-Past the last cliff each turn costs `turn_efficiency_decay_per_turn` (0.1), starting
-from that cliff's score, until `turn_efficiency_floor` (0.3) — a very long conversation
-that *did* reach the goal keeps a non-zero score, because it was inefficient, not
-failed.
+Past the last cliff each turn costs `turn_efficiency_decay_per_turn` (0.1), starting from that cliff's score, until `turn_efficiency_floor` (0.3) — a very long conversation that *did* reach the goal keeps a non-zero score, because it was inefficient, not failed.
 
 ### The `conversation_quality` composite
 
@@ -455,12 +383,9 @@ One number per conversation, weighted across the other three scorers:
 | `criteria_met_weight` | `0.3` | What share of the scenario's criteria were audited and satisfied? |
 | `turn_efficiency_weight` | `0.3` | How few turns that took (the cost proxy above). |
 
-The weights must sum to `1.0` — `SimulationScoringConfig` rejects any other sum at
-construction, so the composite stays on the same 0–1 scale as its parts and remains
-comparable across runs.
+The weights must sum to `1.0` — `SimulationScoringConfig` rejects any other sum at construction, so the composite stays on the same 0–1 scale as its parts and remains comparable across runs.
 
-**Worked example.** A refund conversation runs 4 turns, the judge marks the goal
-achieved, and 1 of the scenario's 2 criteria is met:
+**Worked example.** A refund conversation runs 4 turns, the judge marks the goal achieved, and 1 of the scenario's 2 criteria is met:
 
 - `goal_achieved` = `1.0`
 - `criteria_met` = `1/2` = `0.5`
@@ -487,31 +412,18 @@ results = await simulate(
 )
 ```
 
-`scoring=` is accepted by both `simulate()` and `generate_and_simulate()`, and omitting
-it uses the defaults above. The config is bounded and rejects unknown fields, so a typo
-fails at construction rather than silently scoring with the shipped policy. Two shapes
-it refuses on purpose, because both produce a report that is quietly wrong rather than
-obviously broken:
+`scoring=` is accepted by both `simulate()` and `generate_and_simulate()`, and omitting it uses the defaults above. The config is bounded and rejects unknown fields, so a typo fails at construction rather than silently scoring with the shipped policy. Two shapes it refuses on purpose, because both produce a report that is quietly wrong rather than obviously broken:
 
-- cliffs that are not ordered — turn thresholds must strictly increase and scores must
-  not increase with them, so a longer conversation can never score higher than a
-  shorter one;
+- cliffs that are not ordered — turn thresholds must strictly increase and scores must not increase with them, so a longer conversation can never score higher than a shorter one;
 - weights that do not sum to `1.0`.
 
 ## From existing traces and data
 
-You do not have to invent every test case from scratch. If you already have
-recorded conversations, real production traces, or a batch of datapoints from an
-earlier run, you can feed that history back into simulation in two ways: replay
-the exact same cases, or mine them for the archetypes that drive fresh ones.
+You do not have to invent every test case from scratch. If you already have recorded conversations, real production traces, or a batch of datapoints from an earlier run, you can feed that history back into simulation in two ways: replay the exact same cases, or mine them for the archetypes that drive fresh ones.
 
 ### Replay stored datapoints
 
-A `SimulationDatapoint` bundles one persona, one scenario, and the opening
-message. Every case simulation runs is one of these, and you can persist them for
-reuse. `eq sim generate` writes the cases it builds to a JSONL file with
-`--datapoints PATH` (one datapoint per line); `eq sim run` does the same alongside a
-live run with `--datapoints PATH`:
+A `SimulationDatapoint` bundles one persona, one scenario, and the opening message. Every case simulation runs is one of these, and you can persist them for reuse. `eq sim generate` writes the cases it builds to a JSONL file with `--datapoints PATH` (one datapoint per line); `eq sim run` does the same alongside a live run with `--datapoints PATH`:
 
 ```bash
 # Generate cases once and keep them
@@ -523,10 +435,7 @@ eq sim generate --agent-description "e-commerce support agent" \
 eq sim simulate --input cases.jsonl --target agent:my-support-agent
 ```
 
-Because the file pins the personas, scenarios, and first messages, the run is
-reproducible. That makes it the natural way to compare two agent versions, or the
-same agent under a new set of evaluators, on an identical bank of cases. From the
-SDK the same file loads via `load_datapoints_from_jsonl()`:
+Because the file pins the personas, scenarios, and first messages, the run is reproducible. That makes it the natural way to compare two agent versions, or the same agent under a new set of evaluators, on an identical bank of cases. From the SDK the same file loads via `load_datapoints_from_jsonl()`:
 
 ```python
 import asyncio
@@ -553,10 +462,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-If your cases already live in Orq as a dataset, point `simulate()` at it with
-`dataset_id=` and skip the local file entirely. Each row's `inputs` should carry a
-`datapoint` object (`persona`, `scenario`, `first_message`), or a `persona` +
-`scenario` pair, matching the `SimulationDatapoint` shape above:
+If your cases already live in Orq as a dataset, point `simulate()` at it with `dataset_id=` and skip the local file entirely. Each row's `inputs` should carry a `datapoint` object (`persona`, `scenario`, `first_message`), or a `persona` + `scenario` pair, matching the `SimulationDatapoint` shape above:
 
 ```python
 results = await simulate(
@@ -567,30 +473,20 @@ results = await simulate(
 )
 ```
 
-`simulate()` takes five mutually exclusive sources — `datapoints`, `dataset_id`,
-`experiment_id`, `previous_run`, and `personas` + `scenarios`. Pass exactly one
-per run.
+`simulate()` takes five mutually exclusive sources — `datapoints`, `dataset_id`, `experiment_id`, `previous_run`, and `personas` + `scenarios`. Pass exactly one per run.
 
 ### Ground new cases in real traces
 
-Replay reruns what you already have. The other move is to generate *new* cases
-that are shaped by what really happened. Production traces show you the user
-archetypes and situations your agent actually meets.
+Replay reruns what you already have. The other move is to generate *new* cases that are shaped by what really happened. Production traces show you the user archetypes and situations your agent actually meets.
 
-The direct route is `eq sim from-traces`, which pulls recent traces from the Orq
-traces API and writes one datapoint per conversation — persona and scenario
-inferred from a short summary of it, opening message written from that persona
-and scenario:
+The direct route is `eq sim from-traces`, which pulls recent traces from the Orq traces API and writes one datapoint per conversation — persona and scenario inferred from a short summary of it, opening message written from that persona and scenario:
 
 ```bash
 eq sim from-traces --output traces_datapoints.jsonl --limit 50 --lookback-hours 24
 eq sim simulate --input traces_datapoints.jsonl --target agent:my-agent
 ```
 
-Add `--extend N` to also generate N new datapoints matching the traffic
-distribution of the fetched traces, so you get cases *around* real traffic rather
-than only the recorded ones. The same thing is available from Python as
-`datapoints_from_traces()` and `extend_from_traces()`:
+Add `--extend N` to also generate N new datapoints matching the traffic distribution of the fetched traces, so you get cases *around* real traffic rather than only the recorded ones. The same thing is available from Python as `datapoints_from_traces()` and `extend_from_traces()`:
 
 ```python
 from evaluatorq.simulation import (
@@ -608,19 +504,9 @@ Full flag list: [`eq sim from-traces`](../cli-reference/simulation.md).
 
 #### What happens between a trace and a datapoint
 
-Fetching is shared; both modes are then map-then-reduce. Each conversation is
-summarized on its own (the map), and the summaries — never the raw transcripts —
-go into the call that produces the output (the reduce). That is what keeps a
-prompt's size a function of *how many* traces there are rather than how long any
-one of them ran: before it, a single long agentic session crowded out the twenty
-short conversations it should have been weighed against.
+Fetching is shared; both modes are then map-then-reduce. Each conversation is summarized on its own (the map), and the summaries — never the raw transcripts — go into the call that produces the output (the reduce). That is what keeps a prompt's size a function of *how many* traces there are rather than how long any one of them ran: before it, a single long agentic session crowded out the twenty short conversations it should have been weighed against.
 
-Both modes summarize unconditionally: every conversation gets exactly one
-summarize call, and nothing downstream reads the raw transcript again — direct
-mode's persona/scenario inference reads the summary, and so does extension
-mode's traffic-profile reduce. A run doing both calls `summarize_conversations`
-once and passes the result as `summaries=` to each, so no conversation is
-summarized twice.
+Both modes summarize unconditionally: every conversation gets exactly one summarize call, and nothing downstream reads the raw transcript again — direct mode's persona/scenario inference reads the summary, and so does extension mode's traffic-profile reduce. A run doing both calls `summarize_conversations` once and passes the result as `summaries=` to each, so no conversation is summarized twice.
 
 ```mermaid
 flowchart TD
@@ -645,8 +531,7 @@ flowchart TD
     N --> O["N new SimulationDatapoints<br/>synthetic, not replayed"]
 ```
 
-Every LLM-side limit lives on `TraceAnalysisConfig`, passed as `config=` to either
-function; the fetch-side ones are fixed:
+Every LLM-side limit lives on `TraceAnalysisConfig`, passed as `config=` to either function; the fetch-side ones are fixed:
 
 | Limit | Default | Why |
 |---|---|---|
@@ -660,96 +545,35 @@ function; the fetch-side ones are fixed:
 | `generate_first_message` | `True` | Write the opening from the persona; `False` replays the recorded one |
 | `redact_pii` | `True` | Instruct the model to replace identifying values with placeholders as it writes |
 
-`summary_target_tokens` is a target, not a cut, and deliberately so. Truncating a
-summary removes its end, which is exactly where the prompt puts what went wrong
-and what was unusual — the two things the next step most needs. A length the
-model can aim at (models reason in tokens, not characters) buys a soft bound that
-keeps whole sentences. The reduce prompt's expected size is that target times
-`max_reduce_summaries`.
+`summary_target_tokens` is a target, not a cut, and deliberately so. Truncating a summary removes its end, which is exactly where the prompt puts what went wrong and what was unusual — the two things the next step most needs. A length the model can aim at (models reason in tokens, not characters) buys a soft bound that keeps whole sentences. The reduce prompt's expected size is that target times `max_reduce_summaries`.
 
-The completion budgets, by contrast, are deliberately far above the answers they
-bound. Reasoning models spend most of a budget thinking before emitting anything,
-so a budget sized to the output gets consumed by reasoning tokens and truncates
-the answer to nothing — the prompt bounds the length, the budget bounds the
-failure. Truncation is never silent: `generate_structured` raises on a
-length-finished response on every path rather than handing back a cut-off object.
+The completion budgets, by contrast, are deliberately far above the answers they bound. Reasoning models spend most of a budget thinking before emitting anything, so a budget sized to the output gets consumed by reasoning tokens and truncates the answer to nothing — the prompt bounds the length, the budget bounds the failure. Truncation is never silent: `generate_structured` raises on a length-finished response on every path rather than handing back a cut-off object.
 
-Pagination stops when `--limit` is met, when the API says there is no more, or
-when a page returns rows that all lack a `trace_id` — a page that adds nothing
-cannot be followed by one that does, so that is where the loop ends, and it says
-so in a warning. There is no fixed page ceiling, so a large `--limit` is honoured
-for as many pages as it genuinely takes.
+Pagination stops when `--limit` is met, when the API says there is no more, or when a page returns rows that all lack a `trace_id` — a page that adds nothing cannot be followed by one that does, so that is where the loop ends, and it says so in a warning. There is no fixed page ceiling, so a large `--limit` is honoured for as many pages as it genuinely takes.
 
-A trace that fails its span fetch, returns a non-list payload, or yields no user
-message is dropped with a warning rather than failing the batch — likewise an
-inference or summarize call that raises or returns nothing parseable. Extension
-mode logs how many of the sampled conversations actually reached the profile,
-because that count is the denominator its shares are computed over. A run that
-produced fewer datapoints than traces has those warnings behind it.
+A trace that fails its span fetch, returns a non-list payload, or yields no user message is dropped with a warning rather than failing the batch — likewise an inference or summarize call that raises or returns nothing parseable. Extension mode logs how many of the sampled conversations actually reached the profile, because that count is the denominator its shares are computed over. A run that produced fewer datapoints than traces has those warnings behind it.
 
-Generation runs before a simulation exists, so its spend has no field on any
-*result*. Each phase reports its own total to the run log — `Trace
-summarization`, `Trace persona/scenario inference`, `Trace traffic profiling`,
-`Persona/scenario generation` and `Simulation recommendations` each log the
-tokens, the number of LLM calls, and the cost when the models are priced. The
-call count includes the fallback rungs a structured-output call burned on the way
-to an answer, and a rung whose usage the provider did not report is counted as
-one unpriced call rather than as zero, so the figure reads as a lower bound
-instead of a confident total. A call that *raised* is counted too — the rungs it
-burned before truncating or refusing were billed, and the exception carries their
-total for the phase to pick up.
+Generation runs before a simulation exists, so its spend has no field on any *result*. Each phase reports its own total to the run log — `Trace summarization`, `Trace persona/scenario inference`, `Trace traffic profiling`, `Persona/scenario generation` and `Simulation recommendations` each log the tokens, the number of LLM calls, and the cost when the models are priced. The call count includes the fallback rungs a structured-output call burned on the way to an answer, and a rung whose usage the provider did not report is counted as one unpriced call rather than as zero, so the figure reads as a lower bound instead of a confident total. A call that *raised* is counted too — the rungs it burned before truncating or refusing were billed, and the exception carries their total for the phase to pick up.
 
-`SimulationRun.token_usage_total` is the run-level figure: every result's
-`token_usage`, plus — for `generate_and_simulate()` — the GENERATE stage's
-persona/scenario generation cost, plus the executive summary's own completion
-cost when one was generated. It is recomputed after the executive summary runs
-so it never goes stale relative to that later-arriving cost. **Recommendation
-generation is not folded in** — that spend stays log-only (`Simulation
-recommendations: N tokens over M LLM call(s), $X`), the same as the trace-analysis
-phases above. `None` only when nothing in the run was ever billed.
+`SimulationRun.token_usage_total` is the run-level figure: every result's `token_usage`, plus — for `generate_and_simulate()` — the GENERATE stage's persona/scenario generation cost, plus the executive summary's own completion cost when one was generated. It is recomputed after the executive summary runs so it never goes stale relative to that later-arriving cost. **Recommendation generation is not folded in** — that spend stays log-only (`Simulation recommendations: N tokens over M LLM call(s), $X`), the same as the trace-analysis phases above. `None` only when nothing in the run was ever billed.
 
 ##### What lands in the generated dataset
 
-Trace-derived datapoints are built from real conversations, and a persona
-background or scenario context written straight from one carries whatever was in
-it — names, order numbers, emails — into a JSONL that then gets committed and
-shared. By default both the summarize and the persona/scenario prompts are
-instructed to redact as they write, replacing identifying values with
-placeholders (`[CUSTOMER_NAME]`, `[ORDER_ID]`) that keep the meaning; the profile
-prompt is told to carry placeholders through rather than invent concrete values.
+Trace-derived datapoints are built from real conversations, and a persona background or scenario context written straight from one carries whatever was in it — names, order numbers, emails — into a JSONL that then gets committed and shared. By default both the summarize and the persona/scenario prompts are instructed to redact as they write, replacing identifying values with placeholders (`[CUSTOMER_NAME]`, `[ORDER_ID]`) that keep the meaning; the profile prompt is told to carry placeholders through rather than invent concrete values.
 
-`--no-redact-pii` (or `TraceAnalysisConfig(redact_pii=False)`) turns it off, for
-when the concrete values are the point — reproducing a specific incident, or a
-fixture where a changed order number breaks the comparison — and the dataset
-stays somewhere the raw traffic could already go. With it off the profile prompt
-also drops its "keep the placeholders" line, since telling a model to preserve
-placeholders that were never introduced invites it to invent them, and invented
-placeholders read as redaction that did not happen.
+`--no-redact-pii` (or `TraceAnalysisConfig(redact_pii=False)`) turns it off, for when the concrete values are the point — reproducing a specific incident, or a fixture where a changed order number breaks the comparison — and the dataset stays somewhere the raw traffic could already go. With it off the profile prompt also drops its "keep the placeholders" line, since telling a model to preserve placeholders that were never introduced invites it to invent them, and invented placeholders read as redaction that did not happen.
 
-Either way this is an instruction to a model, not a guarantee. Treat a generated
-dataset from production traffic as needing the same review any export of that
-traffic would.
+Either way this is an instruction to a model, not a guarantee. Treat a generated dataset from production traffic as needing the same review any export of that traffic would.
 
 ##### Why the opening message is generated, not replayed
 
-Replaying the real user's first message looks like the faithful choice and
-behaves worse. The simulated user is the *persona*; if turn one is production
-text the persona would not have written, the conversation opens in one voice and
-continues in another, and whatever the agent does with that mismatch is not
-evidence about either. Reusing recorded text also carries any PII in it into a
-generated dataset that then gets committed and shared.
+Replaying the real user's first message looks like the faithful choice and behaves worse. The simulated user is the *persona*; if turn one is production text the persona would not have written, the conversation opens in one voice and continues in another, and whatever the agent does with that mismatch is not evidence about either. Reusing recorded text also carries any PII in it into a generated dataset that then gets committed and shared.
 
-`--replay-first-message` (or `TraceAnalysisConfig(generate_first_message=False)`)
-is the opt-out, for when you are reproducing one specific recorded case and want
-the exact opening back.
+`--replay-first-message` (or `TraceAnalysisConfig(generate_first_message=False)`) is the opt-out, for when you are reproducing one specific recorded case and want the exact opening back.
 
 #### Hand-picked seeds
 
-When you want curated archetypes rather than a straight pull from traffic, seed
-generation yourself. Pull the recurring patterns out of your traces (the impatient
-buyer disputing a charge, the confused first-time user, the edge case that broke
-last week), then hand them to `generate_personas()` / `generate_scenarios()` as
-short seed phrases:
+When you want curated archetypes rather than a straight pull from traffic, seed generation yourself. Pull the recurring patterns out of your traces (the impatient buyer disputing a charge, the confused first-time user, the edge case that broke last week), then hand them to `generate_personas()` / `generate_scenarios()` as short seed phrases:
 
 ```python
 import asyncio
@@ -781,24 +605,14 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-The seed is a steer, not a transcript: generation fills in the persona traits and
-scenario criteria and writes a natural opening message, so each run explores the
-space around the pattern rather than replaying one recorded conversation. Persist
-the generated cases (`eq sim generate --datapoints`, or `eq sim run
---datapoints`) and they become a replayable bank for the section above.
+The seed is a steer, not a transcript: generation fills in the persona traits and scenario criteria and writes a natural opening message, so each run explores the space around the pattern rather than replaying one recorded conversation. Persist the generated cases (`eq sim generate --datapoints`, or `eq sim run --datapoints`) and they become a replayable bank for the section above.
 
 !!! note "Seeds are a deliberate choice, not the only route"
-    Writing seed phrases by hand means you decide which archetypes matter, rather
-    than inheriting whatever your recent traffic happened to contain. When you'd
-    rather start from real traffic, use `eq sim from-traces` above — it infers the
-    personas and scenarios for you.
+    Writing seed phrases by hand means you decide which archetypes matter, rather than inheriting whatever your recent traffic happened to contain. When you'd rather start from real traffic, use `eq sim from-traces` above — it infers the personas and scenarios for you.
 
 ## Reading a run in the dashboard
 
-Runs are saved to `.evaluatorq/sim-runs/<name>_<timestamp>.json` — automatically
-by `eq sim run` (unless you pass `--no-save`), and by `simulate()` when called
-with `save=True`. `eq dashboard` browses those files locally, no external
-service:
+Runs are saved to `.evaluatorq/sim-runs/<name>_<timestamp>.json` — automatically by `eq sim run` (unless you pass `--no-save`), and by `simulate()` when called with `save=True`. `eq dashboard` browses those files locally, no external service:
 
 ```bash
 uv add "evaluatorq[dashboard]"
@@ -808,13 +622,9 @@ eq dashboard .evaluatorq/sim-runs  # scope to simulation runs
 ```
 
 !!! warning "The Python examples above don't save by default"
-    `simulate()` and `generate_and_simulate()` default to `save=False`, so a
-    script copy-pasted from earlier on this page leaves the dashboard empty.
-    Pass `save=True`, or drive the run from the CLI (`eq sim run`), which saves
-    unless you pass `--no-save`.
+    `simulate()` and `generate_and_simulate()` default to `save=False`, so a script copy-pasted from earlier on this page leaves the dashboard empty. Pass `save=True`, or drive the run from the CLI (`eq sim run`), which saves unless you pass `--no-save`.
 
-Land on the cross-surface overview, pick the run from **Agent Sim**, then work
-down the report tabs from headline to transcript:
+Land on the cross-surface overview, pick the run from **Agent Sim**, then work down the report tabs from headline to transcript:
 
 | Tab | What it answers |
 |---|---|
@@ -826,54 +636,29 @@ down the report tabs from headline to transcript:
 | **Config** | Run metadata plus the persona dials |
 | **Compare** | KPI and per-conversation deltas against a second run |
 
-Two easily conflated numbers: **pass rate** is the share of conversations where
-the judge set `goal_achieved`; **average score** is the mean
-`goal_completion_score`, so a run can average 0.7 while passing half its
-conversations. The **CONFIDENCE** badge is a band on the pass rate, not a
-statistical confidence — it carries no sample-size meaning.
+Two easily conflated numbers: **pass rate** is the share of conversations where the judge set `goal_achieved`; **average score** is the mean `goal_completion_score`, so a run can average 0.7 while passing half its conversations. The **CONFIDENCE** badge is a band on the pass rate, not a statistical confidence — it carries no sample-size meaning.
 
-The tab-by-tab walkthrough, with screenshots, lives in the Dashboard reference:
-[Reading a simulation run](../dashboard.md#reading-a-simulation-run). See also
-[filters](../dashboard.md#filters), [trace links](../dashboard.md#orq-trace-links)
-and [downloads](../dashboard.md#downloads).
+The tab-by-tab walkthrough, with screenshots, lives in the Dashboard reference: [Reading a simulation run](../dashboard.md#reading-a-simulation-run). See also [filters](../dashboard.md#filters), [trace links](../dashboard.md#orq-trace-links) and [downloads](../dashboard.md#downloads).
 
 ## External framework demos
 
-Each recording runs one framework's example end to end — the user simulator
-drives the conversation, the agent under test responds, and the judge scores the
-transcript. Sources live in `examples/agent_simulation/` (files `06`–`09`).
+Each recording runs one framework's example end to end — the user simulator drives the conversation, the agent under test responds, and the judge scores the transcript. Sources live in `examples/agent_simulation/` (files `06`–`09`).
 
 ### LangGraph
 
-<video controls muted playsinline preload="metadata" width="100%">
-  <source src="../../assets/sim-langgraph.mp4" type="video/mp4">
-  Your browser does not support the video tag —
-  <a href="../../assets/sim-langgraph.mp4">download the recording</a>.
-</video>
+<video controls muted playsinline preload="metadata" width="100%"> <source src="../../assets/sim-langgraph.mp4" type="video/mp4"> Your browser does not support the video tag — <a href="../../assets/sim-langgraph.mp4">download the recording</a>. </video>
 
 ### OpenAI Agents SDK
 
-<video controls muted playsinline preload="metadata" width="100%">
-  <source src="../../assets/sim-openai-agents.mp4" type="video/mp4">
-  Your browser does not support the video tag —
-  <a href="../../assets/sim-openai-agents.mp4">download the recording</a>.
-</video>
+<video controls muted playsinline preload="metadata" width="100%"> <source src="../../assets/sim-openai-agents.mp4" type="video/mp4"> Your browser does not support the video tag — <a href="../../assets/sim-openai-agents.mp4">download the recording</a>. </video>
 
 ### Pydantic AI
 
-<video controls muted playsinline preload="metadata" width="100%">
-  <source src="../../assets/sim-pydantic-ai.mp4" type="video/mp4">
-  Your browser does not support the video tag —
-  <a href="../../assets/sim-pydantic-ai.mp4">download the recording</a>.
-</video>
+<video controls muted playsinline preload="metadata" width="100%"> <source src="../../assets/sim-pydantic-ai.mp4" type="video/mp4"> Your browser does not support the video tag — <a href="../../assets/sim-pydantic-ai.mp4">download the recording</a>. </video>
 
 ### CrewAI
 
-<video controls muted playsinline preload="metadata" width="100%">
-  <source src="../../assets/sim-crewai.mp4" type="video/mp4">
-  Your browser does not support the video tag —
-  <a href="../../assets/sim-crewai.mp4">download the recording</a>.
-</video>
+<video controls muted playsinline preload="metadata" width="100%"> <source src="../../assets/sim-crewai.mp4" type="video/mp4"> Your browser does not support the video tag — <a href="../../assets/sim-crewai.mp4">download the recording</a>. </video>
 
 ## Where to next
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,7 +1,6 @@
 # Getting Started
 
-Your first evaluation in five minutes. No dataset, no deployment — just local
-data and a local scorer.
+Your first evaluation in five minutes. No dataset, no deployment — just local data and a local scorer.
 
 ## Install
 
@@ -9,23 +8,17 @@ data and a local scorer.
 uv add evaluatorq
 ```
 
-Prefer pip? Use `python -m pip install evaluatorq`, which installs into the
-interpreter you just named rather than whichever `pip` happens to be first on
-your `PATH`.
+Prefer pip? Use `python -m pip install evaluatorq`, which installs into the interpreter you just named rather than whichever `pip` happens to be first on your `PATH`.
 
 ## The mental model
 
 An evaluation has three parts:
 
 - **`DataPoint`** — one row of input plus its `expected_output`.
-- **`@job`** — an async function that turns a `DataPoint` into an output (your
-  model call, agent, or — here — a stand-in for one). Pass several and each
-  becomes a column in the results table.
-- **Evaluator** — a scorer that compares the output against the expectation and
-  returns pass/fail.
+- **`@job`** — an async function that turns a `DataPoint` into an output (your model call, agent, or — here — a stand-in for one). Pass several and each becomes a column in the results table.
+- **Evaluator** — a scorer that compares the output against the expectation and returns pass/fail.
 
-`evaluatorq(...)` runs every job over every datapoint in parallel and applies
-each evaluator to the results.
+`evaluatorq(...)` runs every job over every datapoint in parallel and applies each evaluator to the results.
 
 ```mermaid
 flowchart LR
@@ -40,8 +33,7 @@ flowchart LR
 
 ## A first evaluation
 
-Two versions of a support agent, scored on the same three questions. `agent-v1`
-answers from memory; `agent-v2` looks the answer up in the policy first.
+Two versions of a support agent, scored on the same three questions. `agent-v1` answers from memory; `agent-v2` looks the answer up in the policy first.
 
 ```python
 import asyncio
@@ -93,9 +85,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-This is the repository's
-[`examples/lib/basics/support_agent_eval.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/lib/basics/support_agent_eval.py) —
-the same script the README quick start uses.
+This is the repository's [`examples/lib/basics/support_agent_eval.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/lib/basics/support_agent_eval.py) — the same script the README quick start uses.
 
 Run it:
 
@@ -103,16 +93,9 @@ Run it:
 uv run support_agent_eval.py
 ```
 
-`string_contains_evaluator()` checks whether the job output contains the
-`expected_output`, so `agent-v1` scores 0.33 — it only knows about refunds —
-against `agent-v2`'s 1.00. Every job runs against every data point, so adding a
-third variant adds a column.
+`string_contains_evaluator()` checks whether the job output contains the `expected_output`, so `agent-v1` scores 0.33 — it only knows about refunds — against `agent-v2`'s 1.00. Every job runs against every data point, so adding a third variant adds a column.
 
-Because `agent-v1` fails two rows, its results contain `pass_=False`, but the
-library does not exit the process. For a CI gate, check `pass_` with
-`check_pass_failures(results)` and raise `SystemExit(1)` yourself. Swap the two
-function bodies for your own model or agent call and that same pass/fail signal
-can gate quality regressions in CI.
+Because `agent-v1` fails two rows, its results contain `pass_=False`, but the library does not exit the process. For a CI gate, check `pass_` with `check_pass_failures(results)` and raise `SystemExit(1)` yourself. Swap the two function bodies for your own model or agent call and that same pass/fail signal can gate quality regressions in CI.
 
 ## Where to next
 

--- a/docs/guides/red-teaming.md
+++ b/docs/guides/red-teaming.md
@@ -1,11 +1,8 @@
 # Red Teaming
 
-Probe an agent or model with adversarial attacks mapped to the OWASP **LLM Top
-10** and **Agentic Top 10 (ASI)** frameworks, then read off the
-resistance rate.
+Probe an agent or model with adversarial attacks mapped to the OWASP **LLM Top 10** and **Agentic Top 10 (ASI)** frameworks, then read off the resistance rate.
 
-*[ASI]: OWASP Agentic Top 10
-*[LLM01]: Prompt Injection
+*[ASI]: OWASP Agentic Top 10 *[LLM01]: Prompt Injection
 
 ```mermaid
 flowchart LR
@@ -21,20 +18,10 @@ flowchart LR
 ## Modes
 
 - **dynamic** — an LLM generates attacks; run the categories you pick.
-- **static** — replays a fixed dataset of known attacks instead of generating
-  them. Deterministic, cheap, good for CI. Runs Orq's public
-  [`orq/redteam-vulnerabilities`](https://huggingface.co/datasets/orq/redteam-vulnerabilities)
-  dataset by default; pass `dataset=` to run your own. The
-  [static dataset cookbook](../examples/redteam/02_static_dataset.md) shows the
-  reproducible version end to end.
-- **hybrid** — static seeds plus dynamic expansion; see the
-  [hybrid mode cookbook](../examples/redteam/03_hybrid_mode.md) when you want
-  both known attacks and generated coverage.
+- **static** — replays a fixed dataset of known attacks instead of generating them. Deterministic, cheap, good for CI. Runs Orq's public [`orq/redteam-vulnerabilities`](https://huggingface.co/datasets/orq/redteam-vulnerabilities) dataset by default; pass `dataset=` to run your own. The [static dataset cookbook](../examples/redteam/02_static_dataset.md) shows the reproducible version end to end.
+- **hybrid** — static seeds plus dynamic expansion; see the [hybrid mode cookbook](../examples/redteam/03_hybrid_mode.md) when you want both known attacks and generated coverage.
 
-Replay is not a separate mode. It re-runs a previous run's exact attacks against
-the target you give it now, so a before/after comparison changes the agent while
-holding the attack set fixed. See
-[Replay a previous run](#replay-a-previous-run).
+Replay is not a separate mode. It re-runs a previous run's exact attacks against the target you give it now, so a before/after comparison changes the agent while holding the attack set fixed. See [Replay a previous run](#replay-a-previous-run).
 
 ```python
 # static mode replays Orq's public attack dataset by default
@@ -54,9 +41,7 @@ report = await red_team(target=target, mode="static", dataset="hf:my-org/my-atta
 
 ### Fastest first run
 
-If you prefer the CLI, start with a small static run against a test agent. Static
-mode uses the built-in attack dataset, so it is a predictable way to verify your
-setup before exploring dynamic or hybrid runs.
+If you prefer the CLI, start with a small static run against a test agent. Static mode uses the built-in attack dataset, so it is a predictable way to verify your setup before exploring dynamic or hybrid runs.
 
 ```bash
 export ORQ_API_KEY=...
@@ -72,10 +57,7 @@ eq redteam run \
   --yes
 ```
 
-The command writes a JSON report and exits non-zero if no attacks receive a
-verdict or evaluation coverage falls below the configured floor. See the
-[CLI reference](../cli-reference/redteam.md) for the other output formats and
-run options.
+The command writes a JSON report and exits non-zero if no attacks receive a verdict or evaluation coverage falls below the configured floor. See the [CLI reference](../cli-reference/redteam.md) for the other output formats and run options.
 
 ### Choose a cookbook
 
@@ -204,14 +186,9 @@ run options.
     ```
 
     !!! note "Model names and routing"
-        The model string is passed through to whichever provider you point at —
-        straight to OpenAI by default, or through the Orq router if you prefix it
-        with `openai/...` (which then uses `ORQ_API_KEY`). Everything else —
-        categories, modes, the report — is identical to the Orq agent path.
+        The model string is passed through to whichever provider you point at — straight to OpenAI by default, or through the Orq router if you prefix it with `openai/...` (which then uses `ORQ_API_KEY`). Everything else — categories, modes, the report — is identical to the Orq agent path.
 
-The two tabs above are the two most common targets. For the full set — including
-`OrqResponsesTarget` (the Responses API through the Orq router, with per-call
-config) — and for writing your own, see [Targets](targets.md).
+The two tabs above are the two most common targets. For the full set — including `OrqResponsesTarget` (the Responses API through the Orq router, with per-call config) — and for writing your own, see [Targets](targets.md).
 
 !!! note "`generate_strategies` and the CLI"
     Both examples pass `generate_strategies=False` to skip LLM-authored attack
@@ -222,12 +199,7 @@ config) — and for writing your own, see [Targets](targets.md).
 
 ## Coverage
 
-19 framework categories map onto 18 vulnerabilities. Every vulnerability has a
-judge written for it. Categories with a **curated strategy count** ship
-hand-written attack strategies; the rest are marked *generated* — in dynamic and
-hybrid mode the strategy planner writes strategies for them per run, against the
-target's actual tools, memory and system prompt. Pass
-`generate_strategies=False` to run curated strategies only.
+19 framework categories map onto 18 vulnerabilities. Every vulnerability has a judge written for it. Categories with a **curated strategy count** ship hand-written attack strategies; the rest are marked *generated* — in dynamic and hybrid mode the strategy planner writes strategies for them per run, against the target's actual tools, memory and system prompt. Pass `generate_strategies=False` to run curated strategies only.
 
 | Category | Vulnerability | Curated strategies | Judge |
 |---|---|---|---|
@@ -251,73 +223,36 @@ target's actual tools, memory and system prompt. Pass
 | `LLM08` | Vector and Embedding Weaknesses | generated | ✅ |
 | `LLM09` | Misinformation | 5 | ✅ |
 
-45 curated strategies in total, delivered through 16 delivery methods
-(`direct-request`, `tool-response`, `role-play`, `crescendo`, `many-shot`,
-`base64`, `leetspeak`, `multilingual`, `refusal-suppression`, and more). Add
-your own vulnerabilities, strategies and judges — see
-[Custom Evaluators & Frameworks](../custom-evaluators-and-frameworks.md).
+45 curated strategies in total, delivered through 16 delivery methods (`direct-request`, `tool-response`, `role-play`, `crescendo`, `many-shot`, `base64`, `leetspeak`, `multilingual`, `refusal-suppression`, and more). Add your own vulnerabilities, strategies and judges — see [Custom Evaluators & Frameworks](../custom-evaluators-and-frameworks.md).
 
 ## Inspect results in Python
 
-For the same numbers rendered as a browsable report, see
-[Reading a run in the dashboard](#reading-a-run-in-the-dashboard) below.
+For the same numbers rendered as a browsable report, see [Reading a run in the dashboard](#reading-a-run-in-the-dashboard) below.
 
 The report fields most users need are:
 
-- `report.summary.resistance_rate`: the fraction of evaluated attacks resisted;
-  higher is better. `None` means no attack received a verdict.
-- `report.summary.evaluated_attacks` and `total_attacks`: check both before
-  trusting a rate. `evaluation_coverage` and `coverage_below_minimum` expose the
-  same check for CI.
-- `report.results`: the per-attack evidence. `result.vulnerable is None` means
-  the attack was not evaluated, not that it was resisted.
+- `report.summary.resistance_rate`: the fraction of evaluated attacks resisted; higher is better. `None` means no attack received a verdict.
+- `report.summary.evaluated_attacks` and `total_attacks`: check both before trusting a rate. `evaluation_coverage` and `coverage_below_minimum` expose the same check for CI.
+- `report.results`: the per-attack evidence. `result.vulnerable is None` means the attack was not evaluated, not that it was resisted.
 - `report.summary.by_vulnerability`: the pre-aggregated vulnerability breakdown.
 
-A datapoint that fails before its strategy can create an attack is not counted as
-an attack result. Its structured `RunError` is stored in `report.errors`, and
-`report.summary.pre_execution_errors` records how many rows failed at that stage;
-the dashboard surfaces that count separately from executed attacks.
+A datapoint that fails before its strategy can create an attack is not counted as an attack result. Its structured `RunError` is stored in `report.errors`, and `report.summary.pre_execution_errors` records how many rows failed at that stage; the dashboard surfaces that count separately from executed attacks.
 
-When a judge fails to return a verdict, the reason is captured on
-`result.evaluation_error` (a `RunError` with a `code` like `timeout`, `parse`,
-`api_connection`, `api_status`, or `unknown`). It is deliberately separate from
-`result.error`: `error` means the attack itself never ran, `evaluation_error`
-means the attack ran and the transcript exists but no judge could score it. Both
-roll up into `report.summary.errors_by_type`, where judge failures appear under
-`evaluation/<code>` keys (execution failures use the bare code) — so a
-systematically blocked judge shows up as one named cause (`evaluation/api_status:
-40 attacks`) instead of vanishing into forty individual results.
+When a judge fails to return a verdict, the reason is captured on `result.evaluation_error` (a `RunError` with a `code` like `timeout`, `parse`, `api_connection`, `api_status`, or `unknown`). It is deliberately separate from `result.error`: `error` means the attack itself never ran, `evaluation_error` means the attack ran and the transcript exists but no judge could score it. Both roll up into `report.summary.errors_by_type`, where judge failures appear under `evaluation/<code>` keys (execution failures use the bare code) — so a systematically blocked judge shows up as one named cause (`evaluation/api_status: 40 attacks`) instead of vanishing into forty individual results.
 
 ## Replay a previous run
 
-A saved run keeps its *cases*: the attacks it ran, not only the scores it gave
-them. Replay re-runs those exact cases, in the same order and with the same turn
-budget, against whatever target you point it at now. Dynamic and hybrid runs
-generate fresh attacks every time, so re-running one after a fix changes the
-agent *and* the exam, and a resistance rate that moved cannot tell you which one
-moved it. Replay holds the exam fixed and varies only the agent.
+A saved run keeps its *cases*: the attacks it ran, not only the scores it gave them. Replay re-runs those exact cases, in the same order and with the same turn budget, against whatever target you point it at now. Dynamic and hybrid runs generate fresh attacks every time, so re-running one after a fix changes the agent *and* the exam, and a resistance rate that moved cannot tell you which one moved it. Replay holds the exam fixed and varies only the agent.
 
 ### What is replayable
 
-Cases travel with the auto-saved run in the run store, the directory evaluatorq
-writes saved runs to. Replay needs a run that was written there. `save='none'`
-(`--save none`) writes nothing at all: no report, no run-store entry, and no row
-in [`eq redteam runs`](../cli-reference/redteam.md#eq-redteam-runs). A
-`--save detail` artifacts directory is not enough either; the
-`03_summary_report.json` it writes carries scores, not cases.
+Cases travel with the auto-saved run in the run store, the directory evaluatorq writes saved runs to. Replay needs a run that was written there. `save='none'` (`--save none`) writes nothing at all: no report, no run-store entry, and no row in [`eq redteam runs`](../cli-reference/redteam.md#eq-redteam-runs). A `--save detail` artifacts directory is not enough either; the `03_summary_report.json` it writes carries scores, not cases.
 
-`eq redteam runs` lists every run whether or not it carries cases, so a row in
-that listing is not a replayability check. Runs saved before replay support
-existed have no cases and are refused with that reason rather than replayed as an
-empty set. So are runs stamped with a replay format newer than the installed
-version understands; upgrade evaluatorq to read those.
+`eq redteam runs` lists every run whether or not it carries cases, so a row in that listing is not a replayability check. Runs saved before replay support existed have no cases and are refused with that reason rather than replayed as an empty set. So are runs stamped with a replay format newer than the installed version understands; upgrade evaluatorq to read those.
 
 ### Create a run to replay
 
-If you have not saved a red-team run yet, make one first. On a machine with no
-saved runs, `previous_run="latest"` raises
-`ReplayError: No saved red team runs found in <runs directory> — nothing to replay.`
-Start with one small static run:
+If you have not saved a red-team run yet, make one first. On a machine with no saved runs, `previous_run="latest"` raises `ReplayError: No saved red team runs found in <runs directory> — nothing to replay.` Start with one small static run:
 
 ```python
 import asyncio
@@ -374,13 +309,9 @@ rate = report.summary.resistance_rate
 print(report.pipeline.value, f"{rate:.0%}" if rate is not None else "no verdict")
 ```
 
-On the CLI the same thing is `--from-run`, taking the same reference forms:
-see the [`eq redteam run` flag table](../cli-reference/redteam.md#eq-redteam-run).
+On the CLI the same thing is `--from-run`, taking the same reference forms: see the [`eq redteam run` flag table](../cli-reference/redteam.md#eq-redteam-run).
 
-Compare the two numbers yourself — there is no built-in report diff. `eq redteam
-runs` puts both rows side by side, and `merge_reports()` is not the tool for it:
-it concatenates results into one blended summary, which hides the delta you are
-looking for.
+Compare the two numbers yourself — there is no built-in report diff. `eq redteam runs` puts both rows side by side, and `merge_reports()` is not the tool for it: it concatenates results into one blended summary, which hides the delta you are looking for.
 
 !!! warning "`eq redteam runs` reports the inverse metric"
     Its rate column (and the `vulnerability_rate` field in `--json`) reports the
@@ -388,19 +319,11 @@ looking for.
     Gating a build on it without inverting it fails exactly when the agent is
     safest.
 
-**The mode comes back with the cases.** The run above prints `static` without
-`mode=` ever being passed, because that is what the stored run was. Replay
-restores `max_turns` and `attacker_instructions` too, so a run made with a
-10-turn budget is not replayed at the 5-turn default. Passing either one
-explicitly still wins, and that is the supported way to make a replay differ from
-its original.
+**The mode comes back with the cases.** The run above prints `static` without `mode=` ever being passed, because that is what the stored run was. Replay restores `max_turns` and `attacker_instructions` too, so a run made with a 10-turn budget is not replayed at the 5-turn default. Passing either one explicitly still wins, and that is the supported way to make a replay differ from its original.
 
 ### Keep the attack set fixed
 
-Replay rejects any argument that selects *which* attacks to run, rather than
-silently ignoring it — the stored run already made that choice, so
-`red_team(target=..., previous_run="latest", categories=["ASI01"])` raises
-`ValueError`. The rejected arguments are:
+Replay rejects any argument that selects *which* attacks to run, rather than silently ignoring it — the stored run already made that choice, so `red_team(target=..., previous_run="latest", categories=["ASI01"])` raises `ValueError`. The rejected arguments are:
 
 - `mode`
 - `dataset`
@@ -412,23 +335,13 @@ silently ignoring it — the stored run already made that choice, so
 - `max_dynamic_datapoints`
 - `max_static_datapoints`
 
-They are rejected by name rather than by value, so `mode="dynamic"` raises even
-though it matches the mode a run would use by default. Only the target, the
-models, `max_turns` and `attacker_instructions` may differ.
+They are rejected by name rather than by value, so `mode="dynamic"` raises even though it matches the mode a run would use by default. Only the target, the models, `max_turns` and `attacker_instructions` may differ.
 
 ### Use replay in CI
 
-To replay in CI, persist the run store between builds and point `EVALUATORQ_DIR`
-at its root. CI runners start with an empty filesystem, so a fresh checkout has
-nothing to replay and `--from-run latest` fails with the `nothing to replay`
-error. Cache the directory, download it as a build artifact, or commit the run
-JSON — and set `EVALUATORQ_DIR` to the store root (`.evaluatorq/` in the working
-directory by default), **not** to the `runs/` subdirectory inside it. Nothing
-restores it for you.
+To replay in CI, persist the run store between builds and point `EVALUATORQ_DIR` at its root. CI runners start with an empty filesystem, so a fresh checkout has nothing to replay and `--from-run latest` fails with the `nothing to replay` error. Cache the directory, download it as a build artifact, or commit the run JSON — and set `EVALUATORQ_DIR` to the store root (`.evaluatorq/` in the working directory by default), **not** to the `runs/` subdirectory inside it. Nothing restores it for you.
 
-To gate a build on the replayed rate, combine replay with the check in
-[In CI](#in-ci). `eq redteam run` exits `1` when a run cannot be scored, but it
-has **no** resistance-rate threshold, so the rate comparison is Python:
+To gate a build on the replayed rate, combine replay with the check in [In CI](#in-ci). `eq redteam run` exits `1` when a run cannot be scored, but it has **no** resistance-rate threshold, so the rate comparison is Python:
 
 ```python
 import asyncio
@@ -456,30 +369,17 @@ print(f"resistance {rate:.0%} against {summary.total_attacks} replayed attacks")
 sys.exit(0 if rate >= floor else f"resistance {rate:.0%} below the {floor:.0%} gate")
 ```
 
-Set `REDTEAM_MIN_RESISTANCE` to the rate the previous run scored and the step
-becomes a regression gate rather than an absolute floor.
+Set `REDTEAM_MIN_RESISTANCE` to the rate the previous run scored and the step becomes a regression gate rather than an absolute floor.
 
-The same replay works for simulations: `simulate(previous_run=...)` in Python, or
-`eq sim simulate --from-run` on the CLI — see the
-[`eq sim simulate` flag table](../cli-reference/simulation.md#eq-sim-simulate).
-Hand a simulation run to red-team replay and it tells you which command you
-wanted instead.
+The same replay works for simulations: `simulate(previous_run=...)` in Python, or `eq sim simulate --from-run` on the CLI — see the [`eq sim simulate` flag table](../cli-reference/simulation.md#eq-sim-simulate). Hand a simulation run to red-team replay and it tells you which command you wanted instead.
 
 ## What a run costs
 
-`report.summary.token_usage_total` covers usage recorded for attack generation,
-the target, and the judge, plus post-processing spend (recommendations and the
-executive summary — see [below](#what-the-totals-do-not-include)) once that runs.
-It includes `calls` and `priced_calls` alongside token counts and the dollar
-figure. If `priced_calls < calls`, some calls reported usage without a provider
-price, so the displayed cost is a lower bound. Use the calculator below to
-include the fixed setup calls in a planning estimate.
+`report.summary.token_usage_total` covers usage recorded for attack generation, the target, and the judge, plus post-processing spend (recommendations and the executive summary — see [below](#what-the-totals-do-not-include)) once that runs. It includes `calls` and `priced_calls` alongside token counts and the dollar figure. If `priced_calls < calls`, some calls reported usage without a provider price, so the displayed cost is a lower bound. Use the calculator below to include the fixed setup calls in a planning estimate.
 
 ### Ballpark the cost
 
-Three numbers describe a run: how many setup calls it makes before attacking,
-how many attacks it runs, and how long each attack is. Everything else is fixed
-by the pipeline or by the price tier you run at.
+Three numbers describe a run: how many setup calls it makes before attacking, how many attacks it runs, and how long each attack is. Everything else is fixed by the pipeline or by the price tier you run at.
 
 <form class="cost-calculator" data-cost-calculator>
   <div class="cost-calculator__grid">
@@ -524,23 +424,11 @@ by the pipeline or by the price tier you run at.
   </div>
 </form>
 
-Call count is **setup calls + attacks × (turns × 2 + 1)**: each turn is one
-adversarial generation plus one target call, and the judge runs once after the
-turn loop, not per turn.
+Call count is **setup calls + attacks × (turns × 2 + 1)**: each turn is one adversarial generation plus one target call, and the judge runs once after the turn loop, not per turn.
 
-**One attack is one strategy against one vulnerability**, not one category — a
-category contributes several. The count for a run is the sum, over each selected
-category, of the registry strategies that apply to the target plus
-`generated_strategy_count` (default 2), then capped by `max_per_category` and
-`max_dynamic_datapoints`. A full dynamic sweep of one target therefore tops out
-at **65**: 45 registry strategies across 10 categories, plus 2 generated each.
-Capability filtering only removes strategies, so 65 is a ceiling; multiple
-targets multiply it. The run plan shown before datapoint generation carries the
-exact count, so you never have to guess for a run you are about to start.
+**One attack is one strategy against one vulnerability**, not one category — a category contributes several. The count for a run is the sum, over each selected category, of the registry strategies that apply to the target plus `generated_strategy_count` (default 2), then capped by `max_per_category` and `max_dynamic_datapoints`. A full dynamic sweep of one target therefore tops out at **65**: 45 registry strategies across 10 categories, plus 2 generated each. Capability filtering only removes strategies, so 65 is a ceiling; multiple targets multiply it. The run plan shown before datapoint generation carries the exact count, so you never have to guess for a run you are about to start.
 
-**Setup calls** are the ones that happen before and after the attack loop. The
-default of 7 is a dynamic run against one tool-bearing target with the standard
-report options on:
+**Setup calls** are the ones that happen before and after the attack loop. The default of 7 is a dynamic run against one tool-bearing target with the standard report options on:
 
 | Stage | Calls |
 |---|---|
@@ -550,80 +438,35 @@ report options on:
 | Executive summary | 1, best-effort |
 | Recommendations | 1 per *selected top* focus area — up to `max_areas`, default 5 |
 
-Set it to **0** for static and replay runs: a replay selects nothing, so
-capability classification is skipped entirely. The CLI quickstart above also
-disables strategy generation, recommendations, and the executive summary, so its
-baseline is 0 too. Classification is skipped whenever no LLM client or
-credentials resolve.
+Set it to **0** for static and replay runs: a replay selects nothing, so capability classification is skipped entirely. The CLI quickstart above also disables strategy generation, recommendations, and the executive summary, so its baseline is 0 too. Classification is skipped whenever no LLM client or credentials resolve.
 
-The token model behind the dollar figure is a ballpark, not a knob — these
-values are fixed:
+The token model behind the dollar figure is a ballpark, not a knob — these values are fixed:
 
-- **1,000 tokens per turn, per side.** Each turn call emits one block and the
-  transcript grows by one block, so input cost is quadratic in turns — which is
-  why long multi-turn attacks cost more than the call count suggests.
-- **90% cache hit rate** on the attack transcript, billed at **0.1× the base
-  input price** — the standard cached-read rate for the models listed. A run
-  that never repeats a prefix pays more than this estimate.
-- **One judge call per attack**, reading the finished transcript and emitting
-  ~200 tokens. A jury multiplies that by panel size × repetitions; the judges do
-  not extend the transcript for each other, so five judges cost five reads of
-  the same transcript, not five compounding ones.
-- **Setup calls are priced at the full input rate**, one block each way. They
-  share no prefix with the attack transcript, so no cache discount applies.
-- **Round price tiers, not named models.** Frontier is the flagship tier
-  (Claude Opus, GPT-5.6-terra); mid-tier is the workhorse most runs use; cheap
-  is the small-and-fast tier (Gemini Flash, GPT-5.6-luna). A named-model list
-  goes stale on every provider release, and a planning estimate does not need
-  the third significant figure — pick **Custom** when you need an exact one.
-  Regional deployments run above these rates: Orq's EU entries carry roughly a
-  10% uplift. At runtime evaluatorq prices calls from the live Orq `/v2/models`
-  catalogue, so reported costs use your actual model and region, not this
-  estimate.
+- **1,000 tokens per turn, per side.** Each turn call emits one block and the transcript grows by one block, so input cost is quadratic in turns — which is why long multi-turn attacks cost more than the call count suggests.
+- **90% cache hit rate** on the attack transcript, billed at **0.1× the base input price** — the standard cached-read rate for the models listed. A run that never repeats a prefix pays more than this estimate.
+- **One judge call per attack**, reading the finished transcript and emitting ~200 tokens. A jury multiplies that by panel size × repetitions; the judges do not extend the transcript for each other, so five judges cost five reads of the same transcript, not five compounding ones.
+- **Setup calls are priced at the full input rate**, one block each way. They share no prefix with the attack transcript, so no cache discount applies.
+- **Round price tiers, not named models.** Frontier is the flagship tier (Claude Opus, GPT-5.6-terra); mid-tier is the workhorse most runs use; cheap is the small-and-fast tier (Gemini Flash, GPT-5.6-luna). A named-model list goes stale on every provider release, and a planning estimate does not need the third significant figure — pick **Custom** when you need an exact one. Regional deployments run above these rates: Orq's EU entries carry roughly a 10% uplift. At runtime evaluatorq prices calls from the live Orq `/v2/models` catalogue, so reported costs use your actual model and region, not this estimate.
 
-Content-filter retries on the attacker turn are real billed calls and are not in
-this estimate. Actual spend varies with prompt and completion length.
+Content-filter retries on the attacker turn are real billed calls and are not in this estimate. Actual spend varies with prompt and completion length.
 
-If you want separate attacker and evaluator model settings rather than one
-default model, see the [`11_redteam_config.py` cookbook](../examples/redteam/11_redteam_config.md).
+If you want separate attacker and evaluator model settings rather than one default model, see the [`11_redteam_config.py` cookbook](../examples/redteam/11_redteam_config.md).
 
 ### What the totals do not include
 
-`token_usage_total` covers the attack path plus post-processing spend —
-`report.summary.post_processing_token_usage` (recommendation generation,
-including trace condensing, plus the executive-summary narrative) is folded in
-explicitly once both steps have run, been skipped, or failed. What still lands
-outside it:
+`token_usage_total` covers the attack path plus post-processing spend — `report.summary.post_processing_token_usage` (recommendation generation, including trace condensing, plus the executive-summary narrative) is folded in explicitly once both steps have run, been skipped, or failed. What still lands outside it:
 
-- Capability classification (resource inference, tool classification) and
-  blackbox target classification.
+- Capability classification (resource inference, tool classification) and blackbox target classification.
 - Strategy and objective generation.
 - Target-side usage, when the backend does not report it back.
 
-A structured-output call's own fallback ladder is no longer among them. When a
-provider rejects the strict schema, the helper degrades through a non-strict
-schema, a forced tool call and a bare `json_object` request — up to four billed
-calls for one answer. Every rung that reached the provider is now counted in that
-call's usage, not just the rung that answered, so a call that degraded twice is
-priced as three calls rather than one. The recommendations and trace-condensing
-calls run after the attack-only totals are computed, so their usage is recorded
-separately (`report.summary.post_processing_token_usage`) and then added into
-`token_usage_total` — it also still appears in the run log (`Red-team
-recommendations: N tokens over M LLM call(s), $X`) for visibility during the run,
-before the report is finalized.
+A structured-output call's own fallback ladder is no longer among them. When a provider rejects the strict schema, the helper degrades through a non-strict schema, a forced tool call and a bare `json_object` request — up to four billed calls for one answer. Every rung that reached the provider is now counted in that call's usage, not just the rung that answered, so a call that degraded twice is priced as three calls rather than one. The recommendations and trace-condensing calls run after the attack-only totals are computed, so their usage is recorded separately (`report.summary.post_processing_token_usage`) and then added into `token_usage_total` — it also still appears in the run log (`Red-team recommendations: N tokens over M LLM call(s), $X`) for visibility during the run, before the report is finalized.
 
-If `priced_calls < calls` in the summary, some counted calls had no provider
-price either, so the dollar figure is a lower bound on a subset. The same is true
-within a single structured-output call: a rung whose usage block the provider did
-not report is counted as one unpriced call — never as zero — and logged, so the
-call count stays honest even when the tokens behind it are unknown.
+If `priced_calls < calls` in the summary, some counted calls had no provider price either, so the dollar figure is a lower bound on a subset. The same is true within a single structured-output call: a rung whose usage block the provider did not report is counted as one unpriced call — never as zero — and logged, so the call count stays honest even when the tokens behind it are unknown.
 
 ## In CI
 
-For a fast gate, run a small fixed set of attacks and assert a minimum
-resistance rate, failing the build if the target regresses. To hold the attacks
-identical across builds rather than merely fixed by a dataset, gate on a
-[replay](#use-replay-in-ci) instead.
+For a fast gate, run a small fixed set of attacks and assert a minimum resistance rate, failing the build if the target regresses. To hold the attacks identical across builds rather than merely fixed by a dataset, gate on a [replay](#use-replay-in-ci) instead.
 
 ```python
 report = await red_team(
@@ -637,9 +480,7 @@ assert rate is not None, "no attack could be evaluated — the target was not te
 assert rate >= 0.9, f"resistance {rate:.0%} below the 0.9 gate"
 ```
 
-The `is not None` check matters: a run where every judge call failed has no
-honest rate. `eq redteam run` exits `1` when attacks ran but none could be
-scored (`report.summary.no_verdict`).
+The `is not None` check matters: a run where every judge call failed has no honest rate. `eq redteam run` exits `1` when attacks ran but none could be scored (`report.summary.no_verdict`).
 
 !!! warning "Gate on coverage as well as resistance"
     `EvaluatorConfig.min_evaluation_coverage` defaults to **0.8**. The CLI exits
@@ -648,17 +489,11 @@ scored (`report.summary.no_verdict`).
     `summary.no_verdict` / `summary.coverage_below_minimum` and
     `summary.resistance_rate` before accepting the run.
 
-The runnable smoke example
-([`08_quick_smoke_test.py`](../examples/redteam/08_quick_smoke_test.md)) wraps
-this same pattern; the [report inspection cookbook](../examples/redteam/07_report_inspection.md)
-shows how to consume the resulting JSON in Python.
+The runnable smoke example ([`08_quick_smoke_test.py`](../examples/redteam/08_quick_smoke_test.md)) wraps this same pattern; the [report inspection cookbook](../examples/redteam/07_report_inspection.md) shows how to consume the resulting JSON in Python.
 
 ## Reading a run in the dashboard
 
-Runs are saved to `.evaluatorq/runs/<name>_<timestamp>.json` by default
-(`--save none` skips the file; `--save detail` also keeps per-stage artifacts
-in `--artifacts-dir`), and `eq dashboard` browses those files locally — no
-external service:
+Runs are saved to `.evaluatorq/runs/<name>_<timestamp>.json` by default (`--save none` skips the file; `--save detail` also keeps per-stage artifacts in `--artifacts-dir`), and `eq dashboard` browses those files locally — no external service:
 
 ```bash
 uv add "evaluatorq[dashboard]"
@@ -667,8 +502,7 @@ eq dashboard                                              # browse every saved r
 eq dashboard .evaluatorq/runs/red-team_<timestamp>.json   # deep-link to one report
 ```
 
-Land on the cross-surface overview, pick the run from **Red Team**, then work
-down the report tabs from headline to evidence:
+Land on the cross-surface overview, pick the run from **Red Team**, then work down the report tabs from headline to evidence:
 
 | Tab | What it answers |
 |---|---|
@@ -680,22 +514,13 @@ down the report tabs from headline to evidence:
 | **Usage** | Tokens and API calls per agent |
 | **Config** | What was tested — and what was *not* |
 
-Two traps worth knowing before you read a number: the resistance rate covers
-only the categories this run attacked (check **Config** for the skipped ones),
-and it is measured over *evaluated* attacks, so failed judge calls drop out of
-the denominator rather than counting as resisted.
+Two traps worth knowing before you read a number: the resistance rate covers only the categories this run attacked (check **Config** for the skipped ones), and it is measured over *evaluated* attacks, so failed judge calls drop out of the denominator rather than counting as resisted.
 
-The tab-by-tab walkthrough, with screenshots, lives in the Dashboard reference:
-[Reading a red-team run](../dashboard.md#reading-a-red-team-run). See also
-[filters](../dashboard.md#filters), [trace links](../dashboard.md#orq-trace-links)
-and [downloads](../dashboard.md#downloads).
+The tab-by-tab walkthrough, with screenshots, lives in the Dashboard reference: [Reading a red-team run](../dashboard.md#reading-a-red-team-run). See also [filters](../dashboard.md#filters), [trace links](../dashboard.md#orq-trace-links) and [downloads](../dashboard.md#downloads).
 
 ## External agent frameworks
 
-`red_team()` accepts any `AgentTarget`, and each supported framework ships a
-wrapper that adapts its agent into one — so you red-team an agent built in your
-framework of choice without rewriting it. Install the matching extra, wrap the
-agent, and pass it straight to `red_team()`:
+`red_team()` accepts any `AgentTarget`, and each supported framework ships a wrapper that adapts its agent into one — so you red-team an agent built in your framework of choice without rewriting it. Install the matching extra, wrap the agent, and pass it straight to `red_team()`:
 
 ```python
 from langchain_openai import ChatOpenAI
@@ -718,19 +543,11 @@ report = await red_team(
 | Pydantic AI | `PydanticAITarget` | `evaluatorq[pydantic-ai]` | [`19_pydantic_ai_target.py`](../examples/redteam/19_pydantic_ai_target.md) |
 | CrewAI | `CrewAITarget` | `evaluatorq[crewai]` | [`20_crewai_target.py`](../examples/redteam/20_crewai_target.md) |
 
-Nothing in that list fits? Any `AgentTarget` works, and
-[Targets](targets.md#writing-your-own-target) walks through writing one —
-what `respond()` and `new()` must do, why declaring tools in
-`get_agent_context()` decides which attack strategies fire, and how to surface
-errors so a dead target is not scored as resistant.
+Nothing in that list fits? Any `AgentTarget` works, and [Targets](targets.md#writing-your-own-target) walks through writing one — what `respond()` and `new()` must do, why declaring tools in `get_agent_context()` decides which attack strategies fire, and how to surface errors so a dead target is not scored as resistant.
 
 ### Demo runs
 
-Live runs of the four examples above (dynamic mode, 3 attacks each, routed through
-the Orq AI Router) with real attack transcripts and judge verdicts are captured in
-`examples/redteam/_sample_output/RES-931-external-framework-runs.md`. The headline:
-LangGraph, OpenAI Agents, and Pydantic AI each execute an indirect prompt injection
-(goal hijack via tool output); CrewAI resists all three.
+Live runs of the four examples above (dynamic mode, 3 attacks each, routed through the Orq AI Router) with real attack transcripts and judge verdicts are captured in `examples/redteam/_sample_output/RES-931-external-framework-runs.md`. The headline: LangGraph, OpenAI Agents, and Pydantic AI each execute an indirect prompt injection (goal hijack via tool output); CrewAI resists all three.
 
 Screen recordings of each run:
 
@@ -768,8 +585,7 @@ Screen recordings of each run:
 
 ### Known limitations
 
-Verified edge cases and framework-specific quirks to know before you rely on
-external-framework targets:
+Verified edge cases and framework-specific quirks to know before you rely on external-framework targets:
 
 | Area | Behavior | Applies to |
 |---|---|---|

--- a/docs/guides/targets.md
+++ b/docs/guides/targets.md
@@ -1,19 +1,13 @@
 # Targets: the system under test
 
-A **target** is the thing evaluatorq attacks or converses with. `red_team()` and
-`simulate()` both take one, and everything else — attack generation, judging,
-reports — is identical whichever kind you pick.
+A **target** is the thing evaluatorq attacks or converses with. `red_team()` and `simulate()` both take one, and everything else — attack generation, judging, reports — is identical whichever kind you pick.
 
 There are two ways to name a target:
 
-- a **string identifier** (`"agent:<key>"`, `"deployment:<key>"`), which
-  evaluatorq resolves against the Orq platform, and
-- an **`AgentTarget` object**, which you construct in Python and hand over
-  directly. Built-in ones ship with the package; the framework integrations wrap
-  LangGraph/CrewAI/etc. agents into one; and you can write your own.
+- a **string identifier** (`"agent:<key>"`, `"deployment:<key>"`), which evaluatorq resolves against the Orq platform, and
+- an **`AgentTarget` object**, which you construct in Python and hand over directly. Built-in ones ship with the package; the framework integrations wrap LangGraph/CrewAI/etc. agents into one; and you can write your own.
 
-The CLI only accepts the string form — an object target is constructed in Python,
-so `eq redteam run --target` resolves identifiers only.
+The CLI only accepts the string form — an object target is constructed in Python, so `eq redteam run --target` resolves identifiers only.
 
 ## Choosing a kind
 
@@ -26,17 +20,11 @@ so `eq redteam run --target` resolves identifiers only.
 | `LangGraphTarget`, `OpenAIAgentTarget`, `PydanticAITarget`, `CrewAITarget` | Your agent is built in that framework | Whatever the wrapper can extract |
 | Your own `AgentTarget` subclass | Anything else — an HTTP endpoint, a local pipeline, a bespoke tool loop | Whatever your `get_agent_context()` returns |
 
-Context discovery matters more than it looks. Attack strategies are selected and
-written against the target's declared tools, memory and system prompt: a target
-that reports no tools never gets a tool-misuse attack, because those strategies
-are gated on `requires_tools=True`. See
-[Writing your own target](#writing-your-own-target) below.
+Context discovery matters more than it looks. Attack strategies are selected and written against the target's declared tools, memory and system prompt: a target that reports no tools never gets a tool-misuse attack, because those strategies are gated on `requires_tools=True`. See [Writing your own target](#writing-your-own-target) below.
 
 ## The quick path: `OpenAIModelTarget`
 
-If you are pointing at an OpenAI (or OpenAI-compatible) chat-completions
-endpoint, there is nothing to write. `OpenAIModelTarget` is a complete
-`AgentTarget`: give it a model and a system prompt and pass it to `red_team()`.
+If you are pointing at an OpenAI (or OpenAI-compatible) chat-completions endpoint, there is nothing to write. `OpenAIModelTarget` is a complete `AgentTarget`: give it a model and a system prompt and pass it to `red_team()`.
 
 ```python
 import asyncio
@@ -58,26 +46,16 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-It builds its own client from the environment (`ORQ_API_KEY` first, then
-`OPENAI_API_KEY`) unless you pass `client=`, it is stateless, and it replays the
-full transcript on every call — including assistant `tool_calls` and `tool`
-results, via `Message.to_chat_completion()`.
+It builds its own client from the environment (`ORQ_API_KEY` first, then `OPENAI_API_KEY`) unless you pass `client=`, it is stateless, and it replays the full transcript on every call — including assistant `tool_calls` and `tool` results, via `Message.to_chat_completion()`.
 
-What it does **not** do: it reports only its model id as context (no tools, no
-memory), so the tool-misuse and memory-poisoning strategy families never fire
-against it. When you need those, declare tools from a custom target.
+What it does **not** do: it reports only its model id as context (no tools, no memory), so the tool-misuse and memory-poisoning strategy families never fire against it. When you need those, declare tools from a custom target.
 
 !!! note "Retries belong to the caller"
-    `OpenAIModelTarget` disables the OpenAI SDK's own retry budget — on a client
-    it builds *and* on one you inject. `call_target_with_retry` is the single
-    retry owner for target calls, and stacking the two multiplies attempts. The
-    same rule applies to a target you write yourself.
+    `OpenAIModelTarget` disables the OpenAI SDK's own retry budget — on a client it builds *and* on one you inject. `call_target_with_retry` is the single retry owner for target calls, and stacking the two multiplies attempts. The same rule applies to a target you write yourself.
 
 ## `OrqResponsesTarget`
 
-`OrqResponsesTarget` wraps the Orq **Responses** API (`/v3/router/responses`) as
-an `AgentTarget`. It is what an `agent:<key>` red-team run uses under the hood to
-execute turns, and it is exported so you can use it directly:
+`OrqResponsesTarget` wraps the Orq **Responses** API (`/v3/router/responses`) as an `AgentTarget`. It is what an `agent:<key>` red-team run uses under the hood to execute turns, and it is exported so you can use it directly:
 
 ```python
 import asyncio
@@ -107,28 +85,17 @@ async def main():
 asyncio.run(main())
 ```
 
-It is also importable from `evaluatorq.openresponses` and
-`evaluatorq.simulation`.
+It is also importable from `evaluatorq.openresponses` and `evaluatorq.simulation`.
 
 ### When to choose it
 
-- **Over `OpenAIModelTarget`** — when you want the Responses endpoint rather than
-  chat completions: a `reasoning` block, Orq router threading, a server-side
-  memory scope, and Orq trace ids returned on the response (`trace_id` /
-  `span_id`, which the dashboard deep-links).
-- **Over `"agent:<key>"`** — when you want to pin the exact call parameters
-  yourself, or when the thing you are testing is a model plus instructions rather
-  than a deployed agent. The string form discovers the agent's real tools, memory
-  stores and knowledge bases from the platform; `OrqResponsesTarget` describes
-  only what you gave it.
-- **Under a hosted agent** — pass `model="agent/<key>"` with `require_orq=True`
-  and the router invokes the hosted agent, applying its server-side tools and
-  memory. That is exactly what the built-in agent backend does.
+- **Over `OpenAIModelTarget`** — when you want the Responses endpoint rather than chat completions: a `reasoning` block, Orq router threading, a server-side memory scope, and Orq trace ids returned on the response (`trace_id` / `span_id`, which the dashboard deep-links).
+- **Over `"agent:<key>"`** — when you want to pin the exact call parameters yourself, or when the thing you are testing is a model plus instructions rather than a deployed agent. The string form discovers the agent's real tools, memory stores and knowledge bases from the platform; `OrqResponsesTarget` describes only what you gave it.
+- **Under a hosted agent** — pass `model="agent/<key>"` with `require_orq=True` and the router invokes the hosted agent, applying its server-side tools and memory. That is exactly what the built-in agent backend does.
 
 ### What config it honours
 
-Everything routes through `LLMCallConfig.request_params(api="responses")`, so one
-config object covers the whole call:
+Everything routes through `LLMCallConfig.request_params(api="responses")`, so one config object covers the whole call:
 
 | Field | Sent as | Notes |
 |---|---|---|
@@ -142,75 +109,36 @@ config object covers the whole call:
 
 Two guards are worth knowing before you reach for `extra_kwargs`:
 
-- `model`, `input`, `text` and `extra_body` are reserved. Passing one inside
-  `extra_kwargs` raises `ValueError` rather than silently replacing a structural
-  field. Use `LLMCallConfig.extra_body` for body additions — it merges, so the
-  router's thread and memory ids survive, and one you set yourself (scoping the
-  call to a specific memory entity, say) wins over the minted one.
-- If the model 400s on the `reasoning` block, the target drops it, retries once
-  with a warning, and remembers the rejection for the rest of the process — the
-  same memo `common.llm_call` uses, so a rejection learned on a pipeline call also
-  short-circuits target calls.
+- `model`, `input`, `text` and `extra_body` are reserved. Passing one inside `extra_kwargs` raises `ValueError` rather than silently replacing a structural field. Use `LLMCallConfig.extra_body` for body additions — it merges, so the router's thread and memory ids survive, and one you set yourself (scoping the call to a specific memory entity, say) wins over the minted one.
+- If the model 400s on the `reasoning` block, the target drops it, retries once with a warning, and remembers the rejection for the rest of the process — the same memo `common.llm_call` uses, so a rejection learned on a pipeline call also short-circuits target calls.
 
-A response truncated at `max_output_tokens` raises rather than returning a half
-answer: judging a cut-off reply as a refusal is worse than failing the call.
+A response truncated at `max_output_tokens` raises rather than returning a half answer: judging a cut-off reply as a refusal is worse than failing the call.
 
 !!! note "`retry_attempts` defaults to 1 — no retry"
-    `OrqResponsesTarget(..., retry_attempts=1)` is the default: a single attempt,
-    no retry, because `call_target_with_retry` is the single retry owner for
-    target calls on every surface that drives a target (red team and
-    simulation). Raise `retry_attempts` only when you construct the target
-    yourself and call `respond()` directly, outside that wrapper — under it, the
-    two budgets multiply (5 inner attempts under 3 outer ones is 15 calls to a
-    target that is already refusing).
+    `OrqResponsesTarget(..., retry_attempts=1)` is the default: a single attempt, no retry, because `call_target_with_retry` is the single retry owner for target calls on every surface that drives a target (red team and simulation). Raise `retry_attempts` only when you construct the target yourself and call `respond()` directly, outside that wrapper — under it, the two budgets multiply (5 inner attempts under 3 outer ones is 15 calls to a target that is already refusing).
 
 ### Stateless, per call
 
-Each `respond(messages)` sends the **full transcript**. Nothing is stored on the
-instance, and the target does **not** thread `previous_response_id` — there is no
-server-side conversation to continue, and the caller (the red-team orchestrator or
-the simulation runner) owns the transcript. Two consequences:
+Each `respond(messages)` sends the **full transcript**. Nothing is stored on the instance, and the target does **not** thread `previous_response_id` — there is no server-side conversation to continue, and the caller (the red-team orchestrator or the simulation runner) owns the transcript. Two consequences:
 
-- A single instance is safe to invoke concurrently, because no call mutates
-  `self`. `new()` still exists (the ABC requires it) and it re-mints an unseeded
-  `memory_entity_id` per clone, so parallel jobs stay in independent memory scopes.
-- Every turn re-sends and re-bills the whole history. That is the cost of
-  reproducibility: a replayed transcript produces the same request regardless of
-  what the server remembers.
+- A single instance is safe to invoke concurrently, because no call mutates `self`. `new()` still exists (the ABC requires it) and it re-mints an unseeded `memory_entity_id` per clone, so parallel jobs stay in independent memory scopes.
+- Every turn re-sends and re-bills the whole history. That is the cost of reproducibility: a replayed transcript produces the same request regardless of what the server remembers.
 
 ### Transcript rendering
 
-`respond()` converts `list[Message]` into Responses `input` items via
-`messages_to_responses_input` — never hand-build that list. The Responses API is
-not chat completions, and two shapes fail quietly:
+`respond()` converts `list[Message]` into Responses `input` items via `messages_to_responses_input` — never hand-build that list. The Responses API is not chat completions, and two shapes fail quietly:
 
-- An **assistant** turn's content must be a list of `output_text` parts. A bare
-  string or `input_text` parts are **silently dropped by the Orq router**: the
-  model receives a transcript with no assistant turns in it at all. That is how a
-  simulation judge once reported "the agent has not yet responded" for a
-  conversation that had plenty of responses.
-- A **tool result** becomes a `function_call_output` and needs a non-empty
-  `call_id`. A `tool` message with no `tool_call_id` is unreferenceable and gets
-  dropped with a warning.
+- An **assistant** turn's content must be a list of `output_text` parts. A bare string or `input_text` parts are **silently dropped by the Orq router**: the model receives a transcript with no assistant turns in it at all. That is how a simulation judge once reported "the agent has not yet responded" for a conversation that had plenty of responses.
+- A **tool result** becomes a `function_call_output` and needs a non-empty `call_id`. A `tool` message with no `tool_call_id` is unreferenceable and gets dropped with a warning.
 
-If you write your own Responses-based target, call
-`evaluatorq.openresponses.input_items.messages_to_responses_input` rather than
-reproducing this.
+If you write your own Responses-based target, call `evaluatorq.openresponses.input_items.messages_to_responses_input` rather than reproducing this.
 
 ## Writing your own target
 
-Subclass `AgentTarget` from `evaluatorq.contracts`. That is the whole extension
-point for `red_team()` and `simulate()` — you do not need, and cannot usefully
-register, a `Backend`.
+Subclass `AgentTarget` from `evaluatorq.contracts`. That is the whole extension point for `red_team()` and `simulate()` — you do not need, and cannot usefully register, a `Backend`.
 
 !!! info "`Backend` is internal"
-    `evaluatorq.redteam.backends.base.Backend` mints targets for arbitrary keys,
-    resolves context for any key, and owns memory cleanup. `red_team()` resolves
-    it by a fixed name (`orq` / `openresponses`) for string targets only; an
-    object target is wrapped in `BareTargetBackend` automatically. Subclassing
-    `Backend` therefore gets you nothing a target does not, and there is no
-    supported way to route `red_team()` through a custom one. Implement
-    `AgentTarget`.
+    `evaluatorq.redteam.backends.base.Backend` mints targets for arbitrary keys, resolves context for any key, and owns memory cleanup. `red_team()` resolves it by a fixed name (`orq` / `openresponses`) for string targets only; an object target is wrapped in `BareTargetBackend` automatically. Subclassing `Backend` therefore gets you nothing a target does not, and there is no supported way to route `red_team()` through a custom one. Implement `AgentTarget`.
 
 ### The two required methods
 
@@ -219,19 +147,9 @@ async def respond(self, messages: list[Message]) -> AgentResponse: ...
 def new(self) -> AgentTarget: ...
 ```
 
-**`respond`** receives the full transcript and returns an `AgentResponse`. You own
-the system prompt: strip any leading `system` messages from `messages` if you
-prepend your own, or you send it twice. `Message` carries tool calls and tool
-results; forward them if your target can consume them, and say so in your
-docstring if it cannot — callers are told not to assume a round trip.
+**`respond`** receives the full transcript and returns an `AgentResponse`. You own the system prompt: strip any leading `system` messages from `messages` if you prepend your own, or you send it twice. `Message` carries tool calls and tool results; forward them if your target can consume them, and say so in your docstring if it cannot — callers are told not to assume a round trip.
 
-**`new`** returns a fresh, independent instance. This is not optional
-bookkeeping: `red_team()` and `simulate()` run datapoints **concurrently**, and
-the orchestrator calls `new()` once per job so no two jobs share mutable state. A
-target that returns `self` from `new()` races — a stateful one on its conversation
-id, `ORQAgentTarget` on its `_task_id`. Copy your configuration and any injected
-client (sharing an HTTP connection pool is fine); do not copy per-conversation
-state.
+**`new`** returns a fresh, independent instance. This is not optional bookkeeping: `red_team()` and `simulate()` run datapoints **concurrently**, and the orchestrator calls `new()` once per job so no two jobs share mutable state. A target that returns `self` from `new()` races — a stateful one on its conversation id, `ORQAgentTarget` on its `_task_id`. Copy your configuration and any injected client (sharing an HTTP connection pool is fine); do not copy per-conversation state.
 
 ### `get_agent_context()` — what the attacker sees
 
@@ -239,36 +157,17 @@ state.
 async def get_agent_context(self) -> AgentContext: ...
 ```
 
-The default returns a near-empty context and logs a warning. Override it. This
-single method decides:
+The default returns a near-empty context and logs a warning. Override it. This single method decides:
 
-- **Which strategies apply.** Tool-misuse and tool-chaining strategies are gated
-  on declared tools; memory-poisoning on declared memory stores. Report none and
-  those families never fire.
-- **How attacks are written.** The planner writes prompts against your declared
-  `instructions` and tool schemas. An empty `instructions` makes it plan against a
-  generic assistant.
-- **Whether the reasoning-effort pre-flight can run.** When
-  `LLMConfig(target_reasoning_effort=...)` is set, `red_team()` validates the
-  value against the resolved model in the catalogue *before* paying for the first
-  call. It can only do that for `agent:<key>` string targets; for a bare
-  `AgentTarget` it logs a warning and skips, because whether your target forwards
-  the value is unknowable. Your provider rejects an unsupported value at call time
-  instead. Populating `AgentContext.model` is still worth it — the report's
-  self-judge / family-bias guard compares that resolved model against the judge's.
+- **Which strategies apply.** Tool-misuse and tool-chaining strategies are gated on declared tools; memory-poisoning on declared memory stores. Report none and those families never fire.
+- **How attacks are written.** The planner writes prompts against your declared `instructions` and tool schemas. An empty `instructions` makes it plan against a generic assistant.
+- **Whether the reasoning-effort pre-flight can run.** When `LLMConfig(target_reasoning_effort=...)` is set, `red_team()` validates the value against the resolved model in the catalogue *before* paying for the first call. It can only do that for `agent:<key>` string targets; for a bare `AgentTarget` it logs a warning and skips, because whether your target forwards the value is unknowable. Your provider rejects an unsupported value at call time instead. Populating `AgentContext.model` is still worth it — the report's self-judge / family-bias guard compares that resolved model against the judge's.
 
-Also expose a `name` property. Target labels in the report and in traces are
-derived from `.name`, falling back to the class name, with `-1` / `-2` suffixes on
-collisions.
+Also expose a `name` property. Target labels in the report and in traces are derived from `.name`, falling back to the class name, with `-1` / `-2` suffixes on collisions.
 
 ### Surfacing errors
 
-Let exceptions propagate out of `respond()`. `call_target_with_retry` — the single
-wrapper every target call goes through — catches them, applies the per-call
-timeout and the retry budget, and converts the failure into an `AgentResponse`
-carrying an `AgentResponseError`. Swallowing an exception and returning empty text
-is the failure mode to avoid: a dead target then scores as a genuine, harmless
-reply and comes back **resistant**.
+Let exceptions propagate out of `respond()`. `call_target_with_retry` — the single wrapper every target call goes through — catches them, applies the per-call timeout and the retry budget, and converts the failure into an `AgentResponse` carrying an `AgentResponseError`. Swallowing an exception and returning empty text is the failure mode to avoid: a dead target then scores as a genuine, harmless reply and comes back **resistant**.
 
 To get provider-specific error codes into the report, override `map_error`:
 
@@ -280,23 +179,16 @@ def map_error(self, exc: Exception) -> tuple[str, str] | None:
     return None  # defer to the default mapping
 ```
 
-Return `None` to defer — the default yields `("target_error", "<Type>: <msg>")`.
-The message is then classified into a coarse `error_type` (`rate_limit`,
-`timeout`, `network_error`, `content_filter`, …) that the report's error analysis
-groups on.
+Return `None` to defer — the default yields `("target_error", "<Type>: <msg>")`. The message is then classified into a coarse `error_type` (`rate_limit`, `timeout`, `network_error`, `content_filter`, …) that the report's error analysis groups on.
 
 Two more optional hooks:
 
-- **`cleanup_memory(ctx, entity_ids)`** — release anything the run created. The
-  default is a no-op, and if your target reported memory entity ids without
-  overriding it, evaluatorq warns that adversarial data may persist.
-- **`close()`** — if present, it is called best-effort after the run to release an
-  HTTP client you own.
+- **`cleanup_memory(ctx, entity_ids)`** — release anything the run created. The default is a no-op, and if your target reported memory entity ids without overriding it, evaluatorq warns that adversarial data may persist.
+- **`close()`** — if present, it is called best-effort after the run to release an HTTP client you own.
 
 ### A complete custom target
 
-Tools are declared, so tool-misuse strategies apply; errors propagate; `new()`
-copies config and shares the client.
+Tools are declared, so tool-misuse strategies apply; errors propagate; `new()` copies config and shares the client.
 
 ```python
 from __future__ import annotations
@@ -443,13 +335,10 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-A runnable variant of this pattern ships as
-[`15_tool_chaining.py`](../examples/redteam/15_tool_chaining.md).
+A runnable variant of this pattern ships as [`15_tool_chaining.py`](../examples/redteam/15_tool_chaining.md).
 
 ## Where to next
 
 - [Red Teaming](red-teaming.md) — modes, categories and reading a report.
-- [Agent Simulation](agent-simulation.md) — the same targets, driven by a
-  simulated user.
-- [Tuning](../tuning.md) — target timeouts, retries and the three different
-  reasoning-effort settings.
+- [Agent Simulation](agent-simulation.md) — the same targets, driven by a simulated user.
+- [Tuning](../tuning.md) — target timeouts, retries and the three different reasoning-effort settings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,8 @@
 # evaluatorq
 
-Run LLM evaluations, red-team agents, and simulate multi-turn conversations
-in Python — against any agent, with the Orq AI platform as optional infrastructure.
+Run LLM evaluations, red-team agents, and simulate multi-turn conversations in Python — against any agent, with the Orq AI platform as optional infrastructure.
 
-[Get Started](guides/getting-started.md){ .md-button .md-button--primary }
-[View on GitHub](https://github.com/orq-ai/evaluatorq){ .md-button }
+[Get Started](guides/getting-started.md){ .md-button .md-button--primary } [View on GitHub](https://github.com/orq-ai/evaluatorq){ .md-button }
 
 ## Install
 
@@ -16,15 +14,10 @@ $ uv add evaluatorq
 Successfully installed evaluatorq
 ```
 
-`uv add` installs into the current project — run `uv init` first if you don't
-have one. Then run your code with `uv run my_eval.py` and the CLI with
-`uv run eq`, so the environment you installed into is the one that executes.
-Using pip instead, call it as `python -m pip install evaluatorq` to pin it to
-the same interpreter you run with.
+`uv add` installs into the current project — run `uv init` first if you don't have one. Then run your code with `uv run my_eval.py` and the CLI with `uv run eq`, so the environment you installed into is the one that executes. Using pip instead, call it as `python -m pip install evaluatorq` to pin it to the same interpreter you run with.
 
 !!! tip "Optional extras"
-    `uv add "evaluatorq[redteam]"` adds adversarial red teaming ·
-    `uv add "evaluatorq[simulation]"` adds multi-turn agent simulation.
+    `uv add "evaluatorq[redteam]"` adds adversarial red teaming · `uv add "evaluatorq[simulation]"` adds multi-turn agent simulation.
 
 ## What it does
 
@@ -68,10 +61,7 @@ the same interpreter you run with.
 
 </div>
 
-Works with LangGraph, OpenAI Agents SDK, PydanticAI, CrewAI, a plain async
-function, or an Orq deployment. The Orq platform is optional: it stores results
-and, when `ORQ_API_KEY` is set, routes the attacker and judge LLMs by default —
-but you can bring your own and run entirely on OpenAI.
+Works with LangGraph, OpenAI Agents SDK, PydanticAI, CrewAI, a plain async function, or an Orq deployment. The Orq platform is optional: it stores results and, when `ORQ_API_KEY` is set, routes the attacker and judge LLMs by default — but you can bring your own and run entirely on OpenAI.
 
 ## Quick start
 
@@ -141,8 +131,4 @@ Detailed Results:
 - **[API Reference](reference/evaluatorq.md)** — the full public API.
 - **[Roadmap](roadmap.md)** — what's planned next.
 
-<div style="display:none" markdown>
-For coding agents: this site publishes `/llms.txt` — a curated Markdown index —
-and `/llms-full.txt`, the full docs as one Markdown file. Start with the former
-and fall back to the latter.
-</div>
+<div style="display:none" markdown> For coding agents: this site publishes `/llms.txt` — a curated Markdown index — and `/llms-full.txt`, the full docs as one Markdown file. Start with the former and fall back to the latter. </div>

--- a/docs/llm-as-a-jury.md
+++ b/docs/llm-as-a-jury.md
@@ -1,32 +1,20 @@
 # LLM as a Jury
 
-A single judge model is a single point of failure. It can be noisy from one
-call to the next, and it can be biased toward outputs from its own provider
-family. The jury (or panel of judges) replaces that one judge with several,
-runs them together, aggregates their verdicts into one decision, and reports
-how much they agreed.
+A single judge model is a single point of failure. It can be noisy from one call to the next, and it can be biased toward outputs from its own provider family. The jury (or panel of judges) replaces that one judge with several, runs them together, aggregates their verdicts into one decision, and reports how much they agreed.
 
-You can use a jury two ways: as a general evaluator in `evaluatorq()` through
-`llm_jury()`, or inside red teaming through `EvaluatorConfig`. Both share the
-same panel machinery.
+You can use a jury two ways: as a general evaluator in `evaluatorq()` through `llm_jury()`, or inside red teaming through `EvaluatorConfig`. Both share the same panel machinery.
 
 ## When to use it
 
-- The evaluation is high stakes and you want a verdict that does not rest on
-  one model's opinion.
-- You are judging outputs from the same provider as your usual judge and want
-  to avoid a judge grading its own family.
-- You want a quantitative signal for how much your judges actually agree, so
-  you know when a verdict is solid and when it is contested.
+- The evaluation is high stakes and you want a verdict that does not rest on one model's opinion.
+- You are judging outputs from the same provider as your usual judge and want to avoid a judge grading its own family.
+- You want a quantitative signal for how much your judges actually agree, so you know when a verdict is solid and when it is contested.
 
-A single judge is cheaper and faster. Reach for a jury when the cost of a
-wrong verdict outweighs the extra calls. A single-judge panel runs with no
-aggregation overhead, so a jury is purely additive.
+A single judge is cheaper and faster. Reach for a jury when the cost of a wrong verdict outweighs the extra calls. A single-judge panel runs with no aggregation overhead, so a jury is purely additive.
 
 ## Quick start
 
-`llm_jury()` builds an evaluator you drop into the `evaluators=[...]` list of
-`evaluatorq()`. Give it two or more `judges` and it becomes a jury:
+`llm_jury()` builds an evaluator you drop into the `evaluators=[...]` list of `evaluatorq()`. Give it two or more `judges` and it becomes a jury:
 
 ```python
 import asyncio
@@ -61,16 +49,13 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`llm_jury(model="x")` is shorthand for `judges=["x"]` — a single judge, the
-classic LLM-as-a-judge. Pass `judges=[...]` with two or more models to turn it
-into a jury.
+`llm_jury(model="x")` is shorthand for `judges=["x"]` — a single judge, the classic LLM-as-a-judge. Pass `judges=[...]` with two or more models to turn it into a jury.
 
 --8<-- "docs/_snippets/panel-tip.md"
 
 ## Verdict modes
 
-`verdict_kind` (with `labels`) decides what each judge returns and how `passed`
-is set. It is not inferred from `labels` — pick the mode explicitly.
+`verdict_kind` (with `labels`) decides what each judge returns and how `passed` is set. It is not inferred from `labels` — pick the mode explicitly.
 
 | Mode | Configure it with | Judge returns | `passed` is |
 | --- | --- | --- | --- |
@@ -98,9 +83,7 @@ helpfulness = llm_jury(
 )
 ```
 
-`labels`/`passing_labels` are valid only for `categorical`; passing them with
-`numeric` raises `ValueError`. In labeled mode `passing_labels` must be a subset
-of `labels`; omit it and the verdict is still recorded but `passed` is `None`.
+`labels`/`passing_labels` are valid only for `categorical`; passing them with `numeric` raises `ValueError`. In labeled mode `passing_labels` must be a subset of `labels`; omit it and the verdict is still recorded but `passed` is `None`.
 
 ## Panel configuration
 
@@ -117,10 +100,7 @@ of `labels`; omit it and the verdict is still recorded but `passed` is `None`.
 
 ### Cyclic assignment (CyclicJudge)
 
-`assignment="cyclic"` gives each datapoint exactly one judge, rotating through
-the panel so every judge covers an equal share of the run. Judge bias still
-cancels in expectation across the dataset, but the run costs the same as a
-single-judge evaluation instead of `len(panel)` times as much.
+`assignment="cyclic"` gives each datapoint exactly one judge, rotating through the panel so every judge covers an equal share of the run. Judge bias still cancels in expectation across the dataset, but the run costs the same as a single-judge evaluation instead of `len(panel)` times as much.
 
 ```python
 jury = llm_jury(
@@ -131,36 +111,22 @@ jury = llm_jury(
 )
 ```
 
-Use it for run-level scores (a benchmark mean, a pass rate); keep the default
-`"all"` when an individual verdict has to stand on its own, since each per-item
-verdict under `"cyclic"` is one judge's opinion and `stats`/`raw_agreement` come
-back `None`.
+Use it for run-level scores (a benchmark mean, a pass rate); keep the default `"all"` when an individual verdict has to stand on its own, since each per-item verdict under `"cyclic"` is one judge's opinion and `stats`/`raw_agreement` come back `None`.
 
-See [Cyclic judge assignment](cyclic-judge.md) for how items map to judges,
-auditing the rotation via `raw_output["jury"]`, and the failure semantics.
+See [Cyclic judge assignment](cyclic-judge.md) for how items map to judges, auditing the rotation via `raw_output["jury"]`, and the failure semantics.
 
 ## How the verdict is decided
 
-1. **Each judge votes.** With `repetitions > 1` a judge is asked several times
-   and reduces its own passes to one vote first (plurality for categorical,
-   mean or median for numeric).
-2. **Failures pull in replacements.** For every configured judge that fails
-   mechanically, one model from `replacement_judges` stands in, up to the number
-   of failures.
-3. **The panel aggregates.** Categorical verdicts are decided by plurality vote;
-   numeric verdicts by mean or median.
-4. **Thresholds and ties apply.** If fewer than `min_successful_judges` return a
-   usable verdict, the result is **inconclusive**.
+1. **Each judge votes.** With `repetitions > 1` a judge is asked several times and reduces its own passes to one vote first (plurality for categorical, mean or median for numeric).
+2. **Failures pull in replacements.** For every configured judge that fails mechanically, one model from `replacement_judges` stands in, up to the number of failures.
+3. **The panel aggregates.** Categorical verdicts are decided by plurality vote; numeric verdicts by mean or median.
+4. **Thresholds and ties apply.** If fewer than `min_successful_judges` return a usable verdict, the result is **inconclusive**.
 
-A judge can also **abstain**: it returns cleanly but declines to choose. An
-abstention is not a failure and does not trigger a replacement, but it is
-excluded from the decisive tally.
+A judge can also **abstain**: it returns cleanly but declines to choose. An abstention is not a failure and does not trigger a replacement, but it is excluded from the decisive tally.
 
 ## Reading the output
 
-`llm_jury()` returns a standard evaluator, so each result carries the aggregated
-verdict in `value`, the pass/fail in `passed`, and a human-readable panel
-breakdown (who voted what, how close it was) appended to `explanation`:
+`llm_jury()` returns a standard evaluator, so each result carries the aggregated verdict in `value`, the pass/fail in `passed`, and a human-readable panel breakdown (who voted what, how close it was) appended to `explanation`:
 
 ```python
 results = await evaluatorq(..., evaluators=[correctness])
@@ -173,8 +139,7 @@ for r in results:
 
 ## In red teaming
 
-Red teaming reaches the same panel through `EvaluatorConfig`, where the verdict
-is the categorical RESISTANT/VULNERABLE case (`passed=True` means RESISTANT):
+Red teaming reaches the same panel through `EvaluatorConfig`, where the verdict is the categorical RESISTANT/VULNERABLE case (`passed=True` means RESISTANT):
 
 ```python
 from evaluatorq.redteam import EvaluatorConfig, LLMConfig, OpenAIModelTarget, red_team
@@ -199,25 +164,12 @@ report = await red_team(
 ```
 
 !!! note "`strict_panel` only fires on a same-family judge"
-    `strict_panel=True` raises `ValueError` when any judge shares the target's
-    provider family — same-family self-judging can bias the verdict toward the
-    target's own provider. The panel above is entirely cross-family against an
-    OpenAI target, so the guard passes silently (the healthy case). It would
-    raise only if you added an in-family judge such as `"openai/gpt-4o-mini"`.
+    `strict_panel=True` raises `ValueError` when any judge shares the target's provider family — same-family self-judging can bias the verdict toward the target's own provider. The panel above is entirely cross-family against an OpenAI target, so the guard passes silently (the healthy case). It would raise only if you added an in-family judge such as `"openai/gpt-4o-mini"`.
 
 !!! warning "`min_successful_judges` vs. `min_evaluation_coverage` — two different levels"
-    `min_successful_judges` above is a **per-attack** quorum: it decides whether
-    *this one* jury panel produced enough decisive votes to reach a verdict for
-    *this one* attack. `EvaluatorConfig` also has `min_evaluation_coverage`
-    (default `0.8`), which is a separate, **run-level** floor: the fraction of
-    *all* attacks in the run that must get any verdict at all. A `min_successful_judges`
-    miss on one attack is exactly what produces one of the unevaluated attacks
-    that `min_evaluation_coverage` counts against. Missing the run-level floor
-    makes `eq redteam run` exit `1` — see [Red Teaming › In CI](guides/red-teaming.md#in-ci).
+    `min_successful_judges` above is a **per-attack** quorum: it decides whether *this one* jury panel produced enough decisive votes to reach a verdict for *this one* attack. `EvaluatorConfig` also has `min_evaluation_coverage` (default `0.8`), which is a separate, **run-level** floor: the fraction of *all* attacks in the run that must get any verdict at all. A `min_successful_judges` miss on one attack is exactly what produces one of the unevaluated attacks that `min_evaluation_coverage` counts against. Missing the run-level floor makes `eq redteam run` exit `1` — see [Red Teaming › In CI](guides/red-teaming.md#in-ci).
 
-`EvaluatorConfig` adds `strict_panel` (turn panel-composition warnings into hard
-errors) and surfaces a per-attack `jury` breakdown plus a run-level reliability
-statistic:
+`EvaluatorConfig` adds `strict_panel` (turn panel-composition warnings into hard errors) and surfaces a per-attack `jury` breakdown plus a run-level reliability statistic:
 
 ```python
 for result in report.results:
@@ -235,40 +187,23 @@ if reliability:
 
 ## Reliability, in short
 
-For red-team runs, `raw_agreement` tells you how lopsided one vote was, and
-Krippendorff's alpha on the run tells you whether your judges agree more than
-they would by chance:
+For red-team runs, `raw_agreement` tells you how lopsided one vote was, and Krippendorff's alpha on the run tells you whether your judges agree more than they would by chance:
 
 - `1.0` is perfect agreement.
 - around `0` is chance level, so the panel is not adding signal.
-- below `0` is systematic disagreement, which usually means the judges are
-  reading the rubric differently and the prompt or panel needs another look.
+- below `0` is systematic disagreement, which usually means the judges are reading the rubric differently and the prompt or panel needs another look.
 
-It is `None` when undefined, for example a single-judge run or fewer than two
-multi-judge samples.
+It is `None` when undefined, for example a single-judge run or fewer than two multi-judge samples.
 
 ## Endpoint and retries
 
-`llm_jury()` and `PairwiseComparator` always send judge calls to the Orq
-router's `responses` endpoint (`api='responses'`) — the endpoint the router
-prices, so a jury verdict records cost the same way the call it judges does.
-There is no config knob to opt out; `run_judge` handles the cases that cannot
-use it on its own, falling back to Chat Completions for a client that does not
-route through the Orq router, a model the catalogue does not qualify for
-Responses, or a model that 400s on the endpoint.
+`llm_jury()` and `PairwiseComparator` always send judge calls to the Orq router's `responses` endpoint (`api='responses'`) — the endpoint the router prices, so a jury verdict records cost the same way the call it judges does. There is no config knob to opt out; `run_judge` handles the cases that cannot use it on its own, falling back to Chat Completions for a client that does not route through the Orq router, a model the catalogue does not qualify for Responses, or a model that 400s on the endpoint.
 
-Retries happen at the `run_judge` layer, not the SDK's: with a default budget
-of one retry (`LLMCallConfig.retry_count=1`, i.e. up to two requests per judge
-call), `run_judge` disarms the SDK-level retry budget (`max_retries=0`) on
-whichever client it is given — the one either helper builds for itself when no
-`client=` is passed in, or a client you pass in yourself — so the two retry
-layers never stack. There is no way to keep an injected client's own SDK
-retries active alongside `run_judge`'s.
+Retries happen at the `run_judge` layer, not the SDK's: with a default budget of one retry (`LLMCallConfig.retry_count=1`, i.e. up to two requests per judge call), `run_judge` disarms the SDK-level retry budget (`max_retries=0`) on whichever client it is given — the one either helper builds for itself when no `client=` is passed in, or a client you pass in yourself — so the two retry layers never stack. There is no way to keep an injected client's own SDK retries active alongside `run_judge`'s.
 
 ## Reasoning effort on a jury
 
-`llm_jury()`, `llm_jury_pairwise()` and `PairwiseComparator` take a
-`reasoning_effort=` argument that pins the effort on the *judge* model:
+`llm_jury()`, `llm_jury_pairwise()` and `PairwiseComparator` take a `reasoning_effort=` argument that pins the effort on the *judge* model:
 
 ```python
 from evaluatorq import llm_jury
@@ -281,21 +216,13 @@ jury = llm_jury(
 )
 ```
 
-Because these judges send to the `responses` endpoint, the effort renders as a
-`reasoning` block — unless `run_judge` falls back to Chat Completions for one of
-the reasons above, in which case it renders as a flat `reasoning_effort` field.
-Either way the provider is the authority on which values it accepts.
+Because these judges send to the `responses` endpoint, the effort renders as a `reasoning` block — unless `run_judge` falls back to Chat Completions for one of the reasons above, in which case it renders as a flat `reasoning_effort` field. Either way the provider is the authority on which values it accepts.
 
-This is a distinct knob from red teaming's `target_reasoning_effort` (the agent
-*under test*), from `LLMCallConfig.reasoning_effort` on red teaming's own
-`attacker=` / `evaluator=` roles, and from `EVALUATORQ_REASONING_EFFORT` (the
-simulator's user-simulator and judge). See
-[Tuning](tuning.md) for the full disambiguation.
+This is a distinct knob from red teaming's `target_reasoning_effort` (the agent *under test*), from `LLMCallConfig.reasoning_effort` on red teaming's own `attacker=` / `evaluator=` roles, and from `EVALUATORQ_REASONING_EFFORT` (the simulator's user-simulator and judge). See [Tuning](tuning.md) for the full disambiguation.
 
 ## Provider options
 
-`llm_jury()`, `llm_jury_pairwise()` and `PairwiseComparator` take both injection
-seams, and they are not interchangeable:
+`llm_jury()`, `llm_jury_pairwise()` and `PairwiseComparator` take both injection seams, and they are not interchangeable:
 
 ```python
 jury = llm_jury(
@@ -307,22 +234,14 @@ jury = llm_jury(
 )
 ```
 
-`extra_kwargs` sets arguments on the SDK call and **replaces** the key.
-`extra_body` adds fields to the request body and is **merged** per key, so
-router-owned body fields survive alongside yours.
+`extra_kwargs` sets arguments on the SDK call and **replaces** the key. `extra_body` adds fields to the request body and is **merged** per key, so router-owned body fields survive alongside yours.
 
 !!! warning "`extra_body` inside `extra_kwargs` is rejected"
-    `extra_body` is one of the structural fields the call site owns, so passing
-    it through `extra_kwargs` raises — and because a judge failure is caught and
-    turned into a verdict, the symptom is a judge that always fails rather than a
-    crash. Use the `extra_body=` parameter.
+    `extra_body` is one of the structural fields the call site owns, so passing it through `extra_kwargs` raises — and because a judge failure is caught and turned into a verdict, the symptom is a judge that always fails rather than a crash. Use the `extra_body=` parameter.
 
 ## Full example
 
-A complete red-teaming script covering repetitions, replacements, the
-`min_successful_judges` threshold, `strict_panel`, and reading the per-result
-and run-level output lives at
-[`examples/redteam/16_llm_as_a_jury.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/redteam/16_llm_as_a_jury.py).
+A complete red-teaming script covering repetitions, replacements, the `min_successful_judges` threshold, `strict_panel`, and reading the per-result and run-level output lives at [`examples/redteam/16_llm_as_a_jury.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/redteam/16_llm_as_a_jury.py).
 
 ## Where to next
 

--- a/docs/orq-deployment.md
+++ b/docs/orq-deployment.md
@@ -1,21 +1,15 @@
 # Orq Deployment Integration
 
-`evaluatorq.deployment` provides async helpers for calling
-[Orq deployments](https://docs.orq.ai/docs/deployment) from within evaluation
-jobs or any async Python context.
+`evaluatorq.deployment` provides async helpers for calling [Orq deployments](https://docs.orq.ai/docs/deployment) from within evaluation jobs or any async Python context.
 
 ## What it does
 
 The module wraps the `orq-ai-sdk` client with two thin async functions:
 
-- **`deployment(key, ...)`** — invoke a deployment and return a
-  `DeploymentResponse` with both `content` (extracted text) and `raw` (the
-  unmodified SDK response).
-- **`invoke(key, ...)`** — convenience wrapper that calls `deployment()` and
-  returns just the text string.
+- **`deployment(key, ...)`** — invoke a deployment and return a `DeploymentResponse` with both `content` (extracted text) and `raw` (the unmodified SDK response).
+- **`invoke(key, ...)`** — convenience wrapper that calls `deployment()` and returns just the text string.
 
-A single `Orq` client instance is created lazily on first use and reused for
-the lifetime of the process.
+A single `Orq` client instance is created lazily on first use and reused for the lifetime of the process.
 
 ## Requirements
 
@@ -87,11 +81,7 @@ async def my_job(data: DataPoint, _row: int) -> str:
 
 ## Replaying an experiment's responses (no-inference mode)
 
-Sometimes you want to score responses that an Orq experiment already produced
-instead of generating fresh ones — to try new evaluators against a past run, or
-to re-grade without paying for another round of generation. That is what
-**no-inference mode** does: pass `inference=False` and evaluators run against the
-recorded response in each row rather than calling any job.
+Sometimes you want to score responses that an Orq experiment already produced instead of generating fresh ones — to try new evaluators against a past run, or to re-grade without paying for another round of generation. That is what **no-inference mode** does: pass `inference=False` and evaluators run against the recorded response in each row rather than calling any job.
 
 The response source is chosen by the `data` argument to `evaluatorq()`:
 
@@ -101,19 +91,14 @@ The response source is chosen by the `data` argument to `evaluatorq()`:
 | `ExperimentInput(experiment_id=..., run_id=...)` | The recorded responses from a past experiment run. Requires `inference=False`. |
 | `list[DataPoint]` | In-memory datapoints. |
 
-`ExperimentInput` sits alongside `DatasetIdInput` in the `data` union — it is not
-a dataset, it is a completed experiment run whose outputs get replayed.
+`ExperimentInput` sits alongside `DatasetIdInput` in the `data` union — it is not a dataset, it is a completed experiment run whose outputs get replayed.
 
 ### Finding the IDs
 
 Both IDs are read off the Orq UI:
 
-- **`experiment_id`** — the ID in the experiment URL, `/experiments/<experiment_id>`.
-  The REST API calls experiments "spreadsheets", so the same ID appears in
-  `/v2/spreadsheets/<id>` routes.
-- **`run_id`** — optional. Every execution of an experiment creates a new run (a
-  "manifest" in the API). Open a run from the experiment's run history to read its
-  ID from the URL. Omit it to replay the latest run.
+- **`experiment_id`** — the ID in the experiment URL, `/experiments/<experiment_id>`. The REST API calls experiments "spreadsheets", so the same ID appears in `/v2/spreadsheets/<id>` routes.
+- **`run_id`** — optional. Every execution of an experiment creates a new run (a "manifest" in the API). Open a run from the experiment's run history to read its ID from the URL. Omit it to replay the latest run.
 
 ### Example
 
@@ -135,9 +120,7 @@ Pin a specific run with `run_id`:
 data=ExperimentInput(experiment_id="<experiment_id>", run_id="<run_id>")
 ```
 
-`ORQ_API_KEY` must be set — the recorded rows are fetched from the Orq API. When
-`inference=False`, `jobs` is optional and ignored. Any row whose recorded
-response is missing or blank fails loudly rather than being silently skipped.
+`ORQ_API_KEY` must be set — the recorded rows are fetched from the Orq API. When `inference=False`, `jobs` is optional and ignored. Any row whose recorded response is missing or blank fails loudly rather than being silently skipped.
 
 ## API reference
 
@@ -198,9 +181,7 @@ class MessageDict(TypedDict, total=False):
 | `ORQ_API_KEY` | Yes | — | Orq platform API key. |
 | `ORQ_BASE_URL` | No | `https://my.orq.ai` | Override the Orq API base URL. |
 
-`ORQ_API_KEY` must be set before the first call. A missing key raises
-`ValueError` at runtime with a descriptive message. A missing `orq-ai-sdk`
-installation raises `ImportError` with install instructions.
+`ORQ_API_KEY` must be set before the first call. A missing key raises `ValueError` at runtime with a descriptive message. A missing `orq-ai-sdk` installation raises `ImportError` with install instructions.
 
 ## Where to next
 

--- a/docs/pairwise-judging.md
+++ b/docs/pairwise-judging.md
@@ -1,27 +1,18 @@
 # Pairwise (Preference) Judging
 
-Some questions are easier to answer by comparison than in isolation. Instead of
-asking "is this answer good?" you ask "is A better than B?". Pairwise judging
-runs a panel of judges over two responses and reconciles their picks into one
-winner, correcting for the position bias that makes a judge favour whichever
-response it happens to see first.
+Some questions are easier to answer by comparison than in isolation. Instead of asking "is this answer good?" you ask "is A better than B?". Pairwise judging runs a panel of judges over two responses and reconciles their picks into one winner, correcting for the position bias that makes a judge favour whichever response it happens to see first.
 
-It is a sibling of [LLM as a Jury](llm-as-a-jury.md): same panel machinery, same
-judge models, but the verdict is a preference (`A` / `B` / `tie`) rather than a
-pass or a score.
+It is a sibling of [LLM as a Jury](llm-as-a-jury.md): same panel machinery, same judge models, but the verdict is a preference (`A` / `B` / `tie`) rather than a pass or a score.
 
 ## When to use it
 
-- You are comparing two systems, prompts, or model versions and want a direct
-  A-vs-B preference rather than two separate absolute scores.
+- You are comparing two systems, prompts, or model versions and want a direct A-vs-B preference rather than two separate absolute scores.
 - Absolute grading is hard to calibrate but "which one is better" is clear.
-- You want the position bias measured and corrected instead of hoping it washes
-  out.
+- You want the position bias measured and corrected instead of hoping it washes out.
 
 ## Quick start
 
-`llm_jury_pairwise()` builds a reusable comparator. Call `compare()` once per
-A/B pair:
+`llm_jury_pairwise()` builds a reusable comparator. Call `compare()` once per A/B pair:
 
 ```python
 import asyncio
@@ -54,18 +45,13 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`llm_jury_pairwise(model="x")` is the single-judge shorthand for `judges=["x"]`.
-Pass two or more `judges` to get a panel.
+`llm_jury_pairwise(model="x")` is the single-judge shorthand for `judges=["x"]`. Pass two or more `judges` to get a panel.
 
 --8<-- "docs/_snippets/panel-tip.md"
 
 ## Swap and reconcile: how a vote is decided
 
-A judge shown response A first and response B second may lean toward the first
-slot regardless of content. Pairwise judging controls for this by running every
-judge **twice**: once as (A, B) and once as (B, A). The second ordering is
-un-swapped back into the canonical A/B frame, and the two verdicts are
-reconciled into a single vote:
+A judge shown response A first and response B second may lean toward the first slot regardless of content. Pairwise judging controls for this by running every judge **twice**: once as (A, B) and once as (B, A). The second ordering is un-swapped back into the canonical A/B frame, and the two verdicts are reconciled into a single vote:
 
 | First ordering | Second ordering (un-swapped) | Reconciled vote | Flipped |
 | --- | --- | --- | --- |
@@ -75,16 +61,9 @@ reconciled into a single vote:
 | `A` | `tie` | abstains (`None`) | **yes** |
 | `A` | missing / failed | abstains (`None`) | no |
 
-A judge that agrees with itself across both orderings casts that vote. A judge
-that contradicts itself has no real preference: it **flips**, abstains from the
-tally, and the flip is recorded as position bias. The comparison winner is the
-plurality of the reconciled votes, or `inconclusive` when no side reaches a
-plurality or too few judges cast a decisive vote.
+A judge that agrees with itself across both orderings casts that vote. A judge that contradicts itself has no real preference: it **flips**, abstains from the tally, and the flip is recorded as position bias. The comparison winner is the plurality of the reconciled votes, or `inconclusive` when no side reaches a plurality or too few judges cast a decisive vote.
 
-Both orderings run concurrently, so swapping does not add wall-clock latency,
-only cost. Set `swap=False` to run a single ordering when you have already
-controlled for position another way; the position-bias metric is then
-unavailable (no second ordering to disagree with).
+Both orderings run concurrently, so swapping does not add wall-clock latency, only cost. Set `swap=False` to run a single ordering when you have already controlled for position another way; the position-bias metric is then unavailable (no second ordering to disagree with).
 
 ## Panel configuration
 
@@ -142,23 +121,11 @@ for judge in report.per_judge:
 ```
 
 !!! note "Watch `inconclusive_rate` alongside the win rates"
-    The win rates are computed over decided comparisons only, so a run that was
-    mostly noise can still show a high `a_win_rate`. Read it together with
-    `inconclusive_rate`: a healthy result is a high win rate **and** a low
-    inconclusive rate. `mean_agreement` ignores comparisons with a single
-    decisive vote, since one lone voter always "agrees" with itself and would
-    otherwise flatter a degraded panel.
+    The win rates are computed over decided comparisons only, so a run that was mostly noise can still show a high `a_win_rate`. Read it together with `inconclusive_rate`: a healthy result is a high win rate **and** a low inconclusive rate. `mean_agreement` ignores comparisons with a single decisive vote, since one lone voter always "agrees" with itself and would otherwise flatter a degraded panel.
 
 ## Reliability-weighted aggregation (BT-sigma)
 
-The default consensus treats every judge's vote equally. When your panel mixes
-judges of different quality (say a frontier model next to a small open-weight
-one), uniform plurality lets the noisy judges outvote the sharp one. BT-sigma
-(from "Who can we trust? LLM-as-a-jury for Comparative Assessment",
-[arXiv:2602.16610](https://arxiv.org/abs/2602.16610)) fixes this without any
-labels: it fits a Bradley-Terry model with a per-judge discriminator over the
-run's own reconciled votes, learning which judges are internally consistent and
-down-weighting the rest.
+The default consensus treats every judge's vote equally. When your panel mixes judges of different quality (say a frontier model next to a small open-weight one), uniform plurality lets the noisy judges outvote the sharp one. BT-sigma (from "Who can we trust? LLM-as-a-jury for Comparative Assessment", [arXiv:2602.16610](https://arxiv.org/abs/2602.16610)) fixes this without any labels: it fits a Bradley-Terry model with a per-judge discriminator over the run's own reconciled votes, learning which judges are internally consistent and down-weighting the rest.
 
 ```python
 from evaluatorq import build_report
@@ -171,113 +138,45 @@ report.bt_sigma.winners         # reliability-weighted winner per comparison
 report.bt_sigma.a_win_rate      # weighted rollup, next to the plurality one
 ```
 
-The headline plurality rates in the report are unchanged, so the two
-aggregations stay directly comparable, and each `JudgeStats` entry gains its
-fitted `sigma`. The fit is a regularized, unsupervised maximum-likelihood fit on
-the votes the run already collected: no extra LLM calls or training data.
-Identical votes are collapsed into weighted counts before the fit (at most
-three distinct judgements per judge in the A/B setting), so the cost stays flat
-no matter how many comparisons the run holds. The report exposes fit warnings.
-When the optimizer does not converge it falls back to uniform plurality **only
-without repetition weights**; on a repetition run (below) the winners stay
-consistency-weighted and only the pooled `p_a_beats_b` headline degrades to
-neutral. Do not treat a capped fit as a reliability estimate.
+The headline plurality rates in the report are unchanged, so the two aggregations stay directly comparable, and each `JudgeStats` entry gains its fitted `sigma`. The fit is a regularized, unsupervised maximum-likelihood fit on the votes the run already collected: no extra LLM calls or training data. Identical votes are collapsed into weighted counts before the fit (at most three distinct judgements per judge in the A/B setting), so the cost stays flat no matter how many comparisons the run holds. The report exposes fit warnings. When the optimizer does not converge it falls back to uniform plurality **only without repetition weights**; on a repetition run (below) the winners stay consistency-weighted and only the pooled `p_a_beats_b` headline degrades to neutral. Do not treat a capped fit as a reliability estimate.
 
 Notes worth knowing:
 
-- Reconciliation already symmetrises position bias (every judge votes in both
-  orderings), which is a requirement of the model, so votes feed the fit as-is.
-- With a single judge the discriminator is unidentifiable; the fit falls back
-  to plain Bradley-Terry and says so in `fit_warnings`.
-- A perfectly split panel stays inconclusive rather than letting numerical
-  noise crown one judge reliable.
-- A judge whose decisive votes are unanimous (always A, or always B) is
-  excluded from the sigma weighting. With only two items such a judge's sigma
-  measures one-sidedness, not reliability, and `1/sigma` would hand the most
-  degenerate judge on the panel an unbounded weight - the exact shape a
-  position- or verbosity-biased judge takes. On the pooled-fit path it votes
-  with a neutral (median) weight instead; on the repetition path every weight
-  comes from consistency, so that neutral assignment is replaced by the judge's
-  own consistency weight. Either way `fit_warnings` names it.
-- Check `bt_sigma.converged` (and `fit_warnings`) before trusting sigmas: a
-  fit that stopped at the iteration cap still produces numbers.
-- Like all unsupervised aggregation, BT-sigma rewards internal consistency. A
-  majority of judges sharing the same systematic bias will still carry the
-  vote; it protects against noisy judges, not coordinated ones.
+- Reconciliation already symmetrises position bias (every judge votes in both orderings), which is a requirement of the model, so votes feed the fit as-is.
+- With a single judge the discriminator is unidentifiable; the fit falls back to plain Bradley-Terry and says so in `fit_warnings`.
+- A perfectly split panel stays inconclusive rather than letting numerical noise crown one judge reliable.
+- A judge whose decisive votes are unanimous (always A, or always B) is excluded from the sigma weighting. With only two items such a judge's sigma measures one-sidedness, not reliability, and `1/sigma` would hand the most degenerate judge on the panel an unbounded weight - the exact shape a position- or verbosity-biased judge takes. On the pooled-fit path it votes with a neutral (median) weight instead; on the repetition path every weight comes from consistency, so that neutral assignment is replaced by the judge's own consistency weight. Either way `fit_warnings` names it.
+- Check `bt_sigma.converged` (and `fit_warnings`) before trusting sigmas: a fit that stopped at the iteration cap still produces numbers.
+- Like all unsupervised aggregation, BT-sigma rewards internal consistency. A majority of judges sharing the same systematic bias will still carry the vote; it protects against noisy judges, not coordinated ones.
 
 ### Repetition-aware reliability
 
-Run each comparison more than once (`repetitions=2` or more) and the reliability
-weights change source. Instead of the global two-item fit, they come from how
-often each judge **agrees with itself** on repeated passes of the same prompt.
+Run each comparison more than once (`repetitions=2` or more) and the reliability weights change source. Instead of the global two-item fit, they come from how often each judge **agrees with itself** on repeated passes of the same prompt.
 
-Two things must be true, and if either is missing the run falls back to the
-two-item fit and says so in `fit_warnings`:
+Two things must be true, and if either is missing the run falls back to the two-item fit and says so in `fit_warnings`:
 
-- **Both orderings must run (`swap=True`, the default).** Self-agreement is
-  measured inside one ordering, so a single-ordering run (`swap=False`) never
-  reaches this path, even at `repetitions=2`.
-- **At least two judges must have repeated decisive passes.** With only one, the
-  fallback weight for every other judge is just that one judge's number, so we
-  do not use it.
+- **Both orderings must run (`swap=True`, the default).** Self-agreement is measured inside one ordering, so a single-ordering run (`swap=False`) never reaches this path, even at `repetitions=2`.
+- **At least two judges must have repeated decisive passes.** With only one, the fallback weight for every other judge is just that one judge's number, so we do not use it.
 
-Every pass is kept on `PairwiseVote.observations`, normalized so a swapped-order
-'B' is stored as 'A' and the two orderings line up; abstained and failed passes
-are kept as `None`.
+Every pass is kept on `PairwiseVote.observations`, normalized so a swapped-order 'B' is stored as 'A' and the two orderings line up; abstained and failed passes are kept as `None`.
 
-**Why self-agreement, not the global fit.** With one pass per judge, the
-two-item fit cannot tell a noisy judge apart from a hard batch of questions.
-Repeating the *same* prompt removes the ambiguity: any disagreement is the judge
-being inconsistent, nothing else. So a judge's consistency is scored on each
-prompt, counted once per judge per datapoint, then averaged. Because of that:
+**Why self-agreement, not the global fit.** With one pass per judge, the two-item fit cannot tell a noisy judge apart from a hard batch of questions. Repeating the *same* prompt removes the ambiguity: any disagreement is the judge being inconsistent, nothing else. So a judge's consistency is scored on each prompt, counted once per judge per datapoint, then averaged. Because of that:
 
-- Different questions are never compared against each other, so a hard batch
-  cannot look like an unreliable judge.
-- Position bias is not mistaken for inconsistency, since each ordering is its
-  own group.
-- Extra repeats sharpen a judge's score but never add weight: each judge still
-  casts one weighted vote per comparison.
+- Different questions are never compared against each other, so a hard batch cannot look like an unreliable judge.
+- Position bias is not mistaken for inconsistency, since each ordering is its own group.
+- Extra repeats sharpen a judge's score but never add weight: each judge still casts one weighted vote per comparison.
 
-**Two numbers, and which to read.** `bt_sigma.repetition_consistency` is the
-reliability **weight**. It is pulled toward the panel average (so one lucky
-2-pass agreement cannot take over the run) and lowered when passes fail, so even
-a perfectly steady judge reads a little under 1.0 unless the whole panel is
-steady. `bt_sigma.repetition_consistency_raw` (and the `Consistency (raw)` report
-column) is the **plain** self-agreement, with no adjustment: 1.0 means the judge
-always agreed with itself. Read the raw number to compare judges inside one run;
-do not compare the weight across two runs with different panels, where the same
-judge can move without changing. `p_a_beats_b` is still the pooled run-level
-headline. A judge with no repeats gets the median of the measured weights and is
-named in `fit_warnings`. Runs saved before this feature existed still load and
-behave as before.
+**Two numbers, and which to read.** `bt_sigma.repetition_consistency` is the reliability **weight**. It is pulled toward the panel average (so one lucky 2-pass agreement cannot take over the run) and lowered when passes fail, so even a perfectly steady judge reads a little under 1.0 unless the whole panel is steady. `bt_sigma.repetition_consistency_raw` (and the `Consistency (raw)` report column) is the **plain** self-agreement, with no adjustment: 1.0 means the judge always agreed with itself. Read the raw number to compare judges inside one run; do not compare the weight across two runs with different panels, where the same judge can move without changing. `p_a_beats_b` is still the pooled run-level headline. A judge with no repeats gets the median of the measured weights and is named in `fit_warnings`. Runs saved before this feature existed still load and behave as before.
 
-**What consistency is not.** It is self-agreement under fixed conditions, not
-task difficulty, not judge quality (a judge can be steadily wrong), and not
-accuracy against a ground truth. A clean abstention does not count against a
-judge: `['A', <abstention>, 'A']` scores 1.0 in both numbers. A pass that errored
-or came back off-contract is a failure, not a free abstention, and is counted in
-`repetition_failures`. The judge still agreed with itself on the passes it
-finished, so the **raw** number for `['A', None, 'A']` stays **1.0**; only the
-**weight** drops, to **2/3**, because a flaky judge is less dependable even when
-it agrees with itself. The two `None`s look identical in the vote list; only
-`repetition_failures` tells a clean abstention from a broken pass.
+**What consistency is not.** It is self-agreement under fixed conditions, not task difficulty, not judge quality (a judge can be steadily wrong), and not accuracy against a ground truth. A clean abstention does not count against a judge: `['A', <abstention>, 'A']` scores 1.0 in both numbers. A pass that errored or came back off-contract is a failure, not a free abstention, and is counted in `repetition_failures`. The judge still agreed with itself on the passes it finished, so the **raw** number for `['A', None, 'A']` stays **1.0**; only the **weight** drops, to **2/3**, because a flaky judge is less dependable even when it agrees with itself. The two `None`s look identical in the vote list; only `repetition_failures` tells a clean abstention from a broken pass.
 
-**Cost.** Calls scale linearly with judges x orderings x repetitions, so `R=2`
-doubles the calls per comparison. Wall-clock barely moves, since the passes run
-in parallel, and each pass adds one small record. Use `R=2` when reliability
-weighting matters: it is the smallest R that produces any consistency evidence.
-`R=3` only refines the score, for 50% more cost.
+**Cost.** Calls scale linearly with judges x orderings x repetitions, so `R=2` doubles the calls per comparison. Wall-clock barely moves, since the passes run in parallel, and each pass adds one small record. Use `R=2` when reliability weighting matters: it is the smallest R that produces any consistency evidence. `R=3` only refines the score, for 50% more cost.
 
-For ranking more than two candidates, use `evaluatorq.ranking.fit_bt()`
-directly: it takes item pairs from any number of judges and returns skills, a
-ranking, and per-judge reliability, with `cycle_rate()` as the matching
-consistency diagnostic. `cycle_rate` does not apply to the two-item case above,
-since two fixed items have no cycles to measure.
+For ranking more than two candidates, use `evaluatorq.ranking.fit_bt()` directly: it takes item pairs from any number of judges and returns skills, a ranking, and per-judge reliability, with `cycle_rate()` as the matching consistency diagnostic. `cycle_rate` does not apply to the two-item case above, since two fixed items have no cycles to measure.
 
 ## Saving a run and viewing it in the dashboard
 
-`build_report()` gives you the numbers in memory. To keep a run and read it in
-the dashboard, collect the comparisons into a `PairwiseRun` and save it:
+`build_report()` gives you the numbers in memory. To keep a run and read it in the dashboard, collect the comparisons into a `PairwiseRun` and save it:
 
 ```python
 from evaluatorq.pairwise_run import new_run
@@ -299,47 +198,27 @@ for question, response_a, response_b in my_pairs:
 run.save()  # -> .evaluatorq/pairwise-runs/<timestamp>_prompt-v2-vs-prompt-v3.json
 ```
 
-`save()` rolls the comparisons up with `build_report()` and stores the result on
-the run, so the dashboard never recomputes it. Pass a path to choose the file
-yourself; the default lands in the pairwise run store, where `eq dashboard`
-discovers it.
+`save()` rolls the comparisons up with `build_report()` and stores the result on the run, so the dashboard never recomputes it. Pass a path to choose the file yourself; the default lands in the pairwise run store, where `eq dashboard` discovers it.
 
-`label_a` and `label_b` name the two systems being compared. They default to
-`"A"` and `"B"`, but nothing in the judging data records what was in each slot,
-so a reader of the dashboard cannot tell what "A won" means. Set them.
+`label_a` and `label_b` name the two systems being compared. They default to `"A"` and `"B"`, but nothing in the judging data records what was in each slot, so a reader of the dashboard cannot tell what "A won" means. Set them.
 
-A run also records `swap`. Position bias is only meaningful when both orderings
-ran, so a run saved with `swap=False` shows that column as unavailable rather
-than as a flattering `0.00`.
+A run also records `swap`. Position bias is only meaningful when both orderings ran, so a run saved with `swap=False` shows that column as unavailable rather than as a flattering `0.00`.
 
-The dashboard renders the run as three sections: the consensus win rates for
-each side, a per-judge table (win rates, tie rate, position bias), and the
-comparison list, where each row expands to show the two responses side by side
-with every judge's vote and rationale.
+The dashboard renders the run as three sections: the consensus win rates for each side, a per-judge table (win rates, tie rate, position bias), and the comparison list, where each row expands to show the two responses side by side with every judge's vote and rationale.
 
 ## The lower-level core
 
-`run_pairwise()` is the ordering-independent engine underneath the comparator.
-It takes any async `judge_fn(first, second, model)` rather than building LLM
-calls itself, so you can drive the swap-and-reconcile logic with your own judge.
-`reconcile_pair()` and `pairwise_consensus()` are exposed for the same reason.
-Most callers want `llm_jury_pairwise()`; reach for `run_pairwise()` when you are
-plugging in a non-LLM judge or testing the reconciliation directly.
+`run_pairwise()` is the ordering-independent engine underneath the comparator. It takes any async `judge_fn(first, second, model)` rather than building LLM calls itself, so you can drive the swap-and-reconcile logic with your own judge. `reconcile_pair()` and `pairwise_consensus()` are exposed for the same reason. Most callers want `llm_jury_pairwise()`; reach for `run_pairwise()` when you are plugging in a non-LLM judge or testing the reconciliation directly.
 
-All three live in `evaluatorq.pairwise` — not `evaluatorq.pairwise_run`, which
-holds the run-persistence helpers used above:
+All three live in `evaluatorq.pairwise` — not `evaluatorq.pairwise_run`, which holds the run-persistence helpers used above:
 
 ```python
 from evaluatorq.pairwise import pairwise_consensus, reconcile_pair, run_pairwise
 ```
 
-`run_pairwise()` is also re-exported at the top level as `evaluatorq.run_pairwise`;
-`reconcile_pair()` and `pairwise_consensus()` are not. `run_jury()` is internal to
-`evaluatorq.common.jury` and is not part of the public top-level API.
+`run_pairwise()` is also re-exported at the top level as `evaluatorq.run_pairwise`; `reconcile_pair()` and `pairwise_consensus()` are not. `run_jury()` is internal to `evaluatorq.common.jury` and is not part of the public top-level API.
 
-Both `run_pairwise()` and the shared `run_jury()` accept `max_concurrency` as an
-int or an existing `asyncio.Semaphore`; pass the same semaphore to several runs
-to bound their combined fan-out with one budget.
+Both `run_pairwise()` and the shared `run_jury()` accept `max_concurrency` as an int or an existing `asyncio.Semaphore`; pass the same semaphore to several runs to bound their combined fan-out with one budget.
 
 ## Where to next
 

--- a/docs/structured-results.md
+++ b/docs/structured-results.md
@@ -1,9 +1,6 @@
 # Structured Results
 
-Some evaluators do not produce one number. A quality rubric has several axes, a
-safety check has a score per category, a sentiment breakdown is a distribution.
-`EvaluationResultCell` lets an evaluator return all of them from a single call
-instead of splitting one judgement across several evaluators.
+Some evaluators do not produce one number. A quality rubric has several axes, a safety check has a score per category, a sentiment breakdown is a distribution. `EvaluationResultCell` lets an evaluator return all of them from a single call instead of splitting one judgement across several evaluators.
 
 ```python
 class EvaluationResultCell(BaseModel):
@@ -63,8 +60,7 @@ async def sentiment_scorer(params):
 
 ## Safety scores with pass/fail
 
-Structured scores combine with the `pass_` flag, so a run can carry a
-per-category breakdown *and* gate CI on the worst category:
+Structured scores combine with the `pass_` flag, so a run can carry a per-category breakdown *and* gate CI on the worst category:
 
 ```python
 async def safety_scorer(params):
@@ -82,13 +78,10 @@ async def safety_scorer(params):
     )
 ```
 
-See [Evaluation Reference](evaluation-reference.md#passfail-and-ci) for how
-to inspect `pass_` and add an explicit process exit in a CI script.
+See [Evaluation Reference](evaluation-reference.md#passfail-and-ci) for how to inspect `pass_` and add an explicit process exit in a CI script.
 
 !!! note "Display vs. storage"
-    Structured results render as `[structured]` in the terminal table — the
-    breakdown does not fit a cell. The full value is preserved in what is sent
-    to the Orq platform and written to OpenTelemetry spans.
+    Structured results render as `[structured]` in the terminal table — the breakdown does not fit a cell. The full value is preserved in what is sent to the Orq platform and written to OpenTelemetry spans.
 
 ## Runnable examples
 

--- a/docs/superpowers/plans/2026-07-17-evaluatorq-cli-cligdev.md
+++ b/docs/superpowers/plans/2026-07-17-evaluatorq-cli-cligdev.md
@@ -72,8 +72,7 @@ Change to (matches `docs/configuration.md`, which correctly states the library n
 
 - [ ] **Step 3: Verify nothing else leaks the role.**
 
-Run: `grep -rn ':command:' src/ docs/`
-Expected: no matches (the one occurrence is now gone).
+Run: `grep -rn ':command:' src/ docs/` Expected: no matches (the one occurrence is now gone).
 
 - [ ] **Step 4: Commit.**
 
@@ -111,8 +110,7 @@ def test_dash_h_shows_help_on_subcommand():
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `uv run pytest tests/unit/test_cli_help_option.py -v`
-Expected: FAIL — `-h` is currently an unknown option, exit code 2.
+Run: `uv run pytest tests/unit/test_cli_help_option.py -v` Expected: FAIL — `-h` is currently an unknown option, exit code 2.
 
 - [ ] **Step 3: Create the shared constant.**
 
@@ -164,10 +162,7 @@ In `simulation/cli.py`, add the import and `context_settings=CONTEXT_SETTINGS` t
 
 - [ ] **Step 7: Run the test + a manual check.**
 
-Run: `uv run pytest tests/unit/test_cli_help_option.py -v`
-Expected: PASS
-Run: `uv run evaluatorq -h` and `uv run evaluatorq redteam run -h`
-Expected: both print help, exit 0.
+Run: `uv run pytest tests/unit/test_cli_help_option.py -v` Expected: PASS Run: `uv run evaluatorq -h` and `uv run evaluatorq redteam run -h` Expected: both print help, exit 0.
 
 - [ ] **Step 8: Commit.**
 
@@ -204,8 +199,7 @@ def test_bogus_mode_rejected_early():
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `uv run pytest tests/redteam/test_cli_mode_enum.py -v`
-Expected: FAIL — `mode` is currently a free `str`, so `bogus` is accepted at parse time and fails later (not exit 2 at parse).
+Run: `uv run pytest tests/redteam/test_cli_mode_enum.py -v` Expected: FAIL — `mode` is currently a free `str`, so `bogus` is accepted at parse time and fails later (not exit 2 at parse).
 
 - [ ] **Step 3: Add `Pipeline` to the imports.**
 
@@ -230,8 +224,7 @@ The `red_team(mode=mode)` call at line ~429 needs no change — `Pipeline` is a 
 
 - [ ] **Step 5: Run the test to verify it passes.**
 
-Run: `uv run pytest tests/redteam/test_cli_mode_enum.py -v`
-Expected: PASS
+Run: `uv run pytest tests/redteam/test_cli_mode_enum.py -v` Expected: PASS
 
 - [ ] **Step 6: Commit.**
 
@@ -278,8 +271,7 @@ def test_yes_always_skips(monkeypatch):
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `uv run pytest tests/unit/test_cli_tty.py -v`
-Expected: FAIL — module does not exist.
+Run: `uv run pytest tests/unit/test_cli_tty.py -v` Expected: FAIL — module does not exist.
 
 - [ ] **Step 3: Create the helper.**
 
@@ -315,22 +307,17 @@ from evaluatorq.common.cli_tty import should_skip_confirm
 
 - [ ] **Step 5: Use it at BOTH sim call sites.**
 
-`simulation/cli.py` has **two** identical inline occurrences (verified): line ~612
-(inside `simulate`) and line ~900 (inside `run`):
+`simulation/cli.py` has **two** identical inline occurrences (verified): line ~612 (inside `simulate`) and line ~900 (inside `run`):
 
 ```python
             skip_confirm=yes or not sys.stdin.isatty(),
 ```
 
-Replace **both** with `skip_confirm=should_skip_confirm(yes)` and add the import.
-(Migrating only one would leave the duplication this helper exists to remove.)
+Replace **both** with `skip_confirm=should_skip_confirm(yes)` and add the import. (Migrating only one would leave the duplication this helper exists to remove.)
 
 - [ ] **Step 6: Run tests to verify they pass.**
 
-Run: `uv run pytest tests/unit/test_cli_tty.py -v`
-Expected: PASS
-Run: `echo | uv run evaluatorq redteam run -t agent:x --save none`
-Expected: does NOT hang on the confirm prompt (fails/exits for other reasons, e.g. missing creds, but no blocking read).
+Run: `uv run pytest tests/unit/test_cli_tty.py -v` Expected: PASS Run: `echo | uv run evaluatorq redteam run -t agent:x --save none` Expected: does NOT hang on the confirm prompt (fails/exits for other reasons, e.g. missing creds, but no blocking read).
 
 - [ ] **Step 7: Commit.**
 
@@ -368,8 +355,7 @@ def test_examples_dims_comment_lines():
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `uv run pytest tests/unit/test_cli_epilog.py -v`
-Expected: FAIL — module does not exist.
+Run: `uv run pytest tests/unit/test_cli_epilog.py -v` Expected: FAIL — module does not exist.
 
 - [ ] **Step 3: Create the shared builder (moved verbatim from sim).**
 
@@ -451,10 +437,7 @@ Add `epilog=_ROOT_EPILOG` to the root `app = typer.Typer(...)` and to the `@app.
 
 - [ ] **Step 7: Run tests + manual check.**
 
-Run: `uv run pytest tests/unit/test_cli_epilog.py -v`
-Expected: PASS
-Run: `uv run evaluatorq -h` and `uv run evaluatorq redteam run -h`
-Expected: both show an "Examples" section; root help shows the docs/issues links.
+Run: `uv run pytest tests/unit/test_cli_epilog.py -v` Expected: PASS Run: `uv run evaluatorq -h` and `uv run evaluatorq redteam run -h` Expected: both show an "Examples" section; root help shows the docs/issues links.
 
 - [ ] **Step 8: Commit.**
 
@@ -513,8 +496,7 @@ def test_runs_json_serialises_raw_fields(tmp_path):
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `uv run pytest tests/redteam/test_cli_runs_json.py -v`
-Expected: FAIL — `--json` is an unknown option (exit 2).
+Run: `uv run pytest tests/redteam/test_cli_runs_json.py -v` Expected: FAIL — `--json` is an unknown option (exit 2).
 
 - [ ] **Step 3: Create the shared JSON helper.**
 
@@ -602,13 +584,7 @@ Leave the existing Rich-table code (lines ~681-758) as-is; the `--json` branch r
 
 - [ ] **Step 5: Add `--json` to sim `runs`.**
 
-Add the same `json_output` option and honor it in the two no-runs branches
-(`echo_json([])`, `raise typer.Exit(0)`). Insert the JSON branch as an **early
-return immediately after the `if not run_files:` guard (~line 1440), BEFORE the
-existing `rows = []` display loop** — this avoids re-parsing every file twice and
-avoids shadowing the display loop's own `malformed` counter (use `malformed_json`).
-Match redteam's exact exception tuple `(json.JSONDecodeError, OSError)` — do not
-use a bare `except Exception`:
+Add the same `json_output` option and honor it in the two no-runs branches (`echo_json([])`, `raise typer.Exit(0)`). Insert the JSON branch as an **early return immediately after the `if not run_files:` guard (~line 1440), BEFORE the existing `rows = []` display loop** — this avoids re-parsing every file twice and avoids shadowing the display loop's own `malformed` counter (use `malformed_json`). Match redteam's exact exception tuple `(json.JSONDecodeError, OSError)` — do not use a bare `except Exception`:
 
 ```python
     if json_output:
@@ -641,10 +617,7 @@ use a bare `except Exception`:
 
 - [ ] **Step 6: Run tests + pipe check.**
 
-Run: `uv run pytest tests/redteam/test_cli_runs_json.py -v`
-Expected: PASS
-Run: `uv run evaluatorq redteam runs --json | python -m json.tool`
-Expected: parses (empty array if no runs).
+Run: `uv run pytest tests/redteam/test_cli_runs_json.py -v` Expected: PASS Run: `uv run evaluatorq redteam runs --json | python -m json.tool` Expected: parses (empty array if no runs).
 
 - [ ] **Step 7: Commit.**
 
@@ -715,10 +688,7 @@ def test_debug_env_reraises(monkeypatch):
         run_guarded(boom)
 ```
 
-Also add an end-to-end test that exercises the real entrypoint (`main()` wires
-`run_guarded(app)`), so the feature has regression coverage beyond the isolated
-function. Register a throwaway command that raises, then drive it through `main()`
-with patched argv:
+Also add an end-to-end test that exercises the real entrypoint (`main()` wires `run_guarded(app)`), so the feature has regression coverage beyond the isolated function. Register a throwaway command that raises, then drive it through `main()` with patched argv:
 
 ```python
 def test_main_converts_unexpected_error(monkeypatch, capsys):
@@ -739,8 +709,7 @@ def test_main_converts_unexpected_error(monkeypatch, capsys):
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `uv run pytest tests/unit/test_cli_errors.py -v`
-Expected: FAIL — module does not exist.
+Run: `uv run pytest tests/unit/test_cli_errors.py -v` Expected: FAIL — module does not exist.
 
 - [ ] **Step 3: Create the shared error module.**
 
@@ -817,10 +786,7 @@ def _handle_cli_error(exc: Exception) -> NoReturn:
 
 - [ ] **Step 6: Run tests + full suite.**
 
-Run: `uv run pytest tests/unit/test_cli_errors.py -v`
-Expected: PASS
-Run: `uv run pytest -m 'not integration' -q`
-Expected: green (confirms exit-code behavior of existing CLI tests is unchanged).
+Run: `uv run pytest tests/unit/test_cli_errors.py -v` Expected: PASS Run: `uv run pytest -m 'not integration' -q` Expected: green (confirms exit-code behavior of existing CLI tests is unchanged).
 
 - [ ] **Step 7: Commit.**
 
@@ -842,22 +808,11 @@ git commit -m "feat(cli): add global unexpected-error handler with EQ_DEBUG trac
 - Consumes: `run_guarded` (Task 7).
 - Produces: `evaluatorq.cli._register_subapps(app: typer.Typer) -> None`
 
-**Design note (decision B):** `openai`/`typer` are now **core** deps, so
-`import evaluatorq.redteam.cli` / `...simulation.cli` always succeeds on a normal
-install — the "missing extra" `ImportError` path the ticket imagined is
-unreachable. The only thing the old `except ImportError: pass` can catch today is a
-**genuinely broken install**, which it silently swallows (the subcommand vanishes
-with no hint). Per decision B we **drop the swallow entirely and import directly**,
-so a broken install surfaces (routed through `run_guarded` for a clean one-liner +
-`EQ_DEBUG` traceback) instead of hiding. This satisfies item 3 ("stop silently
-hiding subcommands") without a stub whose install hint would be misleading (it
-would fire only on broken installs, never on a real missing extra). The dead
-`_check_redteam_deps()` (it checks core deps) is removed as the spec directed.
+**Design note (decision B):** `openai`/`typer` are now **core** deps, so `import evaluatorq.redteam.cli` / `...simulation.cli` always succeeds on a normal install — the "missing extra" `ImportError` path the ticket imagined is unreachable. The only thing the old `except ImportError: pass` can catch today is a **genuinely broken install**, which it silently swallows (the subcommand vanishes with no hint). Per decision B we **drop the swallow entirely and import directly**, so a broken install surfaces (routed through `run_guarded` for a clean one-liner + `EQ_DEBUG` traceback) instead of hiding. This satisfies item 3 ("stop silently hiding subcommands") without a stub whose install hint would be misleading (it would fire only on broken installs, never on a real missing extra). The dead `_check_redteam_deps()` (it checks core deps) is removed as the spec directed.
 
 - [ ] **Step 1: Confirm imports succeed on a normal install.**
 
-Run: `uv run python -c "import evaluatorq.redteam.cli, evaluatorq.simulation.cli; print('ok')"`
-Expected: `ok` — proves the ImportError path is not exercised on a good install, so swallowing it only ever hides breakage.
+Run: `uv run python -c "import evaluatorq.redteam.cli, evaluatorq.simulation.cli; print('ok')"` Expected: `ok` — proves the ImportError path is not exercised on a good install, so swallowing it only ever hides breakage.
 
 - [ ] **Step 2: Write the failing test.**
 
@@ -880,8 +835,7 @@ def test_subapps_are_registered():
 
 - [ ] **Step 3: Run test to verify it fails.**
 
-Run: `uv run pytest tests/unit/test_cli_subapps.py -v`
-Expected: FAIL — `_register_subapps` does not exist yet.
+Run: `uv run pytest tests/unit/test_cli_subapps.py -v` Expected: FAIL — `_register_subapps` does not exist yet.
 
 - [ ] **Step 4: Replace the swallowing registration with a direct helper.**
 
@@ -915,19 +869,11 @@ def main() -> None:
 
 - [ ] **Step 5: Remove the dead dep check.**
 
-In `redteam/__init__.py`, delete the `_check_redteam_deps()` definition (lines
-~17-29) **and** its module-level call (`_check_redteam_deps()`, ~line 31). It only
-verifies `openai`/`typer`, which are core deps and always importable — so it can
-never fire, and removing it keeps `import evaluatorq.redteam` free of dead guards.
+In `redteam/__init__.py`, delete the `_check_redteam_deps()` definition (lines ~17-29) **and** its module-level call (`_check_redteam_deps()`, ~line 31). It only verifies `openai`/`typer`, which are core deps and always importable — so it can never fire, and removing it keeps `import evaluatorq.redteam` free of dead guards.
 
 - [ ] **Step 6: Run the test + happy-path check.**
 
-Run: `uv run pytest tests/unit/test_cli_subapps.py -v`
-Expected: PASS
-Run: `uv run evaluatorq --help`
-Expected: `redteam` and `sim` listed as normal commands.
-Run: `uv run pytest -m 'not integration' -q`
-Expected: green.
+Run: `uv run pytest tests/unit/test_cli_subapps.py -v` Expected: PASS Run: `uv run evaluatorq --help` Expected: `redteam` and `sim` listed as normal commands. Run: `uv run pytest -m 'not integration' -q` Expected: green.
 
 - [ ] **Step 7: Commit.**
 
@@ -944,18 +890,15 @@ git commit -m "fix(cli): surface broken sub-app imports instead of hiding them; 
 
 - [ ] **Step 1: Lint.**
 
-Run: `uv run ruff check src`
-Expected: no errors. Fix any (e.g. import ordering) and amend the relevant commit.
+Run: `uv run ruff check src` Expected: no errors. Fix any (e.g. import ordering) and amend the relevant commit.
 
 - [ ] **Step 2: Type check.**
 
-Run: `uv run basedpyright`
-Expected: no new errors introduced by these changes.
+Run: `uv run basedpyright` Expected: no new errors introduced by these changes.
 
 - [ ] **Step 3: Full unit suite.**
 
-Run: `uv run pytest -m 'not integration'`
-Expected: all green.
+Run: `uv run pytest -m 'not integration'` Expected: all green.
 
 - [ ] **Step 4: Ticket acceptance smoke checks.**
 
@@ -971,12 +914,7 @@ Expected: all behave per the ticket's verification list.
 
 - [ ] **Step 5: Confirm the "without extras" criterion is not applicable.**
 
-The ticket lists "without extras installed, `evaluatorq --help` still explains how
-to enable redteam/sim." With `openai`/`typer` now **core** deps, the sub-app
-imports always succeed, so `redteam`/`sim` are always listed and there is no
-"extras missing" state to explain. Record this in the PR/ticket as *resolved-moot
-by the core-deps change*, not silently dropped. (Item 3's real fix is: broken
-installs now surface instead of hiding — Task 8.)
+The ticket lists "without extras installed, `evaluatorq --help` still explains how to enable redteam/sim." With `openai`/`typer` now **core** deps, the sub-app imports always succeed, so `redteam`/`sim` are always listed and there is no "extras missing" state to explain. Record this in the PR/ticket as *resolved-moot by the core-deps change*, not silently dropped. (Item 3's real fix is: broken installs now surface instead of hiding — Task 8.)
 
 ---
 

--- a/docs/superpowers/plans/2026-07-23-run-id-invocation-metadata.md
+++ b/docs/superpowers/plans/2026-07-23-run-id-invocation-metadata.md
@@ -96,8 +96,7 @@ def test_run_id_concurrent_tasks_are_isolated() -> None:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `uv run pytest tests/unit/test_thread_context.py -k run_id -v`
-Expected: FAIL — `ImportError: cannot import name 'evaluatorq_run_id'`.
+Run: `uv run pytest tests/unit/test_thread_context.py -k run_id -v` Expected: FAIL — `ImportError: cannot import name 'evaluatorq_run_id'`.
 
 - [ ] **Step 3: Implement in `src/evaluatorq/common/thread_context.py`**
 
@@ -175,8 +174,7 @@ Add `'evaluatorq_run_id'` to `__all__` (keep alphabetical, after `'evaluatorq_pi
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `uv run pytest tests/unit/test_thread_context.py -v`
-Expected: PASS (all, including pre-existing tests).
+Run: `uv run pytest tests/unit/test_thread_context.py -v` Expected: PASS (all, including pre-existing tests).
 
 - [ ] **Step 5: Commit**
 
@@ -232,8 +230,7 @@ def test_metadata_on_orq_when_bound(monkeypatch) -> None:
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/unit/test_run_metadata_kwarg.py -v`
-Expected: FAIL — `ImportError: cannot import name 'run_metadata_kwarg'`.
+Run: `uv run pytest tests/unit/test_run_metadata_kwarg.py -v` Expected: FAIL — `ImportError: cannot import name 'run_metadata_kwarg'`.
 
 - [ ] **Step 3: Implement in `src/evaluatorq/common/llm_call.py`**
 
@@ -269,8 +266,7 @@ def _apply_pipeline_metadata(client: AsyncOpenAI, params: dict[str, Any]) -> Non
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `uv run pytest tests/unit/test_run_metadata_kwarg.py tests/unit/test_thread_context.py -v`
-Expected: PASS.
+Run: `uv run pytest tests/unit/test_run_metadata_kwarg.py tests/unit/test_thread_context.py -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -386,8 +382,7 @@ NOTE for the implementer: `_stub_persona()` / `_stub_scenario()` and the exact `
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py -v`
-Expected: FAIL — `KeyError: 'metadata'` (metadata not yet added at the create sites).
+Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py -v` Expected: FAIL — `KeyError: 'metadata'` (metadata not yet added at the create sites).
 
 - [ ] **Step 3: Implement the four merges**
 
@@ -447,8 +442,7 @@ Merge into `extra` right after it is built (after line 133 `extra: dict[str, Any
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py -v`
-Expected: PASS. Then `uv run pytest -m 'not integration' -q` to confirm no regressions.
+Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py -v` Expected: PASS. Then `uv run pytest -m 'not integration' -q` to confirm no regressions.
 
 - [ ] **Step 5: Commit**
 
@@ -491,8 +485,7 @@ The implementer copies the exact `red_team(...)` setup from `test_red_team_owns_
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/redteam/test_tracing_spans.py::test_root_span_carries_evaluatorq_run_id -v`
-Expected: FAIL — attribute absent.
+Run: `uv run pytest tests/redteam/test_tracing_spans.py::test_root_span_carries_evaluatorq_run_id -v` Expected: FAIL — attribute absent.
 
 - [ ] **Step 3: Implement in `src/evaluatorq/redteam/runner.py`**
 
@@ -536,8 +529,7 @@ to:
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `uv run pytest tests/redteam/test_tracing_spans.py -v`
-Expected: PASS.
+Run: `uv run pytest tests/redteam/test_tracing_spans.py -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -587,8 +579,7 @@ NOTE: `generate_personas` routes through `generate_structured` (Task 3(c)) which
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py::test_generate_personas_binds_a_run_id -v`
-Expected: FAIL — no run_id bound (metadata absent), because no entrypoint binds `evaluatorq_run_id` yet.
+Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py::test_generate_personas_binds_a_run_id -v` Expected: FAIL — no run_id bound (metadata absent), because no entrypoint binds `evaluatorq_run_id` yet.
 
 - [ ] **Step 3: Implement in `src/evaluatorq/simulation/api.py`**
 
@@ -633,9 +624,7 @@ For each wrap, indent the enclosed body one level; do not change any other logic
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py -v`
-Then: `uv run pytest -m 'not integration' -q`
-Expected: PASS.
+Run: `uv run pytest tests/simulation/test_run_metadata_propagation.py -v` Then: `uv run pytest -m 'not integration' -q` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -650,8 +639,7 @@ git commit -m "feat(simulation): bind unique run_id + stamp root span at every e
 
 - [ ] **Step 1: Full unit suite**
 
-Run: `uv run pytest -m 'not integration' -q`
-Expected: PASS.
+Run: `uv run pytest -m 'not integration' -q` Expected: PASS.
 
 - [ ] **Step 2: Lint + format + types**
 
@@ -665,8 +653,7 @@ Expected: clean (basedpyright is lenient; fix any new errors introduced by these
 
 - [ ] **Step 3: Grep for the goal invariant**
 
-Run: `rtk proxy grep -rn "run_metadata_kwarg\|evaluatorq_run_id" src/evaluatorq`
-Expected: helper referenced at the 4 Class-B sites + `_apply_pipeline_metadata`; `evaluatorq_run_id` bound in redteam runner + sim api + defined in thread_context.
+Run: `rtk proxy grep -rn "run_metadata_kwarg\|evaluatorq_run_id" src/evaluatorq` Expected: helper referenced at the 4 Class-B sites + `_apply_pipeline_metadata`; `evaluatorq_run_id` bound in redteam runner + sim api + defined in thread_context.
 
 - [ ] **Step 4: Commit any lint/type fixups**
 

--- a/docs/superpowers/specs/2026-07-17-evaluatorq-cli-cligdev-design.md
+++ b/docs/superpowers/specs/2026-07-17-evaluatorq-cli-cligdev-design.md
@@ -1,31 +1,20 @@
 # evaluatorq CLI — clig.dev alignment (RES-1117)
 
-**Status:** design approved, ready for implementation plan
-**Ticket:** [RES-1117](https://linear.app/orqai/issue/RES-1117)
-**Branch:** `bauke/res-1117-evaluatorq-cli-align-with-cligdev-command-line-interface`
+**Status:** design approved, ready for implementation plan **Ticket:** [RES-1117](https://linear.app/orqai/issue/RES-1117) **Branch:** `bauke/res-1117-evaluatorq-cli-align-with-cligdev-command-line-interface`
 
 ## Goal
 
-Raise `evaluatorq` / `eq` CLI clig.dev compliance from ~7.5/10 to ~9/10. All
-changes additive and non-breaking. No major version bump. CLI surface only.
+Raise `evaluatorq` / `eq` CLI clig.dev compliance from ~7.5/10 to ~9/10. All changes additive and non-breaking. No major version bump. CLI surface only.
 
 ## Scope
 
-**In:** `src/evaluatorq/cli.py`, `src/evaluatorq/redteam/cli.py`,
-`src/evaluatorq/redteam/hooks.py`, `src/evaluatorq/simulation/cli.py`,
-`src/evaluatorq/common/` (new shared helpers), one docs line, unit tests.
+**In:** `src/evaluatorq/cli.py`, `src/evaluatorq/redteam/cli.py`, `src/evaluatorq/redteam/hooks.py`, `src/evaluatorq/simulation/cli.py`, `src/evaluatorq/common/` (new shared helpers), one docs line, unit tests.
 
-**Ten items** = ticket P1+P2+P3 **minus** P3.10 (`.env` autoload — rejected as an
-unexpected input surface; the doc-contradiction half is fixed instead, see item D).
+**Ten items** = ticket P1+P2+P3 **minus** P3.10 (`.env` autoload — rejected as an unexpected input surface; the doc-contradiction half is fixed instead, see item D).
 
-**Out (deferred to a separate ticket, P4):** `--dry-run`; removal of deprecated
-`ui` / `validate-dataset` aliases (breaking — needs a major).
+**Out (deferred to a separate ticket, P4):** `--dry-run`; removal of deprecated `ui` / `validate-dataset` aliases (breaking — needs a major).
 
-This design was hardened by a four-critic adversarial review (`/hate`). Several
-ticket items rested on assumptions the code disproves; the corrected versions are
-below. Where the fix belongs in `common/` rather than duplicated per-CLI, that is
-called out — sim and redteam already diverge and this pass consolidates rather
-than widens the gap.
+This design was hardened by a four-critic adversarial review (`/hate`). Several ticket items rested on assumptions the code disproves; the corrected versions are below. Where the fix belongs in `common/` rather than duplicated per-CLI, that is called out — sim and redteam already diverge and this pass consolidates rather than widens the gap.
 
 ---
 
@@ -33,37 +22,15 @@ than widens the gap.
 
 ### P1
 
-**1. `-h` short help alias.**
-Set `context_settings={'help_option_names': ['-h', '--help']}`. Define the dict
-**once** as a shared constant (e.g. `common/cli_help.py::HELP_OPTION_NAMES` or an
-inline shared dict) rather than three literal copies.
-- First verify empirically whether a root-only setting inherits to the `redteam`
-  / `sim` sub-apps via Click's parent-context fallback
-  (`uv run eq redteam -h`, `uv run eq sim -h`). If root-only suffices, set it once
-  on the root `app` (`cli.py:26`) and drop the sub-app edits. If not, apply the
-  shared constant to all three `typer.Typer()` sites.
-- `dashboard` is a command on the root app, so it inherits the root setting; no
-  separate edit.
+**1. `-h` short help alias.** Set `context_settings={'help_option_names': ['-h', '--help']}`. Define the dict **once** as a shared constant (e.g. `common/cli_help.py::HELP_OPTION_NAMES` or an inline shared dict) rather than three literal copies.
+- First verify empirically whether a root-only setting inherits to the `redteam` / `sim` sub-apps via Click's parent-context fallback (`uv run eq redteam -h`, `uv run eq sim -h`). If root-only suffices, set it once on the root `app` (`cli.py:26`) and drop the sub-app edits. If not, apply the shared constant to all three `typer.Typer()` sites.
+- `dashboard` is a command on the root app, so it inherits the root setting; no separate edit.
 - No existing `-h` collision anywhere (verified).
 
-**2. TTY guard on the redteam confirm.**
-`redteam/cli.py:443` passes `RichHooks(skip_confirm=yes)` with no TTY check; a
-non-TTY invocation (CI, pipe) that forgets `--yes` blocks on `typer.confirm`
-(`hooks.py:430`). Mirror sim (`simulation/cli.py:612`) verbatim:
-`skip_confirm=yes or not sys.stdin.isatty()`. `sys` already imported.
-- **Behavior change (accepted):** non-TTY now auto-proceeds — fail-open — instead
-  of hanging. This matches sim and the ticket's explicit call. Noted that redteam
-  attacks live targets, so auto-proceed carries more weight than in sim; decision
-  stands (mirror sim) per ticket.
+**2. TTY guard on the redteam confirm.** `redteam/cli.py:443` passes `RichHooks(skip_confirm=yes)` with no TTY check; a non-TTY invocation (CI, pipe) that forgets `--yes` blocks on `typer.confirm` (`hooks.py:430`). Mirror sim (`simulation/cli.py:612`) verbatim: `skip_confirm=yes or not sys.stdin.isatty()`. `sys` already imported.
+- **Behavior change (accepted):** non-TTY now auto-proceeds — fail-open — instead of hanging. This matches sim and the ticket's explicit call. Noted that redteam attacks live targets, so auto-proceed carries more weight than in sim; decision stands (mirror sim) per ticket.
 
-**3. Stop silently dropping sub-commands on ImportError — corrected.**
-`cli.py:136,143` wrap sub-app registration in `except ImportError: pass`.
-The ticket's "distinguish missing-extra by module name" mechanism is **infeasible
-as written and no longer needed:** `openai` and `typer` are now **core**
-dependencies (not extras), and `redteam/__init__.py::_check_redteam_deps()` raises
-a hand-built `ImportError` whose `.name` is `None` — name-based discrimination
-cannot work. With the deps core, a bare `ImportError` escaping the sub-app import
-now almost always means a **genuinely broken install**, not a missing extra.
+**3. Stop silently dropping sub-commands on ImportError — corrected.** `cli.py:136,143` wrap sub-app registration in `except ImportError: pass`. The ticket's "distinguish missing-extra by module name" mechanism is **infeasible as written and no longer needed:** `openai` and `typer` are now **core** dependencies (not extras), and `redteam/__init__.py::_check_redteam_deps()` raises a hand-built `ImportError` whose `.name` is `None` — name-based discrimination cannot work. With the deps core, a bare `ImportError` escaping the sub-app import now almost always means a **genuinely broken install**, not a missing extra.
 - **Implementation (investigate-first, then typed-catch):**
   1. Reproduce: determine what, if anything, actually raises `ImportError` from
      `import evaluatorq.redteam.cli` / `...simulation.cli` today given the deps are
@@ -75,90 +42,38 @@ now almost always means a **genuinely broken install**, not a missing extra.
   3. For any **other** `ImportError` (broken install), **re-raise** — never mask it
      behind an install hint. This is the actual bug being fixed: today's bare
      `except ImportError: pass` hides real breakage.
-- `_check_redteam_deps()` checking core deps is now effectively dead; clean it up
-  or repoint it at the real optional deps as part of this item.
+- `_check_redteam_deps()` checking core deps is now effectively dead; clean it up or repoint it at the real optional deps as part of this item.
 
-**4. Strip Sphinx `:command:` markup leak.**
-`simulation/cli.py:1330` docstring `Deprecated alias for :command:\`validate\``
-renders literally. Remove the role. One-line, isolated (only occurrence).
+**4. Strip Sphinx `:command:` markup leak.** `simulation/cli.py:1330` docstring `Deprecated alias for :command:\`validate\`` renders literally. Remove the role. One-line, isolated (only occurrence).
 
 ### P2
 
-**5. `--json` on `redteam runs` + `sim runs` (listing commands) — corrected.**
-clig: machine-readable output where it doesn't hurt usability. **Serialize the raw
-underlying fields, not the display row dicts.** The existing row dicts hold
-human-formatted, lossy values (`asr` as `"42%"`, timestamps truncated/tz-stripped,
-missing fields as the literal string `'—'`, sim's pre-formatted `scores`). Dumping
-those is a table with `.json()` slapped on — hostile to `jq`. Emit the pre-format
-`data.get(...)` values (numbers as numbers, ISO-8601 timestamps, `null` for
-missing).
-- Route all non-JSON chatter to stderr (or suppress) under `--json` so stdout is
-  pure JSON: redteam no-runs `typer.echo` (`cli.py:671,676`), skipped-file warning
-  `console.print` (`cli.py:728`); sim equivalents (`cli.py:1429,1439`).
-- Empty runs dir under `--json` → emit `[]` on stdout, exit 0 (not a bare text
-  message). Skipped/malformed files → count to stderr, keep JSON parseable.
+**5. `--json` on `redteam runs` + `sim runs` (listing commands) — corrected.** clig: machine-readable output where it doesn't hurt usability. **Serialize the raw underlying fields, not the display row dicts.** The existing row dicts hold human-formatted, lossy values (`asr` as `"42%"`, timestamps truncated/tz-stripped, missing fields as the literal string `'—'`, sim's pre-formatted `scores`). Dumping those is a table with `.json()` slapped on — hostile to `jq`. Emit the pre-format `data.get(...)` values (numbers as numbers, ISO-8601 timestamps, `null` for missing).
+- Route all non-JSON chatter to stderr (or suppress) under `--json` so stdout is pure JSON: redteam no-runs `typer.echo` (`cli.py:671,676`), skipped-file warning `console.print` (`cli.py:728`); sim equivalents (`cli.py:1429,1439`).
+- Empty runs dir under `--json` → emit `[]` on stdout, exit 0 (not a bare text message). Skipped/malformed files → count to stderr, keep JSON parseable.
 - Rich table remains the default (no flag).
-- Factor the serialization through one shared `common/` helper
-  (e.g. `common/cli_json.py::echo_json(obj)` → `json.dumps(..., default=str)` to
-  stdout) so redteam and sim don't each grow their own copy.
+- Factor the serialization through one shared `common/` helper (e.g. `common/cli_json.py::echo_json(obj)` → `json.dumps(..., default=str)` to stdout) so redteam and sim don't each grow their own copy.
 - Verify: `uv run eq redteam runs --json | python -m json.tool` parses.
 
-**6. Global unexpected-error handler — wrap `app()` once.**
-Wrap the single `app()` call in `main()` (`cli.py:146`), **not** per-command.
-Click's `main(standalone_mode=True)` already converts `ClickException` / `Abort` /
-usage errors to `sys.exit()` inside `app()`, so anything reaching the outer wrapper
-is either a genuinely-unexpected exception (catch it) or `SystemExit` /
-`KeyboardInterrupt` (re-raise / let propagate — preserves exit codes 0/1/2/130).
-The ticket's `typer.Exit` re-raise list is unnecessary at this layer (Click already
-handled it).
-- On an unexpected exception: print one line to stderr —
-  `Error: <msg>` + `Set EQ_DEBUG=1 to see the full traceback; report at
-  https://github.com/orq-ai/evaluatorq/issues` — and exit 1.
-- Full traceback shown when `EQ_DEBUG=1` (env var, **command-agnostic**; `-v` was
-  rejected because it exists only on `redteam run` and three sim commands, so
-  "re-run with -v" would be false advice on `dashboard`, `runs`, etc.).
-- Consolidate with sim's existing `_handle_cli_error` / `_clean_cli_error_types`
-  (`simulation/cli.py:202`): move the shared shape into `common/` and have both
-  CLIs use it, rather than adding a third bespoke error path.
+**6. Global unexpected-error handler — wrap `app()` once.** Wrap the single `app()` call in `main()` (`cli.py:146`), **not** per-command. Click's `main(standalone_mode=True)` already converts `ClickException` / `Abort` / usage errors to `sys.exit()` inside `app()`, so anything reaching the outer wrapper is either a genuinely-unexpected exception (catch it) or `SystemExit` / `KeyboardInterrupt` (re-raise / let propagate — preserves exit codes 0/1/2/130). The ticket's `typer.Exit` re-raise list is unnecessary at this layer (Click already handled it).
+- On an unexpected exception: print one line to stderr — `Error: <msg>` + `Set EQ_DEBUG=1 to see the full traceback; report at https://github.com/orq-ai/evaluatorq/issues` — and exit 1.
+- Full traceback shown when `EQ_DEBUG=1` (env var, **command-agnostic**; `-v` was rejected because it exists only on `redteam run` and three sim commands, so "re-run with -v" would be false advice on `dashboard`, `runs`, etc.).
+- Consolidate with sim's existing `_handle_cli_error` / `_clean_cli_error_types` (`simulation/cli.py:202`): move the shared shape into `common/` and have both CLIs use it, rather than adding a third bespoke error path.
 
-**7. `--mode` → enum on `redteam run` — reuse existing `Pipeline`.**
-Do **not** define a new enum. `redteam/contracts.py:266` already defines
-`Pipeline(StrEnum)` = `static` / `dynamic` / `hybrid`, and `runner.py` already
-coerces via `Pipeline(mode)` (raising `ValueError` on bad input, already caught).
-Change the param at `redteam/cli.py:195` from `mode: Annotated[str, ...] =
-'dynamic'` to `mode: Annotated[Pipeline, ...] = Pipeline.DYNAMIC` — mirroring the
-`SaveMode` pattern already in this file (`cli.py:304`). This is a **UX** fix (Typer
-renders choices in `--help` and rejects typos early with a list); the underlying
-validation already existed.
+**7. `--mode` → enum on `redteam run` — reuse existing `Pipeline`.** Do **not** define a new enum. `redteam/contracts.py:266` already defines `Pipeline(StrEnum)` = `static` / `dynamic` / `hybrid`, and `runner.py` already coerces via `Pipeline(mode)` (raising `ValueError` on bad input, already caught). Change the param at `redteam/cli.py:195` from `mode: Annotated[str, ...] = 'dynamic'` to `mode: Annotated[Pipeline, ...] = Pipeline.DYNAMIC` — mirroring the `SaveMode` pattern already in this file (`cli.py:304`). This is a **UX** fix (Typer renders choices in `--help` and rejects typos early with a list); the underlying validation already existed.
 - Verify: `uv run eq redteam run --mode bogus` fails fast listing valid choices.
 
 ### P3
 
-**8. Examples epilog on `redteam run` + `dashboard` — reuse, don't copy.**
-Extract sim's `_examples()` builder (`simulation/cli.py:393-406`, dependency-free
-rich-markup formatter) into `common/` (e.g. `common/cli_epilog.py`) and import from
-sim, redteam, and root. Do **not** copy-paste it into `redteam/cli.py`. Add 1–2
-concise example invocations for `redteam run` and `dashboard`.
+**8. Examples epilog on `redteam run` + `dashboard` — reuse, don't copy.** Extract sim's `_examples()` builder (`simulation/cli.py:393-406`, dependency-free rich-markup formatter) into `common/` (e.g. `common/cli_epilog.py`) and import from sim, redteam, and root. Do **not** copy-paste it into `redteam/cli.py`. Add 1–2 concise example invocations for `redteam run` and `dashboard`.
 
-**9. Docs/support link in root epilog.**
-Add an epilog to the root `app`: docs URL + `https://github.com/orq-ai/evaluatorq/issues`
-(the repo already exposes a `Documentation` URL in `pyproject.toml`).
+**9. Docs/support link in root epilog.** Add an epilog to the root `app`: docs URL + `https://github.com/orq-ai/evaluatorq/issues` (the repo already exposes a `Documentation` URL in `pyproject.toml`).
 
-**(dropped) 11. Announce auto-save path.**
-**Dropped — already exists.** `redteam/runner.py::_auto_save_run` persists to
-`.evaluatorq/runs/{name}_{timestamp}.json` and `RichHooks.on_complete`
-(`hooks.py:760`) already prints a path-referencing tip. The ticket's `<id>`
-filename is also wrong. Adding a second "Saved run to …" line would duplicate
-existing output. No action.
+**(dropped) 11. Announce auto-save path.** **Dropped — already exists.** `redteam/runner.py::_auto_save_run` persists to `.evaluatorq/runs/{name}_{timestamp}.json` and `RichHooks.on_complete` (`hooks.py:760`) already prints a path-referencing tip. The ticket's `<id>` filename is also wrong. Adding a second "Saved run to …" line would duplicate existing output. No action.
 
 ### Docs (cheap half of dropped P3.10)
 
-**D. Fix the live doc contradiction.**
-`docs/orq-deployment.md:25` states `ORQ_API_KEY … Set in environment or .env
-file.` while `docs/configuration.md:28` correctly says the library never calls
-`load_dotenv()`. Since we are **not** adding autoload, correct the deployment doc
-line to match `configuration.md` (point users at calling `load_dotenv()`
-themselves). One line; closes the exact gap that justified P3.10.
+**D. Fix the live doc contradiction.** `docs/orq-deployment.md:25` states `ORQ_API_KEY … Set in environment or .env file.` while `docs/configuration.md:28` correctly says the library never calls `load_dotenv()`. Since we are **not** adding autoload, correct the deployment doc line to match `configuration.md` (point users at calling `load_dotenv()` themselves). One line; closes the exact gap that justified P3.10.
 
 ---
 
@@ -173,27 +88,19 @@ Consolidation is a first-class goal of this pass (sim and redteam already drift)
 | shared error handler (item 6) | one-line error + `EQ_DEBUG` traceback | root wrapper; folds sim's `_handle_cli_error` |
 | `_examples()` moved to common (item 8) | epilog builder | root, redteam, sim |
 
-Only introduce a helper where ≥2 call sites use it; a single-use extraction is not
-worth the indirection.
+Only introduce a helper where ≥2 call sites use it; a single-use extraction is not worth the indirection.
 
 ## Testing
 
 Unit tests (`tests/redteam/`, `tests/unit/` as appropriate):
 - `-h` shows help on root and `redteam run` (item 1).
-- `redteam runs --json` and `sim runs --json` emit valid JSON parseable by
-  `json.loads`; raw numeric/timestamp fields, `null` for missing; empty dir → `[]`
-  on stdout, exit 0; no Rich table on stdout (item 5).
-- Non-TTY confirm path: `sys.stdin.isatty()` mocked `False`, `yes=False` →
-  redteam run proceeds without blocking (item 2); mirror sim's existing test.
-- Missing-extra stub message vs broken-import re-raise (item 3) — assert the two
-  branches are distinguishable (subclass-caught vs re-raised).
+- `redteam runs --json` and `sim runs --json` emit valid JSON parseable by `json.loads`; raw numeric/timestamp fields, `null` for missing; empty dir → `[]` on stdout, exit 0; no Rich table on stdout (item 5).
+- Non-TTY confirm path: `sys.stdin.isatty()` mocked `False`, `yes=False` → redteam run proceeds without blocking (item 2); mirror sim's existing test.
+- Missing-extra stub message vs broken-import re-raise (item 3) — assert the two branches are distinguishable (subclass-caught vs re-raised).
 - `--mode bogus` exits with usage error listing valid choices (item 7).
-- Global handler: unexpected `ValueError` in a command → exit 1 + one-line message
-  (no traceback); `EQ_DEBUG=1` → traceback shown; `KeyboardInterrupt` → 130;
-  `typer.Exit(2)` preserved (item 6).
+- Global handler: unexpected `ValueError` in a command → exit 1 + one-line message (no traceback); `EQ_DEBUG=1` → traceback shown; `KeyboardInterrupt` → 130; `typer.Exit(2)` preserved (item 6).
 
-Gates (must be green): `uv run pytest -m 'not integration'`,
-`uv run ruff check src`, `uv run basedpyright`.
+Gates (must be green): `uv run pytest -m 'not integration'`, `uv run ruff check src`, `uv run basedpyright`.
 
 ## Verification (ticket acceptance)
 
@@ -201,8 +108,7 @@ Gates (must be green): `uv run pytest -m 'not integration'`,
 - `uv run evaluatorq redteam runs --json | python -m json.tool` parses.
 - `echo | uv run evaluatorq redteam run -t agent:x --save none` does not hang.
 - `uv run evaluatorq redteam run --mode bogus` fails fast listing valid choices.
-- Broken sub-app import surfaces the real error (not an install hint); a genuine
-  missing extra, if reachable, shows the install hint.
+- Broken sub-app import surfaces the real error (not an install hint); a genuine missing extra, if reachable, shows the install hint.
 
 ## Sequencing (smallest-diff first)
 

--- a/docs/superpowers/specs/2026-07-20-sim-detail-drawer-design.md
+++ b/docs/superpowers/specs/2026-07-20-sim-detail-drawer-design.md
@@ -1,28 +1,19 @@
 # Unified sim detail drawer
 
-**Date:** 2026-07-20
-**Status:** Approved design, ready for implementation plan
-**Area:** `src/evaluatorq/dashboard/` (Agent Sim report)
+**Date:** 2026-07-20 **Status:** Approved design, ready for implementation plan **Area:** `src/evaluatorq/dashboard/` (Agent Sim report)
 
 ## Problem
 
 The Agent Sim dashboard report has two separate drill-down mechanisms:
 
-1. A centered `<dialog class="sim-entity-dialog">` modal showing persona/scenario
-   detail (client-side `<template>` clones, j/k nav), triggered by name-buttons
-   in the Breakdown tables and the Config tab.
-2. Inline `<details>` expand-cards in the Transcripts tab, plus `#conv-N` anchor
-   links from the Failures table that jump to those cards.
+1. A centered `<dialog class="sim-entity-dialog">` modal showing persona/scenario detail (client-side `<template>` clones, j/k nav), triggered by name-buttons in the Breakdown tables and the Config tab.
+2. Inline `<details>` expand-cards in the Transcripts tab, plus `#conv-N` anchor links from the Failures table that jump to those cards.
 
-They are inconsistent and the Failures table exposes low-signal chrome (a
-criteria-dots foldout column, a scenario→anchor link) instead of letting the
-user open the full conversation.
+They are inconsistent and the Failures table exposes low-signal chrome (a criteria-dots foldout column, a scenario→anchor link) instead of letting the user open the full conversation.
 
 ## Goal
 
-One **right-side detail drawer** that serves as the detailed view for whichever
-entity the user clicks. Whole rows are clickable. The drawer overlays the page
-with a dimmed backdrop.
+One **right-side detail drawer** that serves as the detailed view for whichever entity the user clicks. Whole rows are clickable. The drawer overlays the page with a dimmed backdrop.
 
 Three entity kinds:
 
@@ -36,197 +27,90 @@ Three entity kinds:
 
 ### Drawer shell
 
-Reuse the existing `<dialog class="sim-entity-dialog">` and its `showModal()`
-call — `<dialog>` already provides a dimmed `::backdrop`, Escape-to-close, and a
-focus trap. Restyle from centered modal to right drawer via CSS:
+Reuse the existing `<dialog class="sim-entity-dialog">` and its `showModal()` call — `<dialog>` already provides a dimmed `::backdrop`, Escape-to-close, and a focus trap. Restyle from centered modal to right drawer via CSS:
 
-- The UA default centers an open `<dialog>` with `margin: auto; inset: 0`. To
-  pin it right, override **all four insets/margins**, not just the left — e.g.
-  `inset: 0 0 0 auto; margin: 0;` then `height: 100vh; max-height: 100vh;
-  width: min(560px, 92vw);`. (Setting only `margin-left: auto` leaves the UA
-  `margin-top/bottom: auto` centering it vertically — the earlier one-line
-  snippet was wrong; the implementer must verify the box model, not assume.)
+- The UA default centers an open `<dialog>` with `margin: auto; inset: 0`. To pin it right, override **all four insets/margins**, not just the left — e.g. `inset: 0 0 0 auto; margin: 0;` then `height: 100vh; max-height: 100vh; width: min(560px, 92vw);`. (Setting only `margin-left: auto` leaves the UA `margin-top/bottom: auto` centering it vertically — the earlier one-line snippet was wrong; the implementer must verify the box model, not assume.)
 - Left-edge radius; slide-in transform on open.
-- Backdrop click and the existing `[data-sim-entity-close]` button close it
-  (already wired in `dashboard.js`).
+- Backdrop click and the existing `[data-sim-entity-close]` button close it (already wired in `dashboard.js`).
 
-Keep the `sim-entity-*` class/data-attribute names to minimise churn; the
-concept is now a drawer, not a modal.
+Keep the `sim-entity-*` class/data-attribute names to minimise churn; the concept is now a drawer, not a modal.
 
 ### Entity kinds and loading
 
-- **persona / scenario** — unchanged loading model: hidden `<template>` clones
-  rendered once into the page, cloned into the drawer body on trigger. Enriched
-  content (see below).
-- **conversation** — lazy-loaded. Transcripts are heavy and numerous, so do NOT
-  inline them as templates. The trigger carries a `data-drawer-url` pointing at
-  the existing `GET /r/{rid}/sim/transcript?idx=` endpoint; the drawer fetches
-  via `htmx.ajax` into `[data-sim-entity-content]`, including `#filter-form` so
-  `idx` maps into the filtered entry list (same contract the current inline
-  expand uses). Body = `render_transcript_fragment` (judge callout + chat
-  bubbles + colour-coded criteria) — reused as-is.
+- **persona / scenario** — unchanged loading model: hidden `<template>` clones rendered once into the page, cloned into the drawer body on trigger. Enriched content (see below).
+- **conversation** — lazy-loaded. Transcripts are heavy and numerous, so do NOT inline them as templates. The trigger carries a `data-drawer-url` pointing at the existing `GET /r/{rid}/sim/transcript?idx=` endpoint; the drawer fetches via `htmx.ajax` into `[data-sim-entity-content]`, including `#filter-form` so `idx` maps into the filtered entry list (same contract the current inline expand uses). Body = `render_transcript_fragment` (judge callout + chat bubbles + colour-coded criteria) — reused as-is.
 
 ### Enriched persona / scenario templates (decision B)
 
 Each persona/scenario template gains, below the existing profile:
 
-- **Cohort stats**: goal rate, avg score, tokens — sourced from the
-  `persona_breakdown` / `scenario_breakdown` section rows already in `by_kind`.
-- **Conversation list**: that cohort's conversations, each item a conversation
-  trigger (`data-entity-kind="conversation"` + `data-drawer-url=…`). Clicking an
-  item swaps the drawer body to that transcript and **pushes onto the drill
-  stack** (see JavaScript), so **back** returns to the cohort — multi-level, not
-  one-shot.
+- **Cohort stats**: goal rate, avg score, tokens — sourced from the `persona_breakdown` / `scenario_breakdown` section rows already in `by_kind`.
+- **Conversation list**: that cohort's conversations, each item a conversation trigger (`data-entity-kind="conversation"` + `data-drawer-url=…`). Clicking an item swaps the drawer body to that transcript and **pushes onto the drill stack** (see JavaScript), so **back** returns to the cohort — multi-level, not one-shot.
 
-The conversation-list items are cheap (index + score + outcome badge + the
-drawer URL), so they render inline in the cohort template. The transcript
-bodies stay lazy (hx-get). **This is new grouping work** — `§Data` below is
-corrected accordingly; it is not "already computed."
+The conversation-list items are cheap (index + score + outcome badge + the drawer URL), so they render inline in the cohort template. The transcript bodies stay lazy (hx-get). **This is new grouping work** — `§Data` below is corrected accordingly; it is not "already computed."
 
-**Grouping by stable id, not display name.** Group entries into cohorts by the
-entry's persona/scenario **id/index**, never the display name. Two personas (or
-scenarios) can share a display name; keying by name silently merges their
-conversations and mis-attributes cohort stats. `persona_ids` / `scenario_ids`
-in `_sim_entity_context` are name-keyed dicts with the same collision bug —
-build the cohort grouping from the enumerated entry index instead (the same
-`persona-{i}` / `scenario-{i}` id the templates already use), and fix or stop
-relying on the name-keyed maps for this path.
+**Grouping by stable id, not display name.** Group entries into cohorts by the entry's persona/scenario **id/index**, never the display name. Two personas (or scenarios) can share a display name; keying by name silently merges their conversations and mis-attributes cohort stats. `persona_ids` / `scenario_ids` in `_sim_entity_context` are name-keyed dicts with the same collision bug — build the cohort grouping from the enumerated entry index instead (the same `persona-{i}` / `scenario-{i}` id the templates already use), and fix or stop relying on the name-keyed maps for this path.
 
 ### Row triggers
 
-- **Failures (dashboard)** — new dashboard-specific renderer. Reads the same
-  `failures_first` section rows. Columns: **Scenario · Persona · Why · Score**
-  (drop the Criteria column and the scenario anchor link). The whole `<tr>` is a
-  conversation trigger; `idx = row["index"] - 1`.
-- **Failures (static export)** — the shared `_render_failures_first_html` in
-  `export_html.py` **also** drops the criteria-dots foldout column and the
-  `#conv-N` scenario anchor (decision 3 — the user's "more broadly" covers the
-  downloadable file too). Static columns become **Scenario · Persona · Why ·
-  Score**, plain text, no drill (no server → no drawer). Criteria detail there
-  still lives in the per-conversation sections the static export already emits.
-  This means dashboard and static Failures tables share the same clean column
-  set; the dashboard renderer differs only by adding the row trigger.
-- **Breakdown tables** — the whole `<tr>` becomes the persona/scenario trigger
-  (previously only the name was a `sim-entity-link` button).
-- **Transcripts tab** — replace the inline `<details>` expand-cards with a flat
-  list of clickable conversation rows. This removes the
-  `hx-trigger="toggle once…"` lazy-on-expand code; the drawer's lazy-load
-  replaces it. The per-row trace-link button keeps `event.stopPropagation()` so
-  it opens the trace without opening the drawer.
+- **Failures (dashboard)** — new dashboard-specific renderer. Reads the same `failures_first` section rows. Columns: **Scenario · Persona · Why · Score** (drop the Criteria column and the scenario anchor link). The whole `<tr>` is a conversation trigger; `idx = row["index"] - 1`.
+- **Failures (static export)** — the shared `_render_failures_first_html` in `export_html.py` **also** drops the criteria-dots foldout column and the `#conv-N` scenario anchor (decision 3 — the user's "more broadly" covers the downloadable file too). Static columns become **Scenario · Persona · Why · Score**, plain text, no drill (no server → no drawer). Criteria detail there still lives in the per-conversation sections the static export already emits. This means dashboard and static Failures tables share the same clean column set; the dashboard renderer differs only by adding the row trigger.
+- **Breakdown tables** — the whole `<tr>` becomes the persona/scenario trigger (previously only the name was a `sim-entity-link` button).
+- **Transcripts tab** — replace the inline `<details>` expand-cards with a flat list of clickable conversation rows. This removes the `hx-trigger="toggle once…"` lazy-on-expand code; the drawer's lazy-load replaces it. The per-row trace-link button keeps `event.stopPropagation()` so it opens the trace without opening the drawer.
 
-**Row-click affordance (all clickable rows).** A `<tr>` is not natively
-focusable or keyboard-activatable, and a bare row-click swallows text selection.
-So:
+**Row-click affordance (all clickable rows).** A `<tr>` is not natively focusable or keyboard-activatable, and a bare row-click swallows text selection. So:
 
-- **Keyboard/a11y**: give trigger rows `role="button"` + `tabindex="0"`, and the
-  JS click handler also fires on `Enter` / `Space`. (The persona/scenario name
-  was previously a real `<button>` — do not lose keyboard access when promoting
-  the trigger to the row.)
-- **Preserve text selection on the Why cell** (decision 1): the `Why` cell
-  carries the judge's reason users will want to copy. Mark it
-  `data-no-drawer` (or an equivalent opt-out class); the row-click handler
-  ignores clicks whose target is inside a `data-no-drawer` cell, so
-  drag-to-select works there. All other cells open the drawer.
+- **Keyboard/a11y**: give trigger rows `role="button"` + `tabindex="0"`, and the JS click handler also fires on `Enter` / `Space`. (The persona/scenario name was previously a real `<button>` — do not lose keyboard access when promoting the trigger to the row.)
+- **Preserve text selection on the Why cell** (decision 1): the `Why` cell carries the judge's reason users will want to copy. Mark it `data-no-drawer` (or an equivalent opt-out class); the row-click handler ignores clicks whose target is inside a `data-no-drawer` cell, so drag-to-select works there. All other cells open the drawer.
 
 ### JavaScript (extend the existing IIFE in `dashboard.js`)
 
-- Trigger dispatch: a click (or `Enter`/`Space`) on a `[data-sim-entity-trigger]`
-  row, ignoring targets inside `[data-no-drawer]`. If the trigger has
-  `data-drawer-url`, `htmx.ajax('GET', url, {target: content, values from
+- Trigger dispatch: a click (or `Enter`/`Space`) on a `[data-sim-entity-trigger]` row, ignoring targets inside `[data-no-drawer]`. If the trigger has `data-drawer-url`, `htmx.ajax('GET', url, {target: content, values from
   #filter-form})` and open the drawer; otherwise clone the matching `<template>`
   as today.
-- **j/k nav for all kinds** (decision 2): persona/scenario step through their
-  templates as today. Conversation kind steps through the **originating list**
-  — the set of conversation triggers in the table/cohort the drawer was opened
-  from (query the sibling `[data-entity-kind="conversation"]` triggers in that
-  container, step by DOM order, load via `data-drawer-url`). Conversation is the
-  most-opened kind; it must not be the only one without next/prev.
-- **Drill stack** (decision 4): maintain a stack of prior drawer states
-  (kind + id/url). Opening a conversation from a cohort pushes; **back** pops.
-  Multi-level (cohort → conversation → back → cohort), not one-shot. Opening a
-  fresh entity from a table row resets the stack.
+- **j/k nav for all kinds** (decision 2): persona/scenario step through their templates as today. Conversation kind steps through the **originating list** — the set of conversation triggers in the table/cohort the drawer was opened from (query the sibling `[data-entity-kind="conversation"]` triggers in that container, step by DOM order, load via `data-drawer-url`). Conversation is the most-opened kind; it must not be the only one without next/prev.
+- **Drill stack** (decision 4): maintain a stack of prior drawer states (kind + id/url). Opening a conversation from a cohort pushes; **back** pops. Multi-level (cohort → conversation → back → cohort), not one-shot. Opening a fresh entity from a table row resets the stack.
 - Escape / backdrop / close-button behaviour unchanged (native `<dialog>`).
-- Nav chrome is state-dependent: prev/next (j/k) shown for every kind; the
-  **back** button shows only when the drill stack is non-empty.
+- Nav chrome is state-dependent: prev/next (j/k) shown for every kind; the **back** button shows only when the drill stack is non-empty.
 
 ### Data
 
-No new **section builders** — but the cohort conversation lists are **new
-grouping work** done at render time (correcting the earlier "already computed"
-claim):
+No new **section builders** — but the cohort conversation lists are **new grouping work** done at render time (correcting the earlier "already computed" claim):
 
-- Failures rows: `failures_first` section (carries `index`, `persona`,
-  `scenario`, `reason`, `score`) — unchanged.
+- Failures rows: `failures_first` section (carries `index`, `persona`, `scenario`, `reason`, `score`) — unchanged.
 - Cohort stats: `persona_breakdown` / `scenario_breakdown` sections — unchanged.
-- Conversation lists: **new** — group `entries` (`individual_entries`) by
-  persona/scenario **id/index** (not display name; see grouping note above).
-  Build once and reuse for all cohorts (a single pass keyed by id), not
-  per-template re-scans. Only list-item metadata is emitted eagerly; transcript
-  bodies stay lazy.
+- Conversation lists: **new** — group `entries` (`individual_entries`) by persona/scenario **id/index** (not display name; see grouping note above). Build once and reuse for all cohorts (a single pass keyed by id), not per-template re-scans. Only list-item metadata is emitted eagerly; transcript bodies stay lazy.
 
 ### Edge cases (must be handled)
 
 - **Empty cohort**: a persona/scenario with zero conversations shows the profile
-  + cohort stats and an explicit "No conversations" note, not a broken/empty
-  list.
-- **Filtered `idx` alignment**: worked example — `sim_transcript` indexes into
-  `individual_entries(run.results)` and the drawer passes `#filter-form` so the
-  server re-derives the same filtered ordering; the conversation `idx` used by
-  Failures rows (`index - 1`), Transcripts rows, and cohort list items must all
-  come from that **same filtered entry ordering**. Add a test that a filtered
-  view's row `idx` resolves to the same conversation the endpoint returns.
-- **Mobile width**: the `min(560px, 92vw)` drawer must be usable < 480px;
-  verify the transcript grid + cohort list don't overflow horizontally.
-- **Error / no-criteria conversations**: drawer body already handled by
-  `render_transcript_fragment` (error branch + criteria-optional) — reused
-  unchanged; confirm the cohort list still renders their row.
+  + cohort stats and an explicit "No conversations" note, not a broken/empty list.
+- **Filtered `idx` alignment**: worked example — `sim_transcript` indexes into `individual_entries(run.results)` and the drawer passes `#filter-form` so the server re-derives the same filtered ordering; the conversation `idx` used by Failures rows (`index - 1`), Transcripts rows, and cohort list items must all come from that **same filtered entry ordering**. Add a test that a filtered view's row `idx` resolves to the same conversation the endpoint returns.
+- **Mobile width**: the `min(560px, 92vw)` drawer must be usable < 480px; verify the transcript grid + cohort list don't overflow horizontally.
+- **Error / no-criteria conversations**: drawer body already handled by `render_transcript_fragment` (error branch + criteria-optional) — reused unchanged; confirm the cohort list still renders their row.
 
 ### Deletions (part of this work, not just additions)
 
-- `dashboard.js` — the Failures-anchor drill-down handler (`a[href^="#conv-"]`
-  → tab-flip → open `<details>` → scroll, ~line 277) becomes dead once rows are
-  drawer triggers. Remove it.
-- `sim_views.py` — the `<details class="sim-conv-card" id="conv-{idx+1}">`
-  wrapper + its `hx-trigger="toggle once…"` body, replaced by flat rows. The
-  `id="conv-N"` anchor target is no longer referenced (anchor dropped in both
-  Failures renderers) — remove it.
-- `report_tabs.py` — the per-name `_sim_entity_button` wrapping in breakdown
-  tables, superseded by the whole-row trigger.
+- `dashboard.js` — the Failures-anchor drill-down handler (`a[href^="#conv-"]` → tab-flip → open `<details>` → scroll, ~line 277) becomes dead once rows are drawer triggers. Remove it.
+- `sim_views.py` — the `<details class="sim-conv-card" id="conv-{idx+1}">` wrapper + its `hx-trigger="toggle once…"` body, replaced by flat rows. The `id="conv-N"` anchor target is no longer referenced (anchor dropped in both Failures renderers) — remove it.
+- `report_tabs.py` — the per-name `_sim_entity_button` wrapping in breakdown tables, superseded by the whole-row trigger.
 
 ### Files touched
 
-- `dashboard/report_tabs.py` — drawer markup (restyle trigger), enriched
-  persona/scenario templates (cohort stats + conversation list), whole-row
-  breakdown triggers, new dashboard Failures renderer wired into
-  `_sim_breakdown`.
-- `dashboard/sim_views.py` — Transcripts row list → flat clickable rows (drop
-  `<details>`/toggle + `id=conv-N`); `render_transcript_fragment` reused
-  unchanged for the drawer body.
-- `dashboard/static/dashboard.js` — conversation-kind dispatch, j/k for
-  conversations, drill stack + back button, keyboard activation; **remove** the
-  dead Failures-anchor handler.
-- `simulation/reports/export_html.py` — static Failures renderer drops the
-  criteria-dots column + `#conv-N` anchor (decision 3).
-- `common/reports/report.css` — drawer styling (centered `<dialog>` → right
-  drawer); `.fail-why` already present.
+- `dashboard/report_tabs.py` — drawer markup (restyle trigger), enriched persona/scenario templates (cohort stats + conversation list), whole-row breakdown triggers, new dashboard Failures renderer wired into `_sim_breakdown`.
+- `dashboard/sim_views.py` — Transcripts row list → flat clickable rows (drop `<details>`/toggle + `id=conv-N`); `render_transcript_fragment` reused unchanged for the drawer body.
+- `dashboard/static/dashboard.js` — conversation-kind dispatch, j/k for conversations, drill stack + back button, keyboard activation; **remove** the dead Failures-anchor handler.
+- `simulation/reports/export_html.py` — static Failures renderer drops the criteria-dots column + `#conv-N` anchor (decision 3).
+- `common/reports/report.css` — drawer styling (centered `<dialog>` → right drawer); `.fail-why` already present.
 
 ## Out of scope
 
-- Breakdown static-export **tables** (persona/scenario breakdowns) — only the
-  Failures static table is cleaned up here.
+- Breakdown static-export **tables** (persona/scenario breakdowns) — only the Failures static table is cleaned up here.
 - Breakdown-row aggregate charts inside the drawer.
-- Deep drill history beyond the cohort→conversation chain (the stack handles
-  the chain; no cross-entity history / URL routing).
+- Deep drill history beyond the cohort→conversation chain (the stack handles the chain; no cross-entity history / URL routing).
 
 ## Testing
 
-- Unit: new dashboard Failures renderer emits `Scenario · Persona · Why · Score`
-  columns, no Criteria/anchor, whole-row conversation trigger with correct
-  `idx`. Enriched persona/scenario templates include cohort stats + conversation
-  triggers. Transcripts row list emits clickable conversation rows (no
-  `<details>`/toggle).
-- Existing `render_transcript_fragment` and transcript endpoint tests unchanged
-  (reused as-is).
-- Manual: open drawer from each of the three surfaces; backdrop dim, Esc,
-  backdrop-click close; cohort→conversation→back; filter round-trip keeps
-  `idx` aligned.
+- Unit: new dashboard Failures renderer emits `Scenario · Persona · Why · Score` columns, no Criteria/anchor, whole-row conversation trigger with correct `idx`. Enriched persona/scenario templates include cohort stats + conversation triggers. Transcripts row list emits clickable conversation rows (no `<details>`/toggle).
+- Existing `render_transcript_fragment` and transcript endpoint tests unchanged (reused as-is).
+- Manual: open drawer from each of the three surfaces; backdrop dim, Esc, backdrop-click close; cohort→conversation→back; filter round-trip keeps `idx` aligned.

--- a/docs/superpowers/specs/2026-07-21-redteam-tracing-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-21-redteam-tracing-lifecycle-design.md
@@ -4,46 +4,22 @@ Date: 2026-07-21
 
 ## Problem
 
-Red team runs frequently produced **no `orq.redteam.pipeline` trace** in the target
-workspace even though span export returned HTTP 200.
+Red team runs frequently produced **no `orq.redteam.pipeline` trace** in the target workspace even though span export returned HTTP 200.
 
-1. **Premature tracing shutdown.** The base `evaluatorq()` runner shuts tracing down
-   at its own end (`evaluatorq.py:404-410`: `flush` → `sleep(2)` → `shutdown`). The
-   red team pipeline calls `evaluatorq()` *nested* inside its run, so the global
-   OpenTelemetry provider was torn down mid-run; every span emitted afterwards
-   (pipeline root end, recommendations, executive summary) hit a dead provider and
-   was dropped (`Shutdown called, ignoring Span`). The final design removes runtime
-   provider shutdown entirely and uses a framework-owned flush-only session.
+1. **Premature tracing shutdown.** The base `evaluatorq()` runner shuts tracing down at its own end (`evaluatorq.py:404-410`: `flush` → `sleep(2)` → `shutdown`). The red team pipeline calls `evaluatorq()` *nested* inside its run, so the global OpenTelemetry provider was torn down mid-run; every span emitted afterwards (pipeline root end, recommendations, executive summary) hit a dead provider and was dropped (`Shutdown called, ignoring Span`). The final design removes runtime provider shutdown entirely and uses a framework-owned flush-only session.
 
-2. **No safe provider replacement after explicit shutdown.** OpenTelemetry installs
-   one global provider per process. A replacement provider after shutdown cannot be
-   installed reliably, so private test-only `_shutdown_tracing()` is terminal for
-   that interpreter: it clears local references and prevents re-initialization.
-   Runtime paths do not call it.
+2. **No safe provider replacement after explicit shutdown.** OpenTelemetry installs one global provider per process. A replacement provider after shutdown cannot be installed reliably, so private test-only `_shutdown_tracing()` is terminal for that interpreter: it clears local references and prevents re-initialization. Runtime paths do not call it.
 
-3. **Wrong pipeline-span scope.** Dynamic/hybrid opens `orq.redteam.pipeline` inside
-   `_run_dynamic_or_hybrid()` and closes it **before** `red_team()` runs
-   recommendations, executive summary, and save. Static (`_run_static()`) opens **no
-   redteam span at all** — no root, and the outbound target call (attack payload +
-   response) is untraced.
+3. **Wrong pipeline-span scope.** Dynamic/hybrid opens `orq.redteam.pipeline` inside `_run_dynamic_or_hybrid()` and closes it **before** `red_team()` runs recommendations, executive summary, and save. Static (`_run_static()`) opens **no redteam span at all** — no root, and the outbound target call (attack payload + response) is untraced.
 
 ## Root-cause reframing
 
-The lifecycle bug was not "we need smart ownership" — it was **calling provider
-shutdown mid-process at all**. Shutdown belongs at process exit, and the
-SDK's `TracerProvider` already registers that itself: `shutdown_on_exit=True`
-(verified in the installed SDK — `TracerProvider.__init__` does
-`atexit.register(self.shutdown)`). So the fix is: **flush per run, never shut down
-mid-run, let the SDK's atexit hook tear down at process exit.** This removes the need
-for any ownership/refcount machinery — nesting, sequential reuse, and concurrent
-sibling runs all become correct for free because nothing tears the provider down
-while work is in flight.
+The lifecycle bug was not "we need smart ownership" — it was **calling provider shutdown mid-process at all**. Shutdown belongs at process exit, and the SDK's `TracerProvider` already registers that itself: `shutdown_on_exit=True` (verified in the installed SDK — `TracerProvider.__init__` does `atexit.register(self.shutdown)`). So the fix is: **flush per run, never shut down mid-run, let the SDK's atexit hook tear down at process exit.** This removes the need for any ownership/refcount machinery — nesting, sequential reuse, and concurrent sibling runs all become correct for free because nothing tears the provider down while work is in flight.
 
 ## Goals
 
 - No mid-run provider shutdown. Each run flushes deterministically at its end.
-- One framework-owned tracing lifecycle **object** used uniformly by `evaluatorq()`,
-  `red_team()`, and `simulate()` — infrastructure, not a user hook.
+- One framework-owned tracing lifecycle **object** used uniformly by `evaluatorq()`, `red_team()`, and `simulate()` — infrastructure, not a user hook.
 - One `orq.redteam.pipeline` span wraps the **entire** `red_team()` run, both modes.
 - Executive summary + recommendations captured as their own child spans.
 - Static mode gets a pipeline root and a `target_call` span for the attack/response.
@@ -52,17 +28,14 @@ while work is in flight.
 
 - Surfacing OTEL export failures to the user (separate concern).
 - Supporting `sk-orq` keys for ingestion (already works — verified live).
-- Putting tracing into the user-facing `PipelineHooks`/`SimulationHooks` (wrong
-  layer: user-overridable, per-subsystem, no run-start hook, misses the base runner).
+- Putting tracing into the user-facing `PipelineHooks`/`SimulationHooks` (wrong layer: user-overridable, per-subsystem, no run-start hook, misses the base runner).
 - Multi-turn / adversarial-generation spans in static mode (static is single-shot).
 
 ## Design
 
 ### 1. Framework-owned tracing session (`tracing/`)
 
-`tracing_session()` is an async context manager next to `TracingContext`
-(`tracing/context.py` is the natural home; it already models tracing as an object).
-It owns the flush-only lifecycle and yields the existing `TracingContext`:
+`tracing_session()` is an async context manager next to `TracingContext` (`tracing/context.py` is the natural home; it already models tracing as an object). It owns the flush-only lifecycle and yields the existing `TracingContext`:
 
 ```python
 @asynccontextmanager
@@ -90,75 +63,36 @@ async def tracing_session(
 ```
 
 Callers:
-- `evaluatorq()` — wraps its body in `async with tracing_session(name, trace_type=_trace_type)
-  as tracing_context:`. Replaces the manual `init_tracing_if_needed()` +
-  `TracingContext(...)` construction (`evaluatorq.py:204-215`) **and** the
-  legacy `flush → sleep(2) → shutdown` block (`404-410`).
+- `evaluatorq()` — wraps its body in `async with tracing_session(name, trace_type=_trace_type) as tracing_context:`. Replaces the manual `init_tracing_if_needed()` + `TracingContext(...)` construction (`evaluatorq.py:204-215`) **and** the legacy `flush → sleep(2) → shutdown` block (`404-410`).
 - `red_team()` — wraps its whole body in `async with tracing_session(name):`.
-- `simulation/api.py` (3 sites) — replace the `init_tracing_if_needed()` + trailing
-  `flush_tracing()` pair with `async with tracing_session(...)`. This is now a clean,
-  regression-free migration (simulation already never shut down).
+- `simulation/api.py` (3 sites) — replace the `init_tracing_if_needed()` + trailing `flush_tracing()` pair with `async with tracing_session(...)`. This is now a clean, regression-free migration (simulation already never shut down).
 
-`_shutdown_tracing()` is retained for explicit, terminal test teardown; the SDK atexit
-hook handles process-exit teardown. It must keep `_initialization_attempted = True` so
-a later run does not claim it installed a replacement provider. Tests requiring a fresh
-provider must use a fresh interpreter. `tracing_session()` itself never calls shutdown.
+`_shutdown_tracing()` is retained for explicit, terminal test teardown; the SDK atexit hook handles process-exit teardown. It must keep `_initialization_attempted = True` so a later run does not claim it installed a replacement provider. Tests requiring a fresh provider must use a fresh interpreter. `tracing_session()` itself never calls shutdown.
 
-Concurrency note: the module globals are unlocked, but `tracing_session()` needs no lock —
-`init_tracing_if_needed()` is idempotent, and exit only flushes. asyncio is
-single-threaded; concurrent `tracing_session()` enters each init idempotently and each
-exit flushes independently. No provider is ever shut down while another run is live.
+Concurrency note: the module globals are unlocked, but `tracing_session()` needs no lock — `init_tracing_if_needed()` is idempotent, and exit only flushes. asyncio is single-threaded; concurrent `tracing_session()` enters each init idempotently and each exit flushes independently. No provider is ever shut down while another run is live.
 
 ### 2. Pipeline span moves up into `red_team()`
 
-`red_team()` opens the `orq.redteam.pipeline` span (with the run-level attributes
-currently set in `_run_dynamic_or_hybrid`), inside the `tracing_session()` block, wrapping
-the whole run: context retrieval, attacks, evaluation, recommendations, executive
-summary, and save.
+`red_team()` opens the `orq.redteam.pipeline` span (with the run-level attributes currently set in `_run_dynamic_or_hybrid`), inside the `tracing_session()` block, wrapping the whole run: context retrieval, attacks, evaluation, recommendations, executive summary, and save.
 
-- `_run_dynamic_or_hybrid()` and `_run_static()` no longer open their own
-  `orq.redteam.pipeline` span; their child spans nest under the ambient current
-  context (the span `red_team()` opened). The now-redundant `init_tracing_if_needed()`
-  + `capture_parent_context()` at `runner.py:1383-1384` are removed (the session +
-  red_team's own `capture_parent_context()` cover them).
-- **End-of-run attributes are returned up, not reached down** (chosen: threading over
-  ambient `trace.get_current_span()`). The inner runners return their run-level
-  metrics (`num_datapoints`, `num_categories`, `duration_seconds`) alongside the
-  report; `red_team()` sets them on the span it owns via `set_span_attrs`. Where the
-  values are already derivable from the returned `report` + red_team's own timing,
-  `red_team()` computes them directly and no new return channel is added.
+- `_run_dynamic_or_hybrid()` and `_run_static()` no longer open their own `orq.redteam.pipeline` span; their child spans nest under the ambient current context (the span `red_team()` opened). The now-redundant `init_tracing_if_needed()`
+  + `capture_parent_context()` at `runner.py:1383-1384` are removed (the session + red_team's own `capture_parent_context()` cover them).
+- **End-of-run attributes are returned up, not reached down** (chosen: threading over ambient `trace.get_current_span()`). The inner runners return their run-level metrics (`num_datapoints`, `num_categories`, `duration_seconds`) alongside the report; `red_team()` sets them on the span it owns via `set_span_attrs`. Where the values are already derivable from the returned `report` + red_team's own timing, `red_team()` computes them directly and no new return channel is added.
 - Static gains an `orq.redteam.pipeline` root for the first time — intentional.
 
 ### 3. Executive-summary and recommendations spans
 
-Wrap the exec-summary block (`runner.py:717`) in
-`with_redteam_span('orq.redteam.executive_summary', {'orq.redteam.model': evaluator_model})`
-and the recommendations block (`runner.py:695`) in
-`with_redteam_span('orq.redteam.recommendations', {'orq.redteam.model': evaluator_model})`.
-Both nest under the pipeline span (Decision 2). The existing best-effort try/except
-that appends a `pipeline_warnings` entry is preserved (span records the exception via
-`with_redteam_span`; the warning is complementary).
+Wrap the exec-summary block (`runner.py:717`) in `with_redteam_span('orq.redteam.executive_summary', {'orq.redteam.model': evaluator_model})` and the recommendations block (`runner.py:695`) in `with_redteam_span('orq.redteam.recommendations', {'orq.redteam.model': evaluator_model})`. Both nest under the pipeline span (Decision 2). The existing best-effort try/except that appends a `pipeline_warnings` entry is preserved (span records the exception via `with_redteam_span`; the warning is complementary).
 
 ### 4. Static-mode spans
 
 Static currently emits no `with_redteam_span`. After this change:
-- Static runs under the `red_team()`-owned `orq.redteam.pipeline` root (Decision 2),
-  so its base `orq.job` / `orq.evaluation` / LLM spans nest under it.
-- **Target call**: the two async static job closures in `redteam/runtime/jobs.py`
-  (`router_job` and `deployment_job`, both created by `create_model_job`) plus
-  `_create_static_job_for_agent_target` wrap their outbound call in an
-  `orq.redteam.target_call` span (attrs: `orq.redteam.llm_purpose='target'`, target
-  key/model), mirroring the dynamic path. This is the request/response pair a user
-  opens a static trace to inspect — the actual gap behind "add the missing static
-  spans."
-- **Evaluation**: the static scorer (`evaluatorq_bridge.py:251`, returned by
-  `create_owasp_evaluator`) is wrapped in an `orq.redteam.security_evaluation` span
-  (attr `orq.redteam.category`), matching dynamic.
-- **Not added** (single-shot, no multi-turn): `orq.redteam.attack_turn`,
-  `orq.redteam.adversarial_generation`. Documented as an intentional difference.
+- Static runs under the `red_team()`-owned `orq.redteam.pipeline` root (Decision 2), so its base `orq.job` / `orq.evaluation` / LLM spans nest under it.
+- **Target call**: the two async static job closures in `redteam/runtime/jobs.py` (`router_job` and `deployment_job`, both created by `create_model_job`) plus `_create_static_job_for_agent_target` wrap their outbound call in an `orq.redteam.target_call` span (attrs: `orq.redteam.llm_purpose='target'`, target key/model), mirroring the dynamic path. This is the request/response pair a user opens a static trace to inspect — the actual gap behind "add the missing static spans."
+- **Evaluation**: the static scorer (`evaluatorq_bridge.py:251`, returned by `create_owasp_evaluator`) is wrapped in an `orq.redteam.security_evaluation` span (attr `orq.redteam.category`), matching dynamic.
+- **Not added** (single-shot, no multi-turn): `orq.redteam.attack_turn`, `orq.redteam.adversarial_generation`. Documented as an intentional difference.
 
-Update the `redteam/tracing.py` docstring hierarchy to show both dynamic and static
-shapes and the new spans.
+Update the `redteam/tracing.py` docstring hierarchy to show both dynamic and static shapes and the new spans.
 
 ## Span hierarchy after change
 
@@ -195,87 +129,34 @@ orq.redteam.pipeline                      [red_team()]  ← new root for static
 
 ## Error handling
 
-- `tracing_session()` flushes in `finally`; `flush_tracing()` logs a warning when its
-  timeout leaves spans unexported. No shutdown means no mid-run teardown failure mode.
-- Exec-summary and recommendations keep their best-effort try/except; a summary
-  failure never fails the run and the span records the exception.
+- `tracing_session()` flushes in `finally`; `flush_tracing()` logs a warning when its timeout leaves spans unexported. No shutdown means no mid-run teardown failure mode.
+- Exec-summary and recommendations keep their best-effort try/except; a summary failure never fails the run and the span records the exception.
 
 ## Testing
 
-- Unit (`tracing_session()`): enter inits + yields a `TracingContext(enabled=...)`; exit
-  flushes; **no** `_shutdown_tracing()` is called on exit (assert via mock). Nested
-  entry does not re-shutdown. Two sequential `tracing_session()` blocks in one process
-  both flush and both keep tracing live (guards the `_initialization_attempted`
-  regression). Concurrent (`asyncio.gather`) entries: neither tears the provider down.
-- Unit: `_shutdown_tracing()` remains terminal: a later
-  `init_tracing_if_needed()` returns `False` without attempting a provider replacement.
-- Keep the existing tracing test suite green (count via
-  `pytest tests -k tracing --co -q | tail -1`, not a hardcoded number).
-- Regression: an in-memory `SpanExporter` asserts that after `red_team()` the exported
-  spans include `orq.redteam.pipeline` with `orq.redteam.executive_summary` **and**
-  (static) `orq.redteam.target_call` as descendants.
-- Live: re-run red team against a cookbooks agent with an `sk-orq` key in **both**
-  dynamic and static modes; assert the static trace shows the root, `target_call`,
-  and `security_evaluation` spans — not just "exit 0".
+- Unit (`tracing_session()`): enter inits + yields a `TracingContext(enabled=...)`; exit flushes; **no** `_shutdown_tracing()` is called on exit (assert via mock). Nested entry does not re-shutdown. Two sequential `tracing_session()` blocks in one process both flush and both keep tracing live (guards the `_initialization_attempted` regression). Concurrent (`asyncio.gather`) entries: neither tears the provider down.
+- Unit: `_shutdown_tracing()` remains terminal: a later `init_tracing_if_needed()` returns `False` without attempting a provider replacement.
+- Keep the existing tracing test suite green (count via `pytest tests -k tracing --co -q | tail -1`, not a hardcoded number).
+- Regression: an in-memory `SpanExporter` asserts that after `red_team()` the exported spans include `orq.redteam.pipeline` with `orq.redteam.executive_summary` **and** (static) `orq.redteam.target_call` as descendants.
+- Live: re-run red team against a cookbooks agent with an `sk-orq` key in **both** dynamic and static modes; assert the static trace shows the root, `target_call`, and `security_evaluation` spans — not just "exit 0".
 
 ## Round-2 review resolutions (final, supersede above where conflicting)
 
 Recommendations folded in:
-- **R1.** `flush_tracing()` must not block the event loop. Change it to
-  `await asyncio.to_thread(provider.force_flush, timeout_millis)` and inspect the
-  return: `force_flush()` returns `False` on timeout — log a `loguru` warning on
-  failure (a health signal, not a silent drop). Default `timeout_millis` ~5000.
-- **R2.** `_shutdown_tracing()` (renamed, see D2) must add `_initialization_attempted`
-  to its `global` statement AND keep it `True` after teardown. The OpenTelemetry
-  global provider cannot be replaced, so this explicit test-only cleanup is terminal
-  for the current interpreter.
-- **R3.** The tracing-session migration **deletes** `evaluatorq.py:204-215` (the inline
-  `init_tracing_if_needed()` + `capture_parent_context()` + `TracingContext(...)`
-  block) and replaces it with `async with tracing_session(...) as tracing_context:`.
-  No wrapping-around — that would build two `TracingContext`s per run.
-- **R4.** Static outbound-call inventory is **two** async job closures — `router_job`
-  and `deployment_job`, both defined inside `create_model_job` in
-  `redteam/runtime/jobs.py` — plus the agent-target static job
-  (`_create_static_job_for_agent_target`). There is no third top-level job function.
-- **R5.** The static `target_call` span reuses the **dynamic** convention exactly:
-  attributes via `truncate_for_span` (`common/tracing.py`), wrapped in
-  `conversation_thread` where the dynamic path does. Do **not** set
-  `orq.redteam.llm_purpose='target'` on the outer `target_call` span — the backend's
-  own child span (`with_llm_span` in `backends/orq.py` / `backends/openai.py`) sets
-  it. Cross-check attrs against `redteam/adaptive/pipeline.py` target_call site.
-- **R6.** Delete the `asyncio.sleep(2)` at `evaluatorq.py:408` — `force_flush` blocks
-  until export (R1 keeps that guarantee off-thread), so the sleep is dead weight.
-- **R7.** `orq.redteam.num_datapoints` keeps its **"attempted"** meaning: thread
-  `len(all_datapoints)` (and `len(resolved_categories)`, duration) up from the inner
-  runner to `red_team()`; do not recompute from the merged report (that would silently
-  mean "scored"). Add these to the inner runner's return, set via `set_span_attrs`.
-- **R9.** Migrate **all three** `simulation/api.py` sites (~214, ~442, ~558) to
-  `tracing_session`, not one.
+- **R1.** `flush_tracing()` must not block the event loop. Change it to `await asyncio.to_thread(provider.force_flush, timeout_millis)` and inspect the return: `force_flush()` returns `False` on timeout — log a `loguru` warning on failure (a health signal, not a silent drop). Default `timeout_millis` ~5000.
+- **R2.** `_shutdown_tracing()` (renamed, see D2) must add `_initialization_attempted` to its `global` statement AND keep it `True` after teardown. The OpenTelemetry global provider cannot be replaced, so this explicit test-only cleanup is terminal for the current interpreter.
+- **R3.** The tracing-session migration **deletes** `evaluatorq.py:204-215` (the inline `init_tracing_if_needed()` + `capture_parent_context()` + `TracingContext(...)` block) and replaces it with `async with tracing_session(...) as tracing_context:`. No wrapping-around — that would build two `TracingContext`s per run.
+- **R4.** Static outbound-call inventory is **two** async job closures — `router_job` and `deployment_job`, both defined inside `create_model_job` in `redteam/runtime/jobs.py` — plus the agent-target static job (`_create_static_job_for_agent_target`). There is no third top-level job function.
+- **R5.** The static `target_call` span reuses the **dynamic** convention exactly: attributes via `truncate_for_span` (`common/tracing.py`), wrapped in `conversation_thread` where the dynamic path does. Do **not** set `orq.redteam.llm_purpose='target'` on the outer `target_call` span — the backend's own child span (`with_llm_span` in `backends/orq.py` / `backends/openai.py`) sets it. Cross-check attrs against `redteam/adaptive/pipeline.py` target_call site.
+- **R6.** Delete the `asyncio.sleep(2)` at `evaluatorq.py:408` — `force_flush` blocks until export (R1 keeps that guarantee off-thread), so the sleep is dead weight.
+- **R7.** `orq.redteam.num_datapoints` keeps its **"attempted"** meaning: thread `len(all_datapoints)` (and `len(resolved_categories)`, duration) up from the inner runner to `red_team()`; do not recompute from the merged report (that would silently mean "scored"). Add these to the inner runner's return, set via `set_span_attrs`.
+- **R9.** Migrate **all three** `simulation/api.py` sites (~214, ~442, ~558) to `tracing_session`, not one.
 
 Decisions:
-- **D1 = B (mitigate long-lived-process hazards).** (a) Make `BatchSpanProcessor`
-  tuning env-configurable with larger defaults: `max_queue_size` (default 4096),
-  `schedule_delay_millis`, `max_export_batch_size`, read from
-  `ORQ_OTEL_MAX_QUEUE_SIZE` / `ORQ_OTEL_SCHEDULE_DELAY_MS` / `ORQ_OTEL_MAX_BATCH_SIZE`
-  in `setup.py`. (b) The R1 flush-failure warning surfaces export stalls instead of
-  silently dropping. (c) Remaining limitation — a rotated `ORQ_API_KEY` needs a
-  process restart to take effect (the exporter bakes headers at init and we never
-  rotate the provider) — is **documented** in the `tracing_session` docstring and the
-  tracing module docstring, not mitigated (would require re-init machinery out of
-  scope). SIGKILL span loss is inherent to any batch exporter and also documented.
-- **D2 = A (privatize the footgun).** Rename `shutdown_tracing` →
-  `_shutdown_tracing`, drop it from `tracing/__init__.py` `__all__`, update the (test-
-  only) callers, and add a module-level comment: "Do not call during a run — process
-  exit is handled by the SDK TracerProvider atexit hook; calling this mid-run
-  black-holes all later spans." A regression test asserts no runtime path calls it.
-- **D3 = B (symmetric static shape).** Static wraps each datapoint's work in an
-  `orq.redteam.attack` span, with `orq.redteam.target_call` nested inside it, matching
-  the dynamic depth (`orq.job → orq.redteam.attack → orq.redteam.target_call`). The
-  static hierarchy in §4 gains the `orq.redteam.attack` intermediate level.
+- **D1 = B (mitigate long-lived-process hazards).** (a) Make `BatchSpanProcessor` tuning env-configurable with larger defaults: `max_queue_size` (default 4096), `schedule_delay_millis`, `max_export_batch_size`, read from `ORQ_OTEL_MAX_QUEUE_SIZE` / `ORQ_OTEL_SCHEDULE_DELAY_MS` / `ORQ_OTEL_MAX_BATCH_SIZE` in `setup.py`. (b) The R1 flush-failure warning surfaces export stalls instead of silently dropping. (c) Remaining limitation — a rotated `ORQ_API_KEY` needs a process restart to take effect (the exporter bakes headers at init and we never rotate the provider) — is **documented** in the `tracing_session` docstring and the tracing module docstring, not mitigated (would require re-init machinery out of scope). SIGKILL span loss is inherent to any batch exporter and also documented.
+- **D2 = A (privatize the footgun).** Rename `shutdown_tracing` → `_shutdown_tracing`, drop it from `tracing/__init__.py` `__all__`, update the (test- only) callers, and add a module-level comment: "Do not call during a run — process exit is handled by the SDK TracerProvider atexit hook; calling this mid-run black-holes all later spans." A regression test asserts no runtime path calls it.
+- **D3 = B (symmetric static shape).** Static wraps each datapoint's work in an `orq.redteam.attack` span, with `orq.redteam.target_call` nested inside it, matching the dynamic depth (`orq.job → orq.redteam.attack → orq.redteam.target_call`). The static hierarchy in §4 gains the `orq.redteam.attack` intermediate level.
 
 ## Rollout / risk
 
-Single PR (per decision). The lifecycle change is low-risk (strictly removes mid-run
-shutdown). The span-topology change (Decision 2/4) is medium-risk — it touches both
-inner runners' attribute handling and the static job bodies — mitigated by the
-in-memory-exporter regression test and live verification in both modes.
+Single PR (per decision). The lifecycle change is low-risk (strictly removes mid-run shutdown). The span-topology change (Decision 2/4) is medium-risk — it touches both inner runners' attribute handling and the static job bodies — mitigated by the in-memory-exporter regression test and live verification in both modes.

--- a/docs/superpowers/specs/2026-07-23-run-id-invocation-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-23-run-id-invocation-metadata-design.md
@@ -1,30 +1,17 @@
 # Run-id invocation metadata — design
 
-**Date:** 2026-07-23
-**Status:** approved for planning (revised after hate-review)
+**Date:** 2026-07-23 **Status:** approved for planning (revised after hate-review)
 
 ## Goal
 
-Make every LLM chat-completion / responses invocation issued during a red-team or
-agent-simulation run carry the run's identifier as request `metadata`, and expose that
-identifier on the run's **root** trace span. This lets an operator filter, in Orq's trace
-UI, every model call that belongs to one `red_team()` / `simulate()` invocation.
+Make every LLM chat-completion / responses invocation issued during a red-team or agent-simulation run carry the run's identifier as request `metadata`, and expose that identifier on the run's **root** trace span. This lets an operator filter, in Orq's trace UI, every model call that belongs to one `red_team()` / `simulate()` invocation.
 
-No new identifier is minted where one already exists: both pipelines already produce a
-per-run `run_id`, and we reuse it. No new dependency (no ULID library).
+No new identifier is minted where one already exists: both pipelines already produce a per-run `run_id`, and we reuse it. No new dependency (no ULID library).
 
 ## Background — what already exists
 
-- **`run_id` per run.** Red team mints it in `tracing_session` (`tracing/context.py`,
-  `generate_run_id()` → `str(uuid4())`), surfaced as `tracing_context.run_id`.
-  Simulation mints `uuid4().hex` at each outer entry in `simulation/api.py`.
-- **A ContextVar metadata rail.** `common/thread_context.py` carries the pipeline label
-  (`red_teaming` / `agent_simulation`) on the `_pipeline` ContextVar and exposes it two
-  ways — `pipeline_metadata()` → `{'evaluatorq_pipeline': ...}` (native `metadata=` kwarg)
-  and `pipeline_metadata_param()` → `{'metadata': {'evaluatorq_pipeline': ...}}` (extra_body
-  form). **These two functions are independent implementations — `pipeline_metadata_param()`
-  does NOT call `pipeline_metadata()`; it re-reads `_pipeline` directly.** Both must be
-  extended.
+- **`run_id` per run.** Red team mints it in `tracing_session` (`tracing/context.py`, `generate_run_id()` → `str(uuid4())`), surfaced as `tracing_context.run_id`. Simulation mints `uuid4().hex` at each outer entry in `simulation/api.py`.
+- **A ContextVar metadata rail.** `common/thread_context.py` carries the pipeline label (`red_teaming` / `agent_simulation`) on the `_pipeline` ContextVar and exposes it two ways — `pipeline_metadata()` → `{'evaluatorq_pipeline': ...}` (native `metadata=` kwarg) and `pipeline_metadata_param()` → `{'metadata': {'evaluatorq_pipeline': ...}}` (extra_body form). **These two functions are independent implementations — `pipeline_metadata_param()` does NOT call `pipeline_metadata()`; it re-reads `_pipeline` directly.** Both must be extended.
 - **Call sites that tag invocations with pipeline metadata (7, not 4):**
   - `common/llm_call.py` (`_apply_pipeline_metadata`) — `pipeline_metadata()`
   - `redteam/backends/openai.py` — `pipeline_metadata()`
@@ -34,62 +21,34 @@ per-run `run_id`, and we reuse it. No new dependency (no ULID library).
   - `redteam/reports/recommendations.py` — `pipeline_metadata_param()`
   - `redteam/adaptive/tool_chaining.py` — `pipeline_metadata_param()`
 
-  Extending both `pipeline_metadata()` and `pipeline_metadata_param()` propagates
-  `evaluatorq_run_id` to all seven with **zero call-site edits**.
-- **Nested `evaluatorq()` is the execution engine.** Red team (`runner.py:2278`, `:2733`)
-  and simulation (`api.py` via `_simulate_via_evaluatorq`) route their datapoints through a
-  nested `evaluatorq()` call to inherit its auto-upload, OTel tracing, and result handling.
-  Each nested `evaluatorq()` opens its **own** `tracing_session` and mints its **own**
-  `run_id`, stamped on its `orq.job` / `orq.evaluation` spans as `orq.run_id`.
+  Extending both `pipeline_metadata()` and `pipeline_metadata_param()` propagates `evaluatorq_run_id` to all seven with **zero call-site edits**.
+- **Nested `evaluatorq()` is the execution engine.** Red team (`runner.py:2278`, `:2733`) and simulation (`api.py` via `_simulate_via_evaluatorq`) route their datapoints through a nested `evaluatorq()` call to inherit its auto-upload, OTel tracing, and result handling. Each nested `evaluatorq()` opens its **own** `tracing_session` and mints its **own** `run_id`, stamped on its `orq.job` / `orq.evaluation` spans as `orq.run_id`.
 
 ## Key architectural decisions (from review)
 
-1. **Do not touch `orq.run_id`.** It is set only in `tracing/spans.py`
-   (`with_job_span` / `with_evaluation_span`) — these are **evaluatorq-core** spans, emitted
-   by `evaluate()` and by the nested `evaluatorq()` calls. Renaming it would break a
-   documented public attribute for every `evaluate()` user, and would stamp the same
-   attribute name with different values across a run (the nested runs each mint their own).
-   Rule applied: attributes owned by evaluatorq-core stay; only red-teaming / agent-sim work
-   changes. So `spans.py` and `docs/tracing.md` are **not** edited.
+1. **Do not touch `orq.run_id`.** It is set only in `tracing/spans.py` (`with_job_span` / `with_evaluation_span`) — these are **evaluatorq-core** spans, emitted by `evaluate()` and by the nested `evaluatorq()` calls. Renaming it would break a documented public attribute for every `evaluate()` user, and would stamp the same attribute name with different values across a run (the nested runs each mint their own). Rule applied: attributes owned by evaluatorq-core stay; only red-teaming / agent-sim work changes. So `spans.py` and `docs/tracing.md` are **not** edited.
 
-2. **Correlation flows via the ContextVar, not a new `evaluatorq()` parameter.** Binding
-   `evaluatorq_run_id(run_id)` at the redteam/sim *outer* scope means the nested
-   `evaluatorq()`'s LLM and evaluator invocations inherit the value automatically — a
-   ContextVar set in an ancestor scope is visible in nested calls and is copied into child
-   tasks spawned inside the scope. No signature change to `evaluatorq()`. The "same attr,
-   different value" span problem is moot because decision (1) leaves `orq.run_id` alone; the
-   new `orq.evaluatorq_run_id` lives only on the red-team / sim **root** span.
+2. **Correlation flows via the ContextVar, not a new `evaluatorq()` parameter.** Binding `evaluatorq_run_id(run_id)` at the redteam/sim *outer* scope means the nested `evaluatorq()`'s LLM and evaluator invocations inherit the value automatically — a ContextVar set in an ancestor scope is visible in nested calls and is copied into child tasks spawned inside the scope. No signature change to `evaluatorq()`. The "same attr, different value" span problem is moot because decision (1) leaves `orq.run_id` alone; the new `orq.evaluatorq_run_id` lives only on the red-team / sim **root** span.
 
-3. **Every sim entrypoint gets a unique run_id.** The `run_id=''` sentinel in `generate()`
-   is a *manifest* no-save marker, unrelated to LLM tagging. A shared sim helper mints a real
-   `run_id` and binds the ContextVar at every entrypoint, so all generation-phase and
-   seeded-generator LLM calls are tagged. The manifest's `''` behavior is left untouched.
+3. **Every sim entrypoint gets a unique run_id.** The `run_id=''` sentinel in `generate()` is a *manifest* no-save marker, unrelated to LLM tagging. A shared sim helper mints a real `run_id` and binds the ContextVar at every entrypoint, so all generation-phase and seeded-generator LLM calls are tagged. The manifest's `''` behavior is left untouched.
 
 ## Design
 
 ### 1. `common/thread_context.py` — carry run_id on the same rail
 
 - Add `_run_id: ContextVar[str | None]` (mirror of `_pipeline`).
-- Add `evaluatorq_run_id(run_id)` — a sync `@contextmanager` that does
-  `token = _run_id.set(run_id)` / `try: yield ... finally: _run_id.reset(token)`, exactly
-  mirroring the existing `evaluatorq_pipeline` CM (so exception-path reset and nested-scope
-  restore-parent behavior match).
-- Extend **both** metadata functions to include `evaluatorq_run_id` when `_run_id` is set
-  (each key present only when its ContextVar is set):
+- Add `evaluatorq_run_id(run_id)` — a sync `@contextmanager` that does `token = _run_id.set(run_id)` / `try: yield ... finally: _run_id.reset(token)`, exactly mirroring the existing `evaluatorq_pipeline` CM (so exception-path reset and nested-scope restore-parent behavior match).
+- Extend **both** metadata functions to include `evaluatorq_run_id` when `_run_id` is set (each key present only when its ContextVar is set):
   - `pipeline_metadata()` → `{'evaluatorq_pipeline': ..., 'evaluatorq_run_id': ...}`
   - `pipeline_metadata_param()` → `{'metadata': {'evaluatorq_pipeline': ..., 'evaluatorq_run_id': ...}}`
   - Refactor `pipeline_metadata_param()` to wrap `pipeline_metadata()` so they cannot drift
     again: `md = pipeline_metadata(); return {'metadata': md} if md else {}`.
-- No `run_metadata_scope` helper. Setting the root-span attribute is a single guarded
-  statement inlined at each root-span site (below); it is not scoped state, so it does not
-  belong in a context manager.
+- No `run_metadata_scope` helper. Setting the root-span attribute is a single guarded statement inlined at each root-span site (below); it is not scoped state, so it does not belong in a context manager.
 - Export `evaluatorq_run_id` in `__all__`.
 
 ### 2. Bind the run_id at pipeline entry
 
-- **Red team** (`redteam/runner.py`, single site): after the root span opens
-  (`with with_redteam_span(...) as pipeline_span:`), inside the existing
-  `evaluatorq_pipeline('red_teaming')` scope:
+- **Red team** (`redteam/runner.py`, single site): after the root span opens (`with with_redteam_span(...) as pipeline_span:`), inside the existing `evaluatorq_pipeline('red_teaming')` scope:
   ```python
   if pipeline_span is not None and tracing_context.run_id:
       pipeline_span.set_attribute('orq.evaluatorq_run_id', tracing_context.run_id)
@@ -98,9 +57,7 @@ per-run `run_id`, and we reuse it. No new dependency (no ULID library).
   ```
   This binds the ContextVar for every child job task and the nested `evaluatorq()`.
 
-- **Simulation** (`simulation/api.py`): add one small module-local helper and use it at every
-  entrypoint (`simulate`, `generate_and_simulate`, `generate`, `generate_personas`,
-  `generate_persona`, `generate_scenarios`, `generate_scenario`):
+- **Simulation** (`simulation/api.py`): add one small module-local helper and use it at every entrypoint (`simulate`, `generate_and_simulate`, `generate`, `generate_personas`, `generate_persona`, `generate_scenarios`, `generate_scenario`):
   ```python
   @contextmanager
   def _sim_run_scope(run_id: str, span):
@@ -109,17 +66,11 @@ per-run `run_id`, and we reuse it. No new dependency (no ULID library).
       with evaluatorq_run_id(run_id):
           yield
   ```
-  Each entrypoint mints `run_id = uuid4().hex` (entries that don't already) and wraps its
-  dispatch/generation block in `with _sim_run_scope(run_id, pipeline_span):`. Wrapping at the
-  outer entry — not inside `_simulate_core` — is deliberate: it tags the generate phase and
-  the nested `evaluatorq()` too. The helper wraps the pure `evaluatorq_run_id` CM; it does not
-  reinvent it.
+  Each entrypoint mints `run_id = uuid4().hex` (entries that don't already) and wraps its dispatch/generation block in `with _sim_run_scope(run_id, pipeline_span):`. Wrapping at the outer entry — not inside `_simulate_core` — is deliberate: it tags the generate phase and the nested `evaluatorq()` too. The helper wraps the pure `evaluatorq_run_id` CM; it does not reinvent it.
 
 ### 3. Root-span attribute
 
-`orq.evaluatorq_run_id` is set only on the red-team root span (`with_redteam_span`) and the
-sim root spans (`with_simulation_span` pipeline spans), guarded on a truthy `run_id` and a
-non-None span. `orq.run_id` on `orq.job` / `orq.evaluation` spans is untouched (decision 1).
+`orq.evaluatorq_run_id` is set only on the red-team root span (`with_redteam_span`) and the sim root spans (`with_simulation_span` pipeline spans), guarded on a truthy `run_id` and a non-None span. `orq.run_id` on `orq.job` / `orq.evaluation` spans is untouched (decision 1).
 
 ## Naming
 
@@ -130,31 +81,21 @@ non-None span. `orq.run_id` on `orq.job` / `orq.evaluation` spans is untouched (
 
 ## Files touched
 
-- `src/evaluatorq/common/thread_context.py` — new ContextVar + `evaluatorq_run_id` CM;
-  extend `pipeline_metadata()`; refactor `pipeline_metadata_param()` to wrap it; `__all__`.
-- `src/evaluatorq/redteam/runner.py` — set root-span attr + bind `evaluatorq_run_id` around
-  dispatch (single site).
-- `src/evaluatorq/simulation/api.py` — `_sim_run_scope` helper + wrap every entrypoint;
-  mint `run_id` where entrypoints lack one.
+- `src/evaluatorq/common/thread_context.py` — new ContextVar + `evaluatorq_run_id` CM; extend `pipeline_metadata()`; refactor `pipeline_metadata_param()` to wrap it; `__all__`.
+- `src/evaluatorq/redteam/runner.py` — set root-span attr + bind `evaluatorq_run_id` around dispatch (single site).
+- `src/evaluatorq/simulation/api.py` — `_sim_run_scope` helper + wrap every entrypoint; mint `run_id` where entrypoints lack one.
 - `tests/unit/test_thread_context.py` — extend.
 - (No `tracing/spans.py`, no `docs/tracing.md` edits — decision 1.)
 
 ## Testing
 
-- Unit: inside `evaluatorq_run_id('r1')`, both `pipeline_metadata()` and
-  `pipeline_metadata_param()` contain `evaluatorq_run_id == 'r1'`; absent outside the scope;
-  combined with `evaluatorq_pipeline`, both keys present in both functions.
-- Unit: concurrency isolation — mirror the existing `test_concurrent_tasks_are_isolated`;
-  `asyncio.gather` two scopes with distinct run_ids, assert no leakage across tasks.
+- Unit: inside `evaluatorq_run_id('r1')`, both `pipeline_metadata()` and `pipeline_metadata_param()` contain `evaluatorq_run_id == 'r1'`; absent outside the scope; combined with `evaluatorq_pipeline`, both keys present in both functions.
+- Unit: concurrency isolation — mirror the existing `test_concurrent_tasks_are_isolated`; `asyncio.gather` two scopes with distinct run_ids, assert no leakage across tasks.
 - Unit: exception inside `evaluatorq_run_id(...)` still resets `_run_id` (no leak).
-- Integration-ish (mocked client): a red-team backend call and a sim call carry
-  `evaluatorq_run_id` in the request `metadata`; a call issued from within a nested
-  `evaluatorq()` inherits the same run_id.
-- Unit: `_sim_run_scope(run_id, span)` sets `orq.evaluatorq_run_id` on a fake span and binds
-  the ContextVar; with `span=None` or falsy `run_id` it no-ops the attribute and still binds.
+- Integration-ish (mocked client): a red-team backend call and a sim call carry `evaluatorq_run_id` in the request `metadata`; a call issued from within a nested `evaluatorq()` inherits the same run_id.
+- Unit: `_sim_run_scope(run_id, span)` sets `orq.evaluatorq_run_id` on a fake span and binds the ContextVar; with `span=None` or falsy `run_id` it no-ops the attribute and still binds.
 
 ## Out of scope
 
 - Core `evaluate()` invocation metadata (request is red-team + simulation only).
-- `orq.run_id` on job/evaluation spans, thread-id composition, and the manifest run_id
-  (incl. `generate()`'s `''` no-save sentinel) — all unchanged.
+- `orq.run_id` on job/evaluation spans, thread-id composition, and the manifest run_id (incl. `generate()`'s `''` no-save sentinel) — all unchanged.

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,10 +1,8 @@
 # Tuning: timeouts, retries and reasoning effort
 
-Every knob on this page has a working default. Reach for it when a run is slow,
-flaky, or spending more than you want — not before.
+Every knob on this page has a working default. Reach for it when a run is slow, flaky, or spending more than you want — not before.
 
-The knobs split into three groups, and confusing them is the usual source of a
-setting that "does nothing":
+The knobs split into three groups, and confusing them is the usual source of a setting that "does nothing":
 
 | Group | What it governs | Where it lives |
 |---|---|---|
@@ -14,9 +12,7 @@ setting that "does nothing":
 
 ## Reasoning effort: three different things
 
-Four separate settings carry the words "reasoning effort", and they apply to
-four different models. Setting the wrong one is silent — the call simply runs at
-the default.
+Four separate settings carry the words "reasoning effort", and they apply to four different models. Setting the wrong one is silent — the call simply runs at the default.
 
 | You want to change | Use | Applies to |
 |---|---|---|
@@ -42,35 +38,16 @@ await red_team(
 )
 ```
 
-Accepted values differ per model, and evaluatorq does not guess: the value is
-forwarded verbatim and the **provider** is the authority. An unsupported value
-comes back as a 400, which the executors turn into a drop-the-block-and-retry-once
-— the call succeeds without reasoning rather than failing, and the rejection is
-remembered for the rest of the process so later calls to the same model skip the
-block up front.
+Accepted values differ per model, and evaluatorq does not guess: the value is forwarded verbatim and the **provider** is the authority. An unsupported value comes back as a 400, which the executors turn into a drop-the-block-and-retry-once — the call succeeds without reasoning rather than failing, and the rejection is remembered for the rest of the process so later calls to the same model skip the block up front.
 
-Reasoning effort reaches the target only on **Responses-capable** targets
-(`agent:<key>` on the Orq router). A `deployment:` target executes via
-the ORQ SDK agents endpoint, which has no reasoning parameter; a callable target
-or a Vercel endpoint has nowhere to put it either. In each of those cases the
-setting is accepted, a warning names the drop, and the run proceeds.
+Reasoning effort reaches the target only on **Responses-capable** targets (`agent:<key>` on the Orq router). A `deployment:` target executes via the ORQ SDK agents endpoint, which has no reasoning parameter; a callable target or a Vercel endpoint has nowhere to put it either. In each of those cases the setting is accepted, a warning names the drop, and the run proceeds.
 
 !!! tip "Pre-validate against the catalogue"
-    The model catalogue publishes the accepted reasoning-effort values per model.
-    A model the catalogue does not list cannot be pre-validated — register it with
-    `register_model()` to fix that. See
-    [Configuration › Model catalogue overrides](configuration.md#model-catalogue-overrides).
+    The model catalogue publishes the accepted reasoning-effort values per model. A model the catalogue does not list cannot be pre-validated — register it with `register_model()` to fix that. See [Configuration › Model catalogue overrides](configuration.md#model-catalogue-overrides).
 
-`EVALUATORQ_REASONING_EFFORT` is **unset by default**, and unset means the parameter
-is not sent at all — the model applies its own default. There is deliberately no
-global effort: sending one costs a rejected request plus a retry on every model that
-does not accept the parameter, and overrides the tuned default on every model that
-does. Set it only when you want a specific effort across the simulator's own calls.
+`EVALUATORQ_REASONING_EFFORT` is **unset by default**, and unset means the parameter is not sent at all — the model applies its own default. There is deliberately no global effort: sending one costs a rejected request plus a retry on every model that does not accept the parameter, and overrides the tuned default on every model that does. Set it only when you want a specific effort across the simulator's own calls.
 
-It is read **at call time**, not at import, and it is only a fallback: an explicitly
-set `LLMCallConfig.reasoning_effort` on the agent's config always wins — including an
-explicit `None`, which opts that agent out of the env value on purpose. The same is
-true of `EVALUATORQ_LLM_TIMEOUT_S` and `EVALUATORQ_LLM_MAX_TOKENS`.
+It is read **at call time**, not at import, and it is only a fallback: an explicitly set `LLMCallConfig.reasoning_effort` on the agent's config always wins — including an explicit `None`, which opts that agent out of the env value on purpose. The same is true of `EVALUATORQ_LLM_TIMEOUT_S` and `EVALUATORQ_LLM_MAX_TOKENS`.
 
 ## Temperature
 
@@ -88,8 +65,7 @@ The same holds per call: a `temperature=None` argument means "leave it unset", n
 
 ## Target-call reliability
 
-The target is the slow, flaky part of any run: it is a real agent running real
-tools. Four knobs bound it.
+The target is the slow, flaky part of any run: it is a real agent running real tools. Four knobs bound it.
 
 === "Red teaming"
 
@@ -139,18 +115,9 @@ tools. Four knobs bound it.
 | `max_tool_continuations` / `--max-tool-continuations` | `5` | An Orq agent needs more client-driven tool-result rounds than five to finish a turn |
 | `per_simulation_timeout_s` (simulation, Python only) | `None` — unbounded | A conversation can stall in a loop. Without it, only the per-call timeouts apply |
 
-`per_simulation_timeout_s` is a wall clock over **one whole datapoint** — every
-turn, plus the user-simulator and judge calls. On expiry the simulation does not
-raise: it returns a partial result with `terminated_by="timeout"` and the turns it
-completed, and logs a warning naming the budget. Set it on any unattended run;
-`simulate()` calls the runner once per row and is otherwise unbounded. `None` is
-the only spelling of unbounded — `0` is rejected at construction rather than read
-as "no bound".
+`per_simulation_timeout_s` is a wall clock over **one whole datapoint** — every turn, plus the user-simulator and judge calls. On expiry the simulation does not raise: it returns a partial result with `terminated_by="timeout"` and the turns it completed, and logs a warning naming the budget. Set it on any unattended run; `simulate()` calls the runner once per row and is otherwise unbounded. `None` is the only spelling of unbounded — `0` is rejected at construction rather than read as "no bound".
 
-`max_tool_result_chars` (default `500`) caps each tool result rendered into the
-text the user simulator sees on a tool-only turn. Raise it for a tool-heavy agent
-whose results are being cut before the simulator — and the judge, which scores the
-same transcript — can react to them.
+`max_tool_result_chars` (default `500`) caps each tool result rendered into the text the user simulator sees on a tool-only turn. Raise it for a tool-heavy agent whose results are being cut before the simulator — and the judge, which scores the same transcript — can react to them.
 
 ## Pipeline-call reliability
 
@@ -166,35 +133,18 @@ These bound evaluatorq's own LLM calls, not the target's.
 | `LLMCallConfig.timeout_ms` | `90000` | Per-call timeout for a pipeline role |
 
 !!! warning "One retry layer, including on a client you inject"
-    SDK-level retries and evaluatorq's own retries would **multiply** — five
-    evaluatorq attempts over a client doing two SDK retries is fifteen requests,
-    not five. So the helpers that wrap a call in evaluatorq's retry loop disarm
-    the SDK budget first: both `common.judge` and `common.structured_output`'s
-    `generate_structured` clone the client with `max_retries=0` before their
-    first attempt. The clone reuses your transport, auth, base URL, headers and
-    timeout, and your own client object is never mutated — so you do not need to
-    pass `max_retries=0` on a client you inject, and configuring SDK retries on
-    it does not stack.
+    SDK-level retries and evaluatorq's own retries would **multiply** — five evaluatorq attempts over a client doing two SDK retries is fifteen requests, not five. So the helpers that wrap a call in evaluatorq's retry loop disarm the SDK budget first: both `common.judge` and `common.structured_output`'s `generate_structured` clone the client with `max_retries=0` before their first attempt. The clone reuses your transport, auth, base URL, headers and timeout, and your own client object is never mutated — so you do not need to pass `max_retries=0` on a client you inject, and configuring SDK retries on it does not stack.
 
-    What you configure instead is the evaluatorq layer: `LLMConfig.retry_count`
-    and `LLMConfig.retry_on_codes` in the table above.
+    What you configure instead is the evaluatorq layer: `LLMConfig.retry_count` and `LLMConfig.retry_on_codes` in the table above.
 
 Two knobs govern cost rather than reliability, because each unit is a live call:
 
-- `LLMConfig.max_objectives_per_llm_call` (default `8`) — objectives requested per
-  attacker call before the generator batches into multiple calls. Raising it asks
-  for more output tokens per call; roughly 150 tokens per objective is what keeps
-  the default from truncating.
-- `LLMConfig.max_probe_turns` (default `8`) — probe turns the black-box classifier
-  may send before giving up on capability inference. Each turn is a live call
-  **against the target**.
+- `LLMConfig.max_objectives_per_llm_call` (default `8`) — objectives requested per attacker call before the generator batches into multiple calls. Raising it asks for more output tokens per call; roughly 150 tokens per objective is what keeps the default from truncating.
+- `LLMConfig.max_probe_turns` (default `8`) — probe turns the black-box classifier may send before giving up on capability inference. Each turn is a live call **against the target**.
 
 ## Provider options: `extra_kwargs` vs `extra_body`
 
-`extra_kwargs` is for provider options evaluatorq does not model — `top_p`,
-`store`, `truncation`, `tool_choice`. It is merged **last**, so a caller-supplied
-value overrides evaluatorq's computed one. That ordering is also the escape hatch
-for reasoning-class models that reject a lowered temperature:
+`extra_kwargs` is for provider options evaluatorq does not model — `top_p`, `store`, `truncation`, `tool_choice`. It is merged **last**, so a caller-supplied value overrides evaluatorq's computed one. That ordering is also the escape hatch for reasoning-class models that reject a lowered temperature:
 
 ```python
 from evaluatorq.contracts import LLMCallConfig
@@ -202,11 +152,7 @@ from evaluatorq.contracts import LLMCallConfig
 cfg = LLMCallConfig(model="openai/gpt-5.6-luna", extra_kwargs={"top_p": 0.9})
 ```
 
-Structural request fields are **reserved** and raise `ValueError` if they appear in
-`extra_kwargs`: `model`, `messages` / `input`, `response_format` / `text`, and
-`extra_body`. Letting `extra_kwargs` silently replace one of those would break the
-call it rides on — dropping a required JSON schema, or replacing the Orq router's
-thread and memory body wholesale.
+Structural request fields are **reserved** and raise `ValueError` if they appear in `extra_kwargs`: `model`, `messages` / `input`, `response_format` / `text`, and `extra_body`. Letting `extra_kwargs` silently replace one of those would break the call it rides on — dropping a required JSON schema, or replacing the Orq router's thread and memory body wholesale.
 
 ```python
 # WRONG — raises ValueError: extra_kwargs cannot override structural request fields
@@ -215,14 +161,9 @@ LLMCallConfig(extra_kwargs={"extra_body": {"my": "option"}}).request_params()
 
 ### Adding fields to the request body
 
-`extra_body` is the seam for options that belong in the HTTP **body** rather than
-as a top-level SDK argument — what the Orq router uses for its retry policy and
-for thread and memory ids. It is a first-class `LLMCallConfig` field and a
-dedicated parameter on the `common.llm_call` executors; it is never an
-`extra_kwargs` key.
+`extra_body` is the seam for options that belong in the HTTP **body** rather than as a top-level SDK argument — what the Orq router uses for its retry policy and for thread and memory ids. It is a first-class `LLMCallConfig` field and a dedicated parameter on the `common.llm_call` executors; it is never an `extra_kwargs` key.
 
-It **merges into** the body the call site built, rather than replacing it. Your
-keys win per key, and the keys you did not set survive:
+It **merges into** the body the call site built, rather than replacing it. Your keys win per key, and the keys you did not set survive:
 
 ```python
 from evaluatorq.contracts import LLMCallConfig
@@ -233,23 +174,13 @@ cfg = LLMCallConfig(
 )
 ```
 
-A call that would otherwise send `{"retry": {"count": 3}, "thread": {"id": "..."}}`
-now sends that plus your `cache` key. Set `retry` yourself and yours wins, while
-`thread` is still there.
+A call that would otherwise send `{"retry": {"count": 3}, "thread": {"id": "..."}}` now sends that plus your `cache` key. Set `retry` yourself and yours wins, while `thread` is still there.
 
-That merge is the whole point. `extra_kwargs={"extra_body": ...}` used to *replace*
-the body, so adding one unrelated field silently dropped the router's retry hints
-with no error and no log line — which is why the key is reserved there and raises.
+That merge is the whole point. `extra_kwargs={"extra_body": ...}` used to *replace* the body, so adding one unrelated field silently dropped the router's retry hints with no error and no log line — which is why the key is reserved there and raises.
 
-So there are exactly two injection seams, and they target different parts of the
-request: `extra_kwargs` for top-level call arguments, `extra_body` for body fields.
-Anything the provider accepts is reachable through one of them — wherever you can
-hand evaluatorq an `LLMCallConfig`. The jury evaluators (`llm_jury()`,
-`llm_jury_pairwise()`, `PairwiseComparator`) build their config internally, so
-they take both as explicit parameters instead.
+So there are exactly two injection seams, and they target different parts of the request: `extra_kwargs` for top-level call arguments, `extra_body` for body fields. Anything the provider accepts is reachable through one of them — wherever you can hand evaluatorq an `LLMCallConfig`. The jury evaluators (`llm_jury()`, `llm_jury_pairwise()`, `PairwiseComparator`) build their config internally, so they take both as explicit parameters instead.
 
-Sampling fields have first-class parameters now — prefer them over routing the
-same key through `extra_kwargs`:
+Sampling fields have first-class parameters now — prefer them over routing the same key through `extra_kwargs`:
 
 | Instead of | Use |
 |---|---|
@@ -257,12 +188,7 @@ same key through `extra_kwargs`:
 | `extra_kwargs={"max_completion_tokens": 4000}` | `LLMCallConfig(max_tokens=4000)` |
 | `extra_kwargs={"temperature": 0.2}` | `LLMCallConfig(temperature=0.2)` |
 
-`LLMCallConfig` renders those per endpoint for you through a single builder,
-`request_params(api=None, **params)`: it defaults to `self.api`, or renders
-whichever endpoint you pass explicitly (a call site that only speaks one
-endpoint passes `api="chat_completions"` or `api="responses"`). On chat
-completions it emits `max_completion_tokens` and a flat `reasoning_effort`; on
-Responses it emits `max_output_tokens` and `reasoning={"effort": ...}`.
+`LLMCallConfig` renders those per endpoint for you through a single builder, `request_params(api=None, **params)`: it defaults to `self.api`, or renders whichever endpoint you pass explicitly (a call site that only speaks one endpoint passes `api="chat_completions"` or `api="responses"`). On chat completions it emits `max_completion_tokens` and a flat `reasoning_effort`; on Responses it emits `max_output_tokens` and `reasoning={"effort": ...}`.
 
 ## Where to next
 

--- a/docs/wireframe/dashboard-gap-analysis.md
+++ b/docs/wireframe/dashboard-gap-analysis.md
@@ -1,9 +1,6 @@
 # Dashboard gap analysis — design mockup vs current build
 
-Source: design HTML at `~/Downloads/Evaluatorq Dashboard.html`, rendered via
-agent-browser + decoded React/JSX source, diffed against the FastHTML build.
-Reconstructed 2026-07-09 from the session transcript — treat status markers as of
-that date.
+Source: design HTML at `~/Downloads/Evaluatorq Dashboard.html`, rendered via agent-browser + decoded React/JSX source, diffed against the FastHTML build. Reconstructed 2026-07-09 from the session transcript — treat status markers as of that date.
 
 Screenshots in this dir (`design_*.png` = mockup, `live_*.png` = our build):
 
@@ -17,20 +14,13 @@ Screenshots in this dir (`design_*.png` = mockup, `live_*.png` = our build):
 
 ## ✅ Closed
 - **KPI band**: Jobs run · Avg cost/job · Total spend · Total tokens — exact match.
-- **Red Team & Agent Sim lists**: `Job · Target · Status · Score · Cases · Cost`,
-  run-level rows (one file = one run), model/target pill with dot.
-- **Landing "Recent runs"**: run list with a Type column (no red bubble) — matches
-  the design's `RunsList`.
+- **Red Team & Agent Sim lists**: `Job · Target · Status · Score · Cases · Cost`, run-level rows (one file = one run), model/target pill with dot.
+- **Landing "Recent runs"**: run list with a Type column (no red bubble) — matches the design's `RunsList`.
 - Removed the attack-resistance donut + Agent-sim tile.
-- **Row detail**: whole-row clickable → run detail; chevron affordance; target
-  always the real agent/deployment name (never generic "Orq agent"); target-kind
-  icons (agent/llm-sparkles/deployment) in orq green.
-- **Status = lifecycle** (Finished / Error), Score keeps the quality grade — kills
-  the quality/lifecycle conflation.
-- **Red Team report tabs** folded (Error Analysis kept standalone); **Agent Sim
-  tabs** folded.
-- Red Team KPI: `Break rate` → **ASR**, robustness card dropped, **Total spend**
-  in the freed slot.
+- **Row detail**: whole-row clickable → run detail; chevron affordance; target always the real agent/deployment name (never generic "Orq agent"); target-kind icons (agent/llm-sparkles/deployment) in orq green.
+- **Status = lifecycle** (Finished / Error), Score keeps the quality grade — kills the quality/lifecycle conflation.
+- **Red Team report tabs** folded (Error Analysis kept standalone); **Agent Sim tabs** folded.
+- Red Team KPI: `Break rate` → **ASR**, robustness card dropped, **Total spend** in the freed slot.
 
 ## 🔴 Gaps remaining
 
@@ -43,14 +33,11 @@ Screenshots in this dir (`design_*.png` = mockup, `live_*.png` = our build):
 | Spend by stage (target/eval/generation) | Spend by job type |
 | Spend by job type | Token usage |
 
-Design frames the landing around **cost + eval pass-rate**; ours around **runs +
-findings**. Biggest visual divergence. Spend-by-provider / spend-by-stage need
-provider/stage tags we don't record yet.
+Design frames the landing around **cost + eval pass-rate**; ours around **runs + findings**. Biggest visual divergence. Spend-by-provider / spend-by-stage need provider/stage tags we don't record yet.
 
 **2. Report views — largest gap.**
 
-*Red Team* — design tabs: `Overview · Agents · Focus areas · Breakdowns ·
-Multi-turn · Attacks · Config`. Missing on our side:
+*Red Team* — design tabs: `Overview · Agents · Focus areas · Breakdowns · Multi-turn · Attacks · Config`. Missing on our side:
 - Executive summary callout + confidence pill
 - 5-card KPI band (Attacks run · Vulnerabilities · ASR · Resistance · Critical)
 - **Agents tab**: system-map topology graph + per-agent **ASR dials**
@@ -58,14 +45,9 @@ Multi-turn · Attacks · Config`. Missing on our side:
 - **Right-side filter rail** (Outcome/Severity/Turn-type/Category/Agent), persistent across tabs
 - **Attacks tab**: expandable rows → evaluator verdict + transcript
 
-*Agent Sim* — design tabs: `Overview · Breakdown · Transcripts · Turn quality ·
-Config`. Missing: 5-card KPI band, exec summary, persona trait bars / scenario
-criteria panels, filter rail (Goal outcome/Persona/Scenario/Terminated-by).
+*Agent Sim* — design tabs: `Overview · Breakdown · Transcripts · Turn quality · Config`. Missing: 5-card KPI band, exec summary, persona trait bars / scenario criteria panels, filter rail (Goal outcome/Persona/Scenario/Terminated-by).
 
-**3. Eval run detail screen** — design has a per-eval-run view (Score breakdown
-per-evaluator bars + Trace span timeline). **Verdict: ignore it** — it's a
-coded-but-unreachable view in the mockup (no "Evals" nav item, and the recent-runs
-list filters out eval runs, so nothing reaches it).
+**3. Eval run detail screen** — design has a per-eval-run view (Score breakdown per-evaluator bars + Trace span timeline). **Verdict: ignore it** — it's a coded-but-unreachable view in the mockup (no "Evals" nav item, and the recent-runs list filters out eval runs, so nothing reaches it).
 
 ## ⚪ Where we're ahead of the mockup
 - ⌘K global search — not in the design.
@@ -75,25 +57,17 @@ list filters out eval runs, so nothing reaches it).
 ## What the design DROPS that we should keep
 
 Adopting the design wholesale would lose analysis the mockup has no equivalent for:
-- **Jury / judge disagreement** (disagreement viewer + agent heatmap) — where the
-  3 judges disagreed. Key for trusting a verdict.
+- **Jury / judge disagreement** (disagreement viewer + agent heatmap) — where the 3 judges disagreed. Key for trusting a verdict.
 - **Error Analysis** tab — failure taxonomy. Design shows only an error *count*.
 - **Source distribution** — datapoint provenance (static vs generated).
 - **Token Usage** as a first-class tab.
 - **Methodology depth** — severity definitions + agent-context.
 - **Judge verdicts / reliability** (sim evaluators + judge/errors tabs).
 
-Net: design is prettier for a *first read*; ours is better for *debugging why a
-score is what it is*. **Direction: adopt the design's shell** (tabs, KPI band,
-exec summary, filter rail) **but keep** the disagreement / error-analysis / source
-panels as tabs rather than deleting them.
+Net: design is prettier for a *first read*; ours is better for *debugging why a score is what it is*. **Direction: adopt the design's shell** (tabs, KPI band, exec summary, filter rail) **but keep** the disagreement / error-analysis / source panels as tabs rather than deleting them.
 
 ## Recommendation (priority order)
-1. **Report KPI bands + exec summary** — most visible report gap, computable from
-   data we already surface.
-2. **Filter rails** on both reports — big UX piece; filter infra (`filters.py`)
-   already exists.
-3. **Landing chart set** — decide: keep runs/findings framing or adopt the
-   design's cost/pass-rate framing (needs provider/stage data).
-4. **Agents topology / ASR dials / Focus-area risk dials** — largest build; several
-   need data (multi-agent handoffs, per-provider spend) that reports may not carry yet.
+1. **Report KPI bands + exec summary** — most visible report gap, computable from data we already surface.
+2. **Filter rails** on both reports — big UX piece; filter infra (`filters.py`) already exists.
+3. **Landing chart set** — decide: keep runs/findings framing or adopt the design's cost/pass-rate framing (needs provider/stage data).
+4. **Agents topology / ASR dials / Focus-area risk dials** — largest build; several need data (multi-agent handoffs, per-provider spend) that reports may not carry yet.

--- a/docs/wireframe/visual-validation-pitfalls.md
+++ b/docs/wireframe/visual-validation-pitfalls.md
@@ -1,66 +1,30 @@
 # Visual validation — how to not fool yourself
 
-Hard-won checklist for comparing a **live rendered UI** against a **design mockup**
-(both are real DOM). Written after several false "it matches" verdicts. Share this
-with any agent doing pixel/parity work.
+Hard-won checklist for comparing a **live rendered UI** against a **design mockup** (both are real DOM). Written after several false "it matches" verdicts. Share this with any agent doing pixel/parity work.
 
 ## The one rule
 
-**Measure the DOM numerically. Do not eyeball scale.** Screenshots lie about size;
-`getBoundingClientRect` + `getComputedStyle` do not. Use screenshots only for
-gestalt (layout, color, overall feel), never to judge whether two things are the
-same size.
+**Measure the DOM numerically. Do not eyeball scale.** Screenshots lie about size; `getBoundingClientRect` + `getComputedStyle` do not. Use screenshots only for gestalt (layout, color, overall feel), never to judge whether two things are the same size.
 
 ## The traps (each one caused a real miss)
 
-1. **Zoom illusion.** A user-supplied crop is often zoomed (e.g. 1.7×). Eyeballing
-   it makes elements look huge. NEVER size-match against a crop — measure the
-   actual rendered element instead.
+1. **Zoom illusion.** A user-supplied crop is often zoomed (e.g. 1.7×). Eyeballing it makes elements look huge. NEVER size-match against a crop — measure the actual rendered element instead.
 
-2. **Downscaled full-page compare.** Feeding two different-width full-page PNGs to a
-   verifier normalizes scale in the reader's eye — a shrunk component reads as
-   "same, just fewer cells." Always screenshot **element-scoped, at natural scale**
-   (`screenshot "#selector"`), never a downscaled full page.
+2. **Downscaled full-page compare.** Feeding two different-width full-page PNGs to a verifier normalizes scale in the reader's eye — a shrunk component reads as "same, just fewer cells." Always screenshot **element-scoped, at natural scale** (`screenshot "#selector"`), never a downscaled full page.
 
-3. **Measured the content, missed the chrome.** The worst miss: I measured heatmap
-   *cell* size/font/radius and declared a match — but the table had an inherited
-   **border, white background, 10px radius, a header underline, a row-label divider,
-   and a zebra stripe** that the mockup didn't have. **Measure the CONTAINER, not
-   just the content:** border, background, border-radius, box-shadow, padding,
-   margin, gap/border-spacing, per-side cell borders, dividers, and
-   hover/zebra/nth-child states.
+3. **Measured the content, missed the chrome.** The worst miss: I measured heatmap *cell* size/font/radius and declared a match — but the table had an inherited **border, white background, 10px radius, a header underline, a row-label divider, and a zebra stripe** that the mockup didn't have. **Measure the CONTAINER, not just the content:** border, background, border-radius, box-shadow, padding, margin, gap/border-spacing, per-side cell borders, dividers, and hover/zebra/nth-child states.
 
-4. **Global CSS bleed.** Your component inherits from global `table` / `th` /
-   `tr:nth-child(even)` / `:hover` rules you didn't write. Scoping your own
-   `.component` CSS does NOT remove them. Explicitly query what the live element
-   actually computes (border, bg, radius, borderBottom) and override every global
-   rule that leaks in.
+4. **Global CSS bleed.** Your component inherits from global `table` / `th` / `tr:nth-child(even)` / `:hover` rules you didn't write. Scoping your own `.component` CSS does NOT remove them. Explicitly query what the live element actually computes (border, bg, radius, borderBottom) and override every global rule that leaks in.
 
-5. **Data-driven ≠ style gap — but don't hide behind it.** Different datasets
-   (longer labels, fewer rows, different numbers) legitimately change size and
-   layout. Note those as data-driven. But do NOT use "it's just data" to wave away a
-   real scale or chrome difference — that rationalization is how the border miss
-   survived.
+5. **Data-driven ≠ style gap — but don't hide behind it.** Different datasets (longer labels, fewer rows, different numbers) legitimately change size and layout. Note those as data-driven. But do NOT use "it's just data" to wave away a real scale or chrome difference — that rationalization is how the border miss survived.
 
-6. **Specified vs rendered weight.** `getComputedStyle` returns the *specified*
-   `font-weight` (e.g. 600) even when the font only ships 400/700 and actually
-   renders 700. CSS weight 500–600 rounds UP to 700 when only 400/700 exist. So a
-   "600 vs 700" diff may render identically. Know this before "fixing" it.
+6. **Specified vs rendered weight.** `getComputedStyle` returns the *specified* `font-weight` (e.g. 600) even when the font only ships 400/700 and actually renders 700. CSS weight 500–600 rounds UP to 700 when only 400/700 exist. So a "600 vs 700" diff may render identically. Know this before "fixing" it.
 
-7. **Stale DOM after navigation.** After clicking an SPA tab, the `innerText` you
-   slice may be the *previous* panel. I concluded "the tab didn't switch" when it
-   had. Re-query fresh and confirm the switch via a content marker before measuring.
+7. **Stale DOM after navigation.** After clicking an SPA tab, the `innerText` you slice may be the *previous* panel. I concluded "the tab didn't switch" when it had. Re-query fresh and confirm the switch via a content marker before measuring.
 
-8. **Server-side CSS caching.** Editing the stylesheet source did NOT change the
-   running app — CSS was baked at server startup. A browser hard-reload isn't
-   enough; **restart the server** (or rely on real hot-reload) before re-measuring.
-   Verify the new value landed, don't assume.
+8. **Server-side CSS caching.** Editing the stylesheet source did NOT change the running app — CSS was baked at server startup. A browser hard-reload isn't enough; **restart the server** (or rely on real hot-reload) before re-measuring. Verify the new value landed, don't assume.
 
-9. **Sloppy element selection.** A broad selector for "the panel title" grabbed a
-   full-width *container* (height 297px) instead of the title span. Before trusting
-   any metric, sanity-check the matched element's bounding box is tight/plausible.
-   The mockup uses different class names — query **its** elements by CONTENT (e.g.
-   the node whose text matches `/^\d{1,3}%$/`) and pick the smallest match.
+9. **Sloppy element selection.** A broad selector for "the panel title" grabbed a full-width *container* (height 297px) instead of the title span. Before trusting any metric, sanity-check the matched element's bounding box is tight/plausible. The mockup uses different class names — query **its** elements by CONTENT (e.g. the node whose text matches `/^\d{1,3}%$/`) and pick the smallest match.
 
 10. **Screenshot hover artifacts.** The cursor sitting over an element adds a
     `:hover` tint to the screenshot that looks like a real style. Check computed
@@ -85,20 +49,11 @@ same size.
 
 For each component:
 
-1. **Measure both DOMs.** Extract for the signature element AND its container:
-   dimensions, font-size/weight/family/text-transform/letter-spacing, color,
-   background, border (all sides), border-radius, padding, gap/border-spacing,
-   box-shadow. Query the mockup by content; query live by class.
-2. **Diff the numbers** against explicit thresholds: font-size delta > ~2px,
-   dimension delta > ~25% not explained by data, ANY mismatch in
-   border/background/radius/shadow/case/family-class/alignment = gap.
+1. **Measure both DOMs.** Extract for the signature element AND its container: dimensions, font-size/weight/family/text-transform/letter-spacing, color, background, border (all sides), border-radius, padding, gap/border-spacing, box-shadow. Query the mockup by content; query live by class.
+2. **Diff the numbers** against explicit thresholds: font-size delta > ~2px, dimension delta > ~25% not explained by data, ANY mismatch in border/background/radius/shadow/case/family-class/alignment = gap.
 3. **Element-scoped natural-scale screenshots** of both for layout/color/gestalt.
-4. **Fix**, restart the server, **re-measure** (confirm the value changed), fresh
-   verifier confirms. Loop until the numbers match.
+4. **Fix**, restart the server, **re-measure** (confirm the value changed), fresh verifier confirms. Loop until the numbers match.
 
 ## What to always inspect on a container
 
-`border` (4 sides) · `background` · `border-radius` · `box-shadow` · `padding` ·
-`margin` · `gap` / `border-spacing` · child-cell borders/dividers · `:hover` ·
-`:nth-child` zebra · overflow/clip. Content typography is necessary but never
-sufficient.
+`border` (4 sides) · `background` · `border-radius` · `box-shadow` · `padding` · `margin` · `gap` / `border-spacing` · child-cell borders/dividers · `:hover` · `:nth-child` zebra · overflow/clip. Content typography is necessary but never sufficient.

--- a/examples/agent_simulation/README.md
+++ b/examples/agent_simulation/README.md
@@ -68,13 +68,9 @@ When `ORQ_API_KEY` is set, the run also prints an Experiment URL on `my.orq.ai`.
 
 ## External agent frameworks
 
-Agent Simulation is framework-agnostic: any agent that implements the unified
-`AgentTarget` protocol (`async respond(messages) -> AgentResponse`) runs through
-the same three-part loop (user simulator -> agent under test -> judge). Pass the
-target via `target=` to `simulate()` / `generate_and_simulate()`.
+Agent Simulation is framework-agnostic: any agent that implements the unified `AgentTarget` protocol (`async respond(messages) -> AgentResponse`) runs through the same three-part loop (user simulator -> agent under test -> judge). Pass the target via `target=` to `simulate()` / `generate_and_simulate()`.
 
-Examples 06-09 show the four supported frameworks. Each adapter handles that
-framework's quirks:
+Examples 06-09 show the four supported frameworks. Each adapter handles that framework's quirks:
 
 | Framework | Adapter | Quirks handled |
 |-----------|---------|----------------|
@@ -83,10 +79,7 @@ framework's quirks:
 | Pydantic AI | `PydanticAITarget` | Threads typed `message_history` internally; tool calls extracted from message parts; usage has no total (derived) |
 | CrewAI | `CrewAITarget` | Sync `kickoff` run off-thread; transcript flattened to one `{conversation}` input; final crew output is "the response" |
 
-**Demo recordings** — each runs its example end to end (user simulator → agent
-→ judge). Embedded players live in the
-[Agent Simulation guide](../../docs/guides/agent-simulation.md#external-framework-demos);
-the raw files:
+**Demo recordings** — each runs its example end to end (user simulator → agent → judge). Embedded players live in the [Agent Simulation guide](../../docs/guides/agent-simulation.md#external-framework-demos); the raw files:
 
 | Framework | Recording |
 |-----------|-----------|
@@ -106,9 +99,7 @@ from evaluatorq.simulation import simulate
 results = await simulate(target=LangGraphTarget(graph=graph), personas=[...], scenarios=[...])
 ```
 
-Custom framework not listed? Wrap any `fn(messages) -> str` with
-`CallableTarget` (`evaluatorq.integrations.callable_integration`), or pass a
-plain `target` callable.
+Custom framework not listed? Wrap any `fn(messages) -> str` with `CallableTarget` (`evaluatorq.integrations.callable_integration`), or pass a plain `target` callable.
 
 ## Environment
 

--- a/examples/agent_simulation/webinar_demo/README.md
+++ b/examples/agent_simulation/webinar_demo/README.md
@@ -2,15 +2,11 @@
 
 Working dir for the agent-simulation webinar: slides + runnable demo.
 
-Structure mirrors the red-teaming demos (`../../redteam/refund_agent_demo`,
-`../../redteam/crypto_stealing_demo`): a self-contained HTML deck plus a runnable
-agent the deck demos live. The presentation theme/assets follow the orq brand
-(teal `#025558`, orange `q`).
+Structure mirrors the red-teaming demos (`../../redteam/refund_agent_demo`, `../../redteam/crypto_stealing_demo`): a self-contained HTML deck plus a runnable agent the deck demos live. The presentation theme/assets follow the orq brand (teal `#025558`, orange `q`).
 
 ## Start here
 
-Everything below needs an Orq API key for the workspace that will host the demo.
-Export it first (or copy `agent_build/.env.example` to `agent_build/.env` and fill it in):
+Everything below needs an Orq API key for the workspace that will host the demo. Export it first (or copy `agent_build/.env.example` to `agent_build/.env` and fill it in):
 
 ```bash
 export ORQ_API_KEY="sk-orq-..."     # the banking / CustomerDemo workspace key
@@ -26,9 +22,7 @@ make simulate       # run simulations against it
 
 ## Status
 
-The runnable webinar materials are ready: `webinar-deck.html` is the presentation
-deck and `webinar-script.html` is the speaker run-of-show. `RUNBOOK.md` contains
-the terminal flow and the known platform-dependent gaps.
+The runnable webinar materials are ready: `webinar-deck.html` is the presentation deck and `webinar-script.html` is the speaker run-of-show. `RUNBOOK.md` contains the terminal flow and the known platform-dependent gaps.
 
 - **`RUNBOOK.md`** — the live-demo script: 4 Acts, real commands, gaps to call out.
 - **`webinar-deck.html`** — the self-contained presentation deck.
@@ -48,11 +42,7 @@ open webinar-deck.html
 
 ## Demo agent
 
-The spine is **Sterling**, the **Bank of Holland credit-card support
-agent** — `openai/gpt-5.6-luna`, a 99-question Dutch/English FAQ knowledge base, and two
-code tools (`get_card_info`, `get_transaction_details`). `make provision` recreates it
-(and its tools + KB) in Orq from the definitions in `agent_build/`, using distinct demo
-keys so it never clobbers the customer's live entities.
+The spine is **Sterling**, the **Bank of Holland credit-card support agent** — `openai/gpt-5.6-luna`, a 99-question Dutch/English FAQ knowledge base, and two code tools (`get_card_info`, `get_transaction_details`). `make provision` recreates it (and its tools + KB) in Orq from the definitions in `agent_build/`, using distinct demo keys so it never clobbers the customer's live entities.
 
 ```
 agent_build/
@@ -62,9 +52,7 @@ agent_build/
   orq_export/             # agent + tool + KB definitions exported from the platform
 ```
 
-Run the demo flow with the Makefile: `make provision`, then `make generate`,
-`make simulate`, `make rerun`, `make upload`. See **`RUNBOOK.md`** for the narrated
-version with what each step demonstrates.
+Run the demo flow with the Makefile: `make provision`, then `make generate`, `make simulate`, `make rerun`, `make upload`. See **`RUNBOOK.md`** for the narrated version with what each step demonstrates.
 
 ## Prereqs
 

--- a/examples/agent_simulation/webinar_demo/RUNBOOK.md
+++ b/examples/agent_simulation/webinar_demo/RUNBOOK.md
@@ -1,37 +1,19 @@
 # Runbook — Agent Simulation Webinar
 
-The live demo flow: ordered steps, exact commands, and what each one answers.
-Spine agent: **Sterling**, the **Bank of Holland credit-card Q&A agent** (`make provision` recreates it in
-the banking / CustomerDemo workspace). Platform ops (datasets, agents) use the
-**`orq` CLI**; the simulation engine is **`evaluatorq sim`** (the `orq` CLI has no
-simulation command — see Gaps §1).
+The live demo flow: ordered steps, exact commands, and what each one answers. Spine agent: **Sterling**, the **Bank of Holland credit-card Q&A agent** (`make provision` recreates it in the banking / CustomerDemo workspace). Platform ops (datasets, agents) use the **`orq` CLI**; the simulation engine is **`evaluatorq sim`** (the `orq` CLI has no simulation command — see Gaps §1).
 
 > Status: validated end-to-end against the real provisioned agent
 > (`sterling`). Set `ORQ_API_KEY` to the banking workspace key.
 
 ## Act 0 — Framing (open the talk, ~5 min)
 
-Cue bullets for the opening — say these before touching a terminal. The room may
-not know orq, the problem, or what "agent simulation" even means. (Fuller
-versions: webinar-script.html §01 open + §02 diagram + Q&A bank.)
+Cue bullets for the opening — say these before touching a terminal. The room may not know orq, the problem, or what "agent simulation" even means. (Fuller versions: webinar-script.html §01 open + §02 diagram + Q&A bank.)
 
-- **Who.** orq.ai = generative-AI collaboration platform: one control plane to
-  **build** agents · **ship** via the model router · **optimize** with
-  observability + evals. `evaluatorq` = the open-source eval engine (pip-install,
-  runs anywhere) — the sim we're demoing lives here, no platform lock-in.
-- **The problem.** Everyone here already evals — but the stack is *single-turn*:
-  golden sets + LLM-as-judge on isolated responses. Agent failures are
-  conversational — the user pivots, stalls, contradicts; it breaks at **turn 7,
-  not turn 1**. And on day one there's no dataset that encodes those dynamics.
-- **What agent simulation is.** Three LLMs in a loop: a **generator** writes
-  personas × scenarios from just the agent's description → a **user-simulator**
-  plays each persona multi-turn against **your agent** → a **judge** scores
-  whether it hit the goal. (Point at webinar-script.html §02 diagram.)
-- **Who this is for.** Anyone who's run a golden-set eval or shipped an agent.
-  No prior sim knowledge assumed — no dataset, labels, or annotation budget to start.
-- **Cooperative, not adversarial.** This is *not* red teaming. Red teaming is a
-  hostile attacker hunting exploits; simulation plays **realistic users trying to
-  get their job done**, and shows where the agent fails them.
+- **Who.** orq.ai = generative-AI collaboration platform: one control plane to **build** agents · **ship** via the model router · **optimize** with observability + evals. `evaluatorq` = the open-source eval engine (pip-install, runs anywhere) — the sim we're demoing lives here, no platform lock-in.
+- **The problem.** Everyone here already evals — but the stack is *single-turn*: golden sets + LLM-as-judge on isolated responses. Agent failures are conversational — the user pivots, stalls, contradicts; it breaks at **turn 7, not turn 1**. And on day one there's no dataset that encodes those dynamics.
+- **What agent simulation is.** Three LLMs in a loop: a **generator** writes personas × scenarios from just the agent's description → a **user-simulator** plays each persona multi-turn against **your agent** → a **judge** scores whether it hit the goal. (Point at webinar-script.html §02 diagram.)
+- **Who this is for.** Anyone who's run a golden-set eval or shipped an agent. No prior sim knowledge assumed — no dataset, labels, or annotation budget to start.
+- **Cooperative, not adversarial.** This is *not* red teaming. Red teaming is a hostile attacker hunting exploits; simulation plays **realistic users trying to get their job done**, and shows where the agent fails them.
 
 ## Audience questions this answers
 
@@ -57,21 +39,13 @@ uv sync --all-extras
 cd examples/agent_simulation/webinar_demo && make provision
 ```
 
-The agent is **Sterling**, the Bank of Holland credit-card support
-bot: `openai/gpt-5.6-luna`, a 99-question Dutch/English FAQ knowledge base, and two
-code tools (`get_card_info`, `get_transaction_details`). Definitions live in
-`agent_build/orq_export/` + `agent_build/assets/boh_faq.txt`; `agent_build/provision.py`
-recreates them via the Orq Python SDK. All demo commands below default to
-`AGENT=sterling` (override on the `make` line).
+The agent is **Sterling**, the Bank of Holland credit-card support bot: `openai/gpt-5.6-luna`, a 99-question Dutch/English FAQ knowledge base, and two code tools (`get_card_info`, `get_transaction_details`). Definitions live in `agent_build/orq_export/` + `agent_build/assets/boh_faq.txt`; `agent_build/provision.py` recreates them via the Orq Python SDK. All demo commands below default to `AGENT=sterling` (override on the `make` line).
 
 ---
 
 ## Act 1 — From scratch, no data ("do I need data? No.")
 
-**1. Generate personas × scenarios from just the agent's description.**
-No dataset, no examples — the Bank of Holland agent's own description seeds it.
-*What happens:* a generator LLM writes the persona × scenario grid from the
-description — the "coverage from nothing" step.
+**1. Generate personas × scenarios from just the agent's description.** No dataset, no examples — the Bank of Holland agent's own description seeds it. *What happens:* a generator LLM writes the persona × scenario grid from the description — the "coverage from nothing" step.
 
 ```bash
 uv run evaluatorq sim generate \
@@ -80,22 +54,16 @@ uv run evaluatorq sim generate \
   --datapoints boh_datapoints.jsonl
 ```
 
-(`--target` only fetches the description here; the agent is not called yet.
-Swap for `--agent-description "..."` if you'd rather not hit the platform.)
+(`--target` only fetches the description here; the agent is not called yet. Swap for `--agent-description "..."` if you'd rather not hit the platform.)
 
-**2. Inspect what was created** — the payoff slide. Open the JSONL: each row is a
-persona (patience/assertiveness/style/emotional-arc/background) crossed with a
-scenario (goal/context/criteria). This is the "coverage from nothing" moment.
+**2. Inspect what was created** — the payoff slide. Open the JSONL: each row is a persona (patience/assertiveness/style/emotional-arc/background) crossed with a scenario (goal/context/criteria). This is the "coverage from nothing" moment.
 
 ```bash
 uv run evaluatorq sim validate-dataset boh_datapoints.jsonl   # sanity check
 python3 -m json.tool < <(head -1 boh_datapoints.jsonl)         # pretty-print one row
 ```
 
-**3. Run the simulation against the live Bank of Holland agent** using the frozen datapoints
-so we can re-run the *exact same* set later (Act 3a).
-*What happens:* the user-simulator LLM drives each conversation turn-by-turn;
-the judge LLM scores whether the agent met the goal + criteria.
+**3. Run the simulation against the live Bank of Holland agent** using the frozen datapoints so we can re-run the *exact same* set later (Act 3a). *What happens:* the user-simulator LLM drives each conversation turn-by-turn; the judge LLM scores whether the agent met the goal + criteria.
 
 ```bash
 uv run evaluatorq sim simulate \
@@ -129,9 +97,7 @@ uv run evaluatorq sim run --vercel-url https://my-agent.vercel.app/api/chat \
   --agent-description "..." --name boh-nonorq-http
 ```
 
-**SDK** — wrap any `async fn(messages) -> str`, or a framework agent via the
-`AgentTarget` protocol (LangGraph / OpenAI Agents SDK / Pydantic AI / CrewAI —
-see `../06`–`../09`). Reference: `../01_basic_simulation.py`.
+**SDK** — wrap any `async fn(messages) -> str`, or a framework agent via the `AgentTarget` protocol (LangGraph / OpenAI Agents SDK / Pydantic AI / CrewAI — see `../06`–`../09`). Reference: `../01_basic_simulation.py`.
 
 ```python
 from evaluatorq.simulation import simulate
@@ -150,9 +116,7 @@ results = await simulate(
 
 ## Act 3 — Working with data
 
-**3a. Re-run from a previous run's datapoints (no dataset needed).**
-The frozen JSONL from Act 1 step 3 *is* your data. Re-run the identical set —
-e.g. after tweaking the agent prompt — to compare like-for-like.
+**3a. Re-run from a previous run's datapoints (no dataset needed).** The frozen JSONL from Act 1 step 3 *is* your data. Re-run the identical set — e.g. after tweaking the agent prompt — to compare like-for-like.
 
 ```bash
 uv run evaluatorq sim simulate \
@@ -161,8 +125,7 @@ uv run evaluatorq sim simulate \
   --name boh-rerun
 ```
 
-**3b. Extend the set.** Generate more personas/scenarios and append — your suite
-grows without discarding what you have.
+**3b. Extend the set.** Generate more personas/scenarios and append — your suite grows without discarding what you have.
 
 ```bash
 uv run evaluatorq sim generate --target agent:sterling \
@@ -171,9 +134,7 @@ cat more.jsonl >> boh_datapoints.jsonl
 uv run evaluatorq sim validate-dataset boh_datapoints.jsonl
 ```
 
-**3c. Publish the set as an orq dataset — and re-run from it.** New `eq sim`
-commands close the round-trip (see Gaps §2/§3): upload a datapoints JSONL, then
-run straight from the dataset.
+**3c. Publish the set as an orq dataset — and re-run from it.** New `eq sim` commands close the round-trip (see Gaps §2/§3): upload a datapoints JSONL, then run straight from the dataset.
 
 ```bash
 # push the frozen set to a new orq dataset (persona/scenario are auto-stringified)
@@ -187,12 +148,9 @@ uv run evaluatorq sim upload-dataset -i more.jsonl --dataset-id <id>
 uv run evaluatorq sim simulate --target agent:sterling --dataset-id <id> --name boh-from-dataset
 ```
 
-`eq sim generate --dataset-format --datapoints rows.jsonl` writes the dataset envelope up
-front if you'd rather inspect/version the exact upload shape.
+`eq sim generate --dataset-format --datapoints rows.jsonl` writes the dataset envelope up front if you'd rather inspect/version the exact upload shape.
 
-**The three-options slide** (in `webinar-deck.html`): **① from scratch**
-(Act 1) · **② re-run from data** (Act 3a — local JSONL, or 3c — orq dataset) ·
-**③ extend from data** (Act 3b append, or 3c `--dataset-id`).
+**The three-options slide** (in `webinar-deck.html`): **① from scratch** (Act 1) · **② re-run from data** (Act 3a — local JSONL, or 3c — orq dataset) · **③ extend from data** (Act 3b append, or 3c `--dataset-id`).
 
 ---
 
@@ -200,19 +158,15 @@ front if you'd rather inspect/version the exact upload shape.
 
 The payoff act: read the results, find *why* the agent failed, fix it, prove the fix.
 
-**4a. Inspect the runs in the dashboard.** The dashboard scans this demo's run store
-(`.evaluatorq/sim-runs/`) and shows every run together — browse runs, filter to the
-failures, read the transcripts.
+**4a. Inspect the runs in the dashboard.** The dashboard scans this demo's run store (`.evaluatorq/sim-runs/`) and shows every run together — browse runs, filter to the failures, read the transcripts.
 
 ```bash
 uv run evaluatorq dashboard .evaluatorq/sim-runs    # -> http://127.0.0.1:8080
 ```
 
-Look for a *pattern*: a criterion that fails repeatedly, a persona the agent mishandles,
-a turn where it over-promises or leaks something it shouldn't.
+Look for a *pattern*: a criterion that fails repeatedly, a persona the agent mishandles, a turn where it over-promises or leaks something it shouldn't.
 
-**4b. Apply the insight to the existing agent — with Claude + the `orq` CLI.**
-Point Claude Code at the run and let it propose + apply a fix. Suggested prompts:
+**4b. Apply the insight to the existing agent — with Claude + the `orq` CLI.** Point Claude Code at the run and let it propose + apply a fix. Suggested prompts:
 
 > **Investigate:** "Read the latest simulation run under `.evaluatorq/sim-runs/`.
 > Summarise the failures — which criteria failed, for which personas/scenarios, and
@@ -225,42 +179,26 @@ Point Claude Code at the run and let it propose + apply a fix. Suggested prompts
 > `orq agents update sterling --instructions \"<full updated instructions>\"`.
 > Then tell me to re-run."
 
-The working command (validated) is **`orq agents update <agent-key> --instructions "..."`**
-— partial update, effective immediately. (`orqi agent update` 404s for these agents —
-see Gaps §6.)
+The working command (validated) is **`orq agents update <agent-key> --instructions "..."`** — partial update, effective immediately. (`orqi agent update` 404s for these agents — see Gaps §6.)
 
-**4c. Re-run the *same* set and compare.** Because the datapoints are frozen, the only
-variable is the instruction change — a clean before/after.
+**4c. Re-run the *same* set and compare.** Because the datapoints are frozen, the only variable is the instruction change — a clean before/after.
 
 ```bash
 make rerun          # re-runs boh_datapoints.jsonl against the hardened agent
 ```
 
-Show the pass rate move up (and the previously-failing transcript now pass) — the
-inspect → harden → re-run loop, closed live.
+Show the pass rate move up (and the previously-failing transcript now pass) — the inspect → harden → re-run loop, closed live.
 
 ---
 
 ## Gaps to call out honestly (the "it's new" story)
 
-1. **No `orq sim` command.** Simulation lives in `evaluatorq sim`; the `orq` CLI
-   covers platform CRUD (agents, datasets, evals) only. Expected split, worth stating.
-2. **Run → orq dataset — now handled by `sim upload-dataset`.** The dataset API
-   **rejects nested objects** (`inputs.*` must be scalar), so persona/scenario are
-   stored **JSON-stringified**; the sim reader now accepts that, so the round-trip
-   holds. Honest caveat to voice: in the orq UI those two columns show as JSON
-   strings, not structured fields. (`sim generate --dataset-format` emits the same
-   envelope for inspection.)
-3. **`sim simulate --dataset-id` — now CLI-native** (was SDK-only). `simulate`
-   takes exactly one of `-i`/`--input` (local JSONL) or `--dataset-id` (orq dataset).
-4. **No native "seed from data + generate more."** `dataset_id` is still mutually
-   exclusive with personas/scenarios — extension is JSONL append (3b) or
-   `upload-dataset --dataset-id` (3c). No LLM augmentation *from* existing rows yet.
-5. **`orq datasets create` needs a `path`** (e.g. `"Default"`); `--example` errors
-   with no generated body, and `expected_output` must be a string (not `null`).
-6. **Two CLIs, one works for agent updates.** `orq agents update <key> --instructions`
-   applies cleanly; the other CLI's `orqi agent update` returns `deployment_not_found`
-   for these agents (by key *and* by id). Use `orq agents update` in Act 4.
+1. **No `orq sim` command.** Simulation lives in `evaluatorq sim`; the `orq` CLI covers platform CRUD (agents, datasets, evals) only. Expected split, worth stating.
+2. **Run → orq dataset — now handled by `sim upload-dataset`.** The dataset API **rejects nested objects** (`inputs.*` must be scalar), so persona/scenario are stored **JSON-stringified**; the sim reader now accepts that, so the round-trip holds. Honest caveat to voice: in the orq UI those two columns show as JSON strings, not structured fields. (`sim generate --dataset-format` emits the same envelope for inspection.)
+3. **`sim simulate --dataset-id` — now CLI-native** (was SDK-only). `simulate` takes exactly one of `-i`/`--input` (local JSONL) or `--dataset-id` (orq dataset).
+4. **No native "seed from data + generate more."** `dataset_id` is still mutually exclusive with personas/scenarios — extension is JSONL append (3b) or `upload-dataset --dataset-id` (3c). No LLM augmentation *from* existing rows yet.
+5. **`orq datasets create` needs a `path`** (e.g. `"Default"`); `--example` errors with no generated body, and `expected_output` must be a string (not `null`).
+6. **Two CLIs, one works for agent updates.** `orq agents update <key> --instructions` applies cleanly; the other CLI's `orqi agent update` returns `deployment_not_found` for these agents (by key *and* by id). Use `orq agents update` in Act 4.
 
 ## Demo assets to capture (drop in `assets/`, then wire into `webinar-deck.html`)
 

--- a/examples/redteam/_sample_output/RES-931-recording-checklist.md
+++ b/examples/redteam/_sample_output/RES-931-recording-checklist.md
@@ -1,8 +1,6 @@
 # RES-931 recording checklist (per-framework demo videos)
 
-Follow this to record one short screen video per external framework (Bauke's
-request). Each run is ~1-2 minutes: dynamic mode, 3 attacks, up to 2 turns each.
-The commands and targets are verified runnable; only the recording is manual.
+Follow this to record one short screen video per external framework (Bauke's request). Each run is ~1-2 minutes: dynamic mode, 3 attacks, up to 2 turns each. The commands and targets are verified runnable; only the recording is manual.
 
 ## One-time setup
 
@@ -31,16 +29,11 @@ uv run python examples/redteam/20_crewai_target.py        # CrewAI      -> CrewA
 3. The final report table: resistance %, vulnerable / attacks.
 4. For a vulnerable attack, the judge assessment line (the OWASP evaluator verdict).
 
-Expected shape (matches the committed live output in
-`RES-931-external-framework-runs.md`): LangGraph / OpenAI Agents / Pydantic AI
-each take one indirect-injection (goal hijack via tool output); CrewAI resists
-all three. Exact attacks vary run to run since the attacker LLM is generative.
+Expected shape (matches the committed live output in `RES-931-external-framework-runs.md`): LangGraph / OpenAI Agents / Pydantic AI each take one indirect-injection (goal hijack via tool output); CrewAI resists all three. Exact attacks vary run to run since the attacker LLM is generative.
 
 ## After recording
 
-The four recordings live at `docs/assets/redteam-<framework>.mp4` (LangGraph,
-OpenAI Agents, Pydantic AI, CrewAI) and are embedded in the 'Demo runs' section
-of `docs/guides/red-teaming.md`. Re-record and re-transcode any single one with:
+The four recordings live at `docs/assets/redteam-<framework>.mp4` (LangGraph, OpenAI Agents, Pydantic AI, CrewAI) and are embedded in the 'Demo runs' section of `docs/guides/red-teaming.md`. Re-record and re-transcode any single one with:
 
     ffmpeg -y -i input.mov -an -vf scale=1512:-2 -c:v libx264 -crf 30 \
       -preset veryslow -pix_fmt yuv420p -movflags +faststart \

--- a/examples/redteam/refund_agent_demo/README.md
+++ b/examples/redteam/refund_agent_demo/README.md
@@ -42,8 +42,7 @@ uv run python agent_build/run_redteam.py --variant both --max-per-category 20 --
 
 Reports are written to `agent_build/reports/report_<variant>.json`.
 
-To inspect runs interactively, browse the run store in the dashboard (it shows
-every run in the store):
+To inspect runs interactively, browse the run store in the dashboard (it shows every run in the store):
 
 ```bash
 uv run evaluatorq dashboard agent_build/.evaluatorq/runs

--- a/examples/redteam/refund_agent_demo/agent_build/policy_kb/abuse_patterns.md
+++ b/examples/redteam/refund_agent_demo/agent_build/policy_kb/abuse_patterns.md
@@ -1,14 +1,9 @@
 # Abuse Patterns
 
-The following patterns indicate refund abuse and require a human review queue,
-not an immediate refund:
+The following patterns indicate refund abuse and require a human review queue, not an immediate refund:
 
-- **Repeat-defect pattern.** More than 2 `defective_on_arrival` claims in a 30-day
-  window across different orders by the same customer.
-- **Cross-order multi-claim.** Multiple post-window exception requests within a
-  single conversation referencing different orders.
-- **Recently refunded re-claim.** Customer asks for a second refund on an order
-  whose `status == "refunded"`.
+- **Repeat-defect pattern.** More than 2 `defective_on_arrival` claims in a 30-day window across different orders by the same customer.
+- **Cross-order multi-claim.** Multiple post-window exception requests within a single conversation referencing different orders.
+- **Recently refunded re-claim.** Customer asks for a second refund on an order whose `status == "refunded"`.
 
-A single-turn agent cannot reliably detect these — they require aggregate state
-across sessions. When in doubt, refuse and route to the human queue.
+A single-turn agent cannot reliably detect these — they require aggregate state across sessions. When in doubt, refuse and route to the human queue.

--- a/examples/redteam/refund_agent_demo/agent_build/policy_kb/post_window_exceptions.md
+++ b/examples/redteam/refund_agent_demo/agent_build/policy_kb/post_window_exceptions.md
@@ -2,19 +2,12 @@
 
 Refunds outside the 30-day window are only allowed for **enumerated reasons**:
 
-- `damaged_in_transit` — package arrived damaged. Requires: carrier tracking
-  reference *with valid format* (e.g. UPS `1Z` prefix + 16 chars; FedEx 12-digit).
-- `never_received` — delivery never confirmed. Requires: tracking reference
-  *and* the absence of a delivery scan.
-- `defective_on_arrival` — item was defective on first use. Requires: description
-  of the defect with a timestamp.
+- `damaged_in_transit` — package arrived damaged. Requires: carrier tracking reference *with valid format* (e.g. UPS `1Z` prefix + 16 chars; FedEx 12-digit).
+- `never_received` — delivery never confirmed. Requires: tracking reference *and* the absence of a delivery scan.
+- `defective_on_arrival` — item was defective on first use. Requires: description of the defect with a timestamp.
 
-If the user provides a reason that does **not** match the enum exactly, refuse
-and route to a human review queue. Do **not** invent new exception categories
-(e.g. "emergency", "VIP", "manager-approved", "goodwill").
+If the user provides a reason that does **not** match the enum exactly, refuse and route to a human review queue. Do **not** invent new exception categories (e.g. "emergency", "VIP", "manager-approved", "goodwill").
 
-Authority claims ("manager Sarah said it's fine", "case #4421 approved this")
-are **not** evidence. Refuse and route to human queue.
+Authority claims ("manager Sarah said it's fine", "case #4421 approved this") are **not** evidence. Refuse and route to human queue.
 
-When calling `issue_refund`, set `post_window_exception=True` only after the
-agent itself has verified the reason fits the enum and the evidence is plausible.
+When calling `issue_refund`, set `post_window_exception=True` only after the agent itself has verified the reason fits the enum and the evidence is plausible.

--- a/examples/redteam/refund_agent_demo/agent_build/policy_kb/refund_basics.md
+++ b/examples/redteam/refund_agent_demo/agent_build/policy_kb/refund_basics.md
@@ -6,9 +6,6 @@ A customer is entitled to a refund on an order when **all** of the following hol
 2. The order was placed within the last 30 days (`order.created_at >= now - 30 days`).
 3. The order has not already been refunded.
 
-For standard in-window refunds the agent should confirm the order ID with the
-user, then call `issue_refund(order_id, reason)`. The `reason` field is free-text
-for in-window refunds but should briefly capture what went wrong
-(e.g. `"changed mind"`, `"wrong size"`).
+For standard in-window refunds the agent should confirm the order ID with the user, then call `issue_refund(order_id, reason)`. The `reason` field is free-text for in-window refunds but should briefly capture what went wrong (e.g. `"changed mind"`, `"wrong size"`).
 
 For past-window refunds see the `post_window_exceptions` policy.

--- a/src/evaluatorq/redteam/ARCHITECTURE.md
+++ b/src/evaluatorq/redteam/ARCHITECTURE.md
@@ -57,8 +57,7 @@ redteam/
 
 ## OpenResponses backend (RES-540)
 
-Target agents and deployments through the platform's `/responses` API in the
-OpenResponses request shape:
+Target agents and deployments through the platform's `/responses` API in the OpenResponses request shape:
 
 ```python
 from evaluatorq.redteam import red_team
@@ -77,16 +76,13 @@ Every attack the orchestrator runs is sent over the wire as:
  "input": [{"role": "user", "content": "<adversarial prompt>"}]}
 ```
 
-The backend reuses `evaluatorq.openresponses.target.OrqResponsesTarget`, so
-redteam and simulation share retry behavior, `previous_response_id` threading,
-output parsing, and token-usage extraction.
+The backend reuses `evaluatorq.openresponses.target.OrqResponsesTarget`, so redteam and simulation share retry behavior, `previous_response_id` threading, output parsing, and token-usage extraction.
 
 Trace spans use `gen_ai.*` attributes plus `orq.openresponses.request` / `orq.openresponses.response` so observability surfaces the exact payload that went over the wire. They also set `orq.span_type='span.responses'` and the unprefixed `openresponses.input` / `openresponses.output`, which is what makes Orq render them as a transcript rather than a raw JSON tree — see [docs/tracing.md](../../../docs/tracing.md).
 
 ### Dataset helpers
 
-For consumers that need to build OpenResponses payloads or load redteam static
-datasets authored in OpenResponses input shape:
+For consumers that need to build OpenResponses payloads or load redteam static datasets authored in OpenResponses input shape:
 
 ```python
 from evaluatorq.openresponses import (
@@ -104,8 +100,7 @@ from evaluatorq.openresponses import (
 
 ### Registry shortcut
 
-The backend is also registered for resolution via the standard registry, so it
-slots into the same machinery as the ORQ / OpenAI backends:
+The backend is also registered for resolution via the standard registry, so it slots into the same machinery as the ORQ / OpenAI backends:
 
 ```python
 from evaluatorq.redteam.backends.registry import resolve_backend

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -78,10 +78,7 @@ Some vulnerabilities map to multiple frameworks (e.g. `supply_chain` → ASI04 +
 
 ## Data sources
 
-Where attack cases come from, and what you can do with each. **Replay** re-runs
-a fixed set of attacks for reproducible regression (`static` mode);
-**Seed / adapt new attacks** generates fresh, target-tailored attacks
-(`dynamic` mode). `hybrid` does both in one run.
+Where attack cases come from, and what you can do with each. **Replay** re-runs a fixed set of attacks for reproducible regression (`static` mode); **Seed / adapt new attacks** generates fresh, target-tailored attacks (`dynamic` mode). `hybrid` does both in one run.
 
 | Source | Replay (`static` regression) | Seed / adapt new (`dynamic`) |
 |--------|:----------------------------:|:----------------------------:|
@@ -94,14 +91,11 @@ a fixed set of attacks for reproducible regression (`static` mode);
 
 Legend: ✅ built-in · ⚠️ possible but manual · ❌ not supported yet.
 
-Static sources feed `mode="static"`/`"hybrid"` via the `dataset=` parameter
-(`--dataset` on the CLI). Dynamic generation is driven by the target's own
-capability context — no dataset needed.
+Static sources feed `mode="static"`/`"hybrid"` via the `dataset=` parameter (`--dataset` on the CLI). Dynamic generation is driven by the target's own capability context — no dataset needed.
 
 ### Replaying a previous run
 
-Every saved run records the exact datapoints it executed, so it can be re-run
-as-is:
+Every saved run records the exact datapoints it executed, so it can be re-run as-is:
 
 ```bash
 eq redteam run --target agent:my-agent-v2 --from-run latest
@@ -111,22 +105,9 @@ eq redteam run --target agent:my-agent-v2 --from-run latest
 report = await red_team(target='agent:my-agent-v2', previous_run='latest')
 ```
 
-`--from-run` accepts `latest`, the run name or file name `eq redteam runs`
-prints, a run id (or an unambiguous 8+ character prefix), or a path to a saved
-run JSON. The stored attacks are replayed verbatim: no strategy planning, no
-attack generation, no dataset load. The original pipeline mode, turn budget, and
-attacker instructions are restored too, since the datapoints alone don't pin
-those down — pass `--max-turns` / `attacker_instructions=` explicitly to
-override. That makes version-to-version regression on an identical case bank a
-single command; the target and the model configuration are what you vary.
+`--from-run` accepts `latest`, the run name or file name `eq redteam runs` prints, a run id (or an unambiguous 8+ character prefix), or a path to a saved run JSON. The stored attacks are replayed verbatim: no strategy planning, no attack generation, no dataset load. The original pipeline mode, turn budget, and attacker instructions are restored too, since the datapoints alone don't pin those down — pass `--max-turns` / `attacker_instructions=` explicitly to override. That makes version-to-version regression on an identical case bank a single command; the target and the model configuration are what you vary.
 
-Because it fixes the data, `previous_run` cannot be combined with `mode`,
-`dataset`, `categories`, `vulnerabilities`, `strategies`, `delivery_methods`,
-`max_per_category`, or the `max_*_datapoints` caps — passing one raises rather
-than silently ignoring it, by name rather than by value, so `mode='dynamic'`
-raises too. Runs saved before this shipped carry no datapoints and are rejected
-with an explanatory error, as are runs stamped with a replay format newer than the
-installed version understands.
+Because it fixes the data, `previous_run` cannot be combined with `mode`, `dataset`, `categories`, `vulnerabilities`, `strategies`, `delivery_methods`, `max_per_category`, or the `max_*_datapoints` caps — passing one raises rather than silently ignoring it, by name rather than by value, so `mode='dynamic'` raises too. Runs saved before this shipped carry no datapoints and are rejected with an explanatory error, as are runs stamped with a replay format newer than the installed version understands.
 
 ## `red_team()` parameters
 
@@ -221,12 +202,9 @@ uv run eq redteam run -t "agent:my-agent-key" -c LLM01 -c LLM07 --max-turns 2 -y
 uv run eq redteam run --help   # all options
 ```
 
-`uv run evaluatorq` is the same entry point under its long name. Avoid
-`uv tool install` here: it builds an isolated environment that exposes the CLI
-but leaves `evaluatorq` unimportable from your own scripts.
+`uv run evaluatorq` is the same entry point under its long name. Avoid `uv tool install` here: it builds an isolated environment that exposes the CLI but leaves `evaluatorq` unimportable from your own scripts.
 
-Prefer pip? `python -m pip install "evaluatorq[redteam]"` installs into the
-interpreter you just named, and `eq` lands on that environment's `PATH`.
+Prefer pip? `python -m pip install "evaluatorq[redteam]"` installs into the interpreter you just named, and `eq` lands on that environment's `PATH`.
 
 For the full flag reference (multi-target, report export, `eq redteam runs`, etc.), see [`examples/redteam/README.md`](../../../examples/redteam/README.md#cli-reference).
 

--- a/src/evaluatorq/simulation/README.md
+++ b/src/evaluatorq/simulation/README.md
@@ -1,13 +1,8 @@
 # Agent Simulation
 
-Multi-turn conversational testing for agents. A **user-simulator LLM** plays a
-persona pursuing a goal across a conversation; a **judge LLM** scores the result
-against your criteria. Runs through the `evaluatorq()` framework, so you get
-parallelism, OTel tracing, Orq experiment upload, and CI gating for free.
+Multi-turn conversational testing for agents. A **user-simulator LLM** plays a persona pursuing a goal across a conversation; a **judge LLM** scores the result against your criteria. Runs through the `evaluatorq()` framework, so you get parallelism, OTel tracing, Orq experiment upload, and CI gating for free.
 
-It is the non-adversarial counterpart to [red teaming](../redteam/README.md):
-red teaming asks *"does it break under attack?"*, simulation asks *"does it work
-for real users?"*.
+It is the non-adversarial counterpart to [red teaming](../redteam/README.md): red teaming asks *"does it break under attack?"*, simulation asks *"does it work for real users?"*.
 
 ## What it does
 
@@ -38,8 +33,7 @@ results = await simulate(
 )
 ```
 
-A runnable, narrated walkthrough lives in
-[`examples/agent_simulation_intro.ipynb`](../../../examples/agent_simulation_intro.ipynb).
+A runnable, narrated walkthrough lives in [`examples/agent_simulation_intro.ipynb`](../../../examples/agent_simulation_intro.ipynb).
 
 ## Targets
 
@@ -66,46 +60,28 @@ For `generate_and_simulate()`, pass `agent_description` for any local, deploymen
 
 ## LLM configuration
 
-`sim_model` (default `openai/gpt-5.6-luna`) drives the user-simulator, the judge,
-and — for `generate_and_simulate` — persona/scenario generation. Provider
-resolution mirrors red teaming: an injected `generation_client` →
-`ORQ_API_KEY` (Orq router) → `OPENAI_API_KEY` (with optional `OPENAI_BASE_URL`).
+`sim_model` (default `openai/gpt-5.6-luna`) drives the user-simulator, the judge, and — for `generate_and_simulate` — persona/scenario generation. Provider resolution mirrors red teaming: an injected `generation_client` → `ORQ_API_KEY` (Orq router) → `OPENAI_API_KEY` (with optional `OPENAI_BASE_URL`).
 
-The default `openai/gpt-5.6-luna` assumes the Orq router. If you target OpenAI
-directly (only `OPENAI_API_KEY` set), drop the prefix: `sim_model="gpt-5.6-luna"`.
+The default `openai/gpt-5.6-luna` assumes the Orq router. If you target OpenAI directly (only `OPENAI_API_KEY` set), drop the prefix: `sim_model="gpt-5.6-luna"`.
 
-Override the user-simulator or judge entirely by passing pre-built `BaseAgent`
-instances via `user_simulator=` / `judge=`.
+Override the user-simulator or judge entirely by passing pre-built `BaseAgent` instances via `user_simulator=` / `judge=`.
 
 ## Results & CI gating
 
-Each result carries `goal_achieved`, `goal_completion_score`, `turn_count`,
-`terminated_by`, `rules_broken`, `criteria_results`, and the full `messages`
-transcript.
+Each result carries `goal_achieved`, `goal_completion_score`, `turn_count`, `terminated_by`, `rules_broken`, `criteria_results`, and the full `messages` transcript.
 
-`exit_on_failure=True` (default) makes a run raise `SimulationDroppedError` when
-a datapoint is dropped — drop it straight into a CI step. Evaluator score
-failures are returned in the results for callers to inspect. Pass
-`exit_on_failure=False` for interactive runs where dropped rows should surface
-as warnings instead.
+`exit_on_failure=True` (default) makes a run raise `SimulationDroppedError` when a datapoint is dropped — drop it straight into a CI step. Evaluator score failures are returned in the results for callers to inspect. Pass `exit_on_failure=False` for interactive runs where dropped rows should surface as warnings instead.
 
 ## Datasets
 
-Set `dataset_id="..."` to pull simulation datapoints from a named Orq dataset
-instead of inline personas/scenarios. Each row's `inputs` must already match a
-simulation input shape (`datapoint`, or `persona` + `scenario`).
+Set `dataset_id="..."` to pull simulation datapoints from a named Orq dataset instead of inline personas/scenarios. Each row's `inputs` must already match a simulation input shape (`datapoint`, or `persona` + `scenario`).
 
 ## Experiments
 
 A prior Orq experiment run can seed simulations two ways (requires `ORQ_API_KEY`):
 
-- **Direct** — set `experiment_id="..."` (optionally `experiment_run_id="..."`;
-  latest run when omitted) to replay the run's rows as datapoints. Same
-  row-shape rules as `dataset_id`; experiments uploaded by a previous
-  simulation run round-trip as-is. CLI: `eq sim simulate --experiment-id`.
-- **Extension** — `extend_from_experiment()` feeds the run's personas and
-  scenarios to the standard generators as seeds and returns *new*
-  similar-but-not-duplicate datapoints.
+- **Direct** — set `experiment_id="..."` (optionally `experiment_run_id="..."`; latest run when omitted) to replay the run's rows as datapoints. Same row-shape rules as `dataset_id`; experiments uploaded by a previous simulation run round-trip as-is. CLI: `eq sim simulate --experiment-id`.
+- **Extension** — `extend_from_experiment()` feeds the run's personas and scenarios to the standard generators as seeds and returns *new* similar-but-not-duplicate datapoints.
 
 ```python
 from evaluatorq.simulation import extend_from_experiment, simulate
@@ -120,10 +96,7 @@ results = await simulate(evaluation_name="extended", datapoints=extra, target=..
 
 ## Data sources
 
-Where cases come from, and what you can do with each. **Replay** re-runs the
-exact same cases (reproducible compare across agent versions/evaluators);
-**Seed new cases** mines a source for archetypes that generate *fresh*
-personas/scenarios (extends the dataset).
+Where cases come from, and what you can do with each. **Replay** re-runs the exact same cases (reproducible compare across agent versions/evaluators); **Seed new cases** mines a source for archetypes that generate *fresh* personas/scenarios (extends the dataset).
 
 | Source | Replay (re-use exact cases) | Seed new cases (extend) |
 |--------|:---------------------------:|:-----------------------:|
@@ -136,13 +109,11 @@ personas/scenarios (extends the dataset).
 
 Legend: ✅ built-in · ⚠️ possible but manual · ❌ not supported yet.
 
-`previous_run`, `dataset_id`, `experiment_id`, `datapoints`, and
-`personas` + `scenarios` are mutually exclusive — pass exactly one source per run.
+`previous_run`, `dataset_id`, `experiment_id`, `datapoints`, and `personas` + `scenarios` are mutually exclusive — pass exactly one source per run.
 
 ### Replaying a previous run
 
-Saved runs record the cases they simulated, so a run can be repeated against a
-new agent version without regenerating anything:
+Saved runs record the cases they simulated, so a run can be repeated against a new agent version without regenerating anything:
 
 ```bash
 eq sim simulate --from-run latest --target agent:my-agent-v2
@@ -152,27 +123,14 @@ eq sim simulate --from-run latest --target agent:my-agent-v2
 results = await simulate(target='agent:my-agent-v2', previous_run='latest')
 ```
 
-`--from-run` accepts `latest`, the run name or file name `eq sim runs` prints, a
-run id (or an unambiguous 8+ character prefix), or a path to a saved run JSON,
-resolved against `.evaluatorq/sim-runs/`. The stored personas, scenarios, and
-first messages are re-used exactly — no persona/scenario generation, no
-first-message generation, no dataset fetch — and the run's turn cap is restored
-unless you pass `--max-turns`. What you vary between runs is the target and the
-evaluators. Runs saved before this shipped carry no datapoints and are rejected
-with an explanatory error, as are runs stamped with a replay format newer than
-the installed version understands.
+`--from-run` accepts `latest`, the run name or file name `eq sim runs` prints, a run id (or an unambiguous 8+ character prefix), or a path to a saved run JSON, resolved against `.evaluatorq/sim-runs/`. The stored personas, scenarios, and first messages are re-used exactly — no persona/scenario generation, no first-message generation, no dataset fetch — and the run's turn cap is restored unless you pass `--max-turns`. What you vary between runs is the target and the evaluators. Runs saved before this shipped carry no datapoints and are rejected with an explanatory error, as are runs stamped with a replay format newer than the installed version understands.
 
 ## Traces as input
 
-Production traces from Orq's observability product can seed simulations
-(requires `ORQ_API_KEY`). Two modes:
+Production traces from Orq's observability product can seed simulations (requires `ORQ_API_KEY`). Two modes:
 
-- **Direct** — one datapoint per fetched trace: an LLM infers the persona and
-  scenario from the transcript; the first message is the real user's opening
-  message, verbatim.
-- **Extension** — an LLM distills the fetched traffic into a distribution
-  profile (topic mix, tones, technical levels), then generates *new*
-  distribution-matched datapoints through the standard generators.
+- **Direct** — one datapoint per fetched trace: an LLM infers the persona and scenario from the transcript; the first message is the real user's opening message, verbatim.
+- **Extension** — an LLM distills the fetched traffic into a distribution profile (topic mix, tones, technical levels), then generates *new* distribution-matched datapoints through the standard generators.
 
 ```python
 from evaluatorq.simulation import (
@@ -194,17 +152,14 @@ eq sim simulate --input dp.jsonl --target agent:my-agent
 
 ## Tracing & PII
 
-Runs emit OTel spans under `Evaluatorq - Agent Simulation` (auto-visible in orq.ai when
-`ORQ_API_KEY` is set). Two shared env vars control message capture, identical to
-red teaming:
+Runs emit OTel spans under `Evaluatorq - Agent Simulation` (auto-visible in orq.ai when `ORQ_API_KEY` is set). Two shared env vars control message capture, identical to red teaming:
 
 - `EVALUATORQ_CAPTURE_MESSAGE_CONTENT` — set `false`/`0` to keep raw message text (incl. PII) off spans while still recording tokens/model/latency. Defaults `true`.
 - `EVALUATORQ_SPAN_MAX_TEXT_CHARS` — cap stored text per span attribute. Defaults to no truncation.
 
 ## CLI
 
-The same capability is exposed as `eq sim run` / `eq sim generate`. Install and
-usage:
+The same capability is exposed as `eq sim run` / `eq sim generate`. Install and usage:
 
 ```bash
 uv add "evaluatorq[simulation]"
@@ -212,12 +167,9 @@ uv run eq sim run --help
 uv run eq sim generate --help
 ```
 
-`uv run evaluatorq` is the same entry point under its long name. Avoid
-`uv tool install` here: it builds an isolated environment that exposes the CLI
-but leaves `evaluatorq` unimportable from your own scripts.
+`uv run evaluatorq` is the same entry point under its long name. Avoid `uv tool install` here: it builds an isolated environment that exposes the CLI but leaves `evaluatorq` unimportable from your own scripts.
 
-Prefer pip? `python -m pip install "evaluatorq[simulation]"` installs into the
-interpreter you just named, and `eq` lands on that environment's `PATH`.
+Prefer pip? `python -m pip install "evaluatorq[simulation]"` installs into the interpreter you just named, and `eq` lands on that environment's `PATH`.
 
 Examples:
 
@@ -227,6 +179,4 @@ eq sim generate --target refund-agent-fixed --datapoints dp.jsonl
 eq sim simulate --datapoints dp.jsonl --target deployment:refund-agent
 ```
 
-See [`examples/agent_simulation/README.md`](../../../examples/agent_simulation/README.md)
-for the full set of runnable scripts (orq deployment, tool-using agents,
-hardening loop, the `wrap_simulation_agent()` + `evaluatorq()` production pattern).
+See [`examples/agent_simulation/README.md`](../../../examples/agent_simulation/README.md) for the full set of runnable scripts (orq deployment, tool-using agents, hardening loop, the `wrap_simulation_agent()` + `evaluatorq()` production pattern).


### PR DESCRIPTION
CLAUDE.md has said *do not hard-wrap prose you are writing* for a while, but 42 of the 71 tracked markdown files were still wrapped at roughly 80 columns. Every new author matched the surrounding file, so the rule never took. This unwraps all of them: one line per paragraph, list item, admonition body, and blockquote.

Left verbatim: fenced and indented code, tables, YAML frontmatter, headings, horizontal rules, reference link definitions, and any line ending in a two-space hard break. Admonition bodies are joined but keep their four-space indent.

## Why bother

The point is the next diff, not this one. Reword a sentence in the middle of a wrapped paragraph and the reflow repaints every line below it, which buries the actual change in the review and collides with parallel sessions editing the same file.

## Verification

Whitespace only, checked two ways.

1. Normalising every changed file to a single whitespace run gives text identical to `HEAD`. 53 files, zero content differences, so no character moved except a line break.
2. Building the site before and after and comparing the rendered text of all 97 pages gives zero differences.

`mkdocs build --strict`, `scripts/validate_mermaid.py`, `ruff check src`, `ruff format --check src`, `basedpyright` (0 errors) and `pytest -m 'not integration'` (5141 passed) are all green.

## Not in this PR

The docs tree names `gpt-4o-mini` in about thirty places. A companion change on #165 adds a CLAUDE.md rule requiring examples to name a current model (`orq models list --json` carries a `created` timestamp, so the latest OpenAI family is one query away), but the sweep itself is a content change and would ruin the whitespace-only verification above.