### PR TITLE
docs: explain how vulnerabilities relate to OWASP category codes

### DIFF
--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -241,6 +241,9 @@ The registry is **in-memory and process-local** — it is not persisted and ther
 
 ## Adding a new framework
 
+!!! warning "Custom category codes fail at report time, after the run is billed"
+    `Framework` is a fixed enum today — it only accepts `ASI*` and `LLM*` prefixes. A custom framework whose category codes use a different prefix, like `RAI01` or `MAP-1.1` below, runs and scores every attack and then fails when the bundled report is assembled, so the run is fully executed and billed before the failure surfaces. Until that is lifted, either map your custom vulnerability onto an existing `ASI*` or `LLM*` code, or skip the bundled report and consume `report.results` programmatically — each result carries `framework_categories` with every mapped code. Tracked in RES-1479.
+
 Frameworks are a reporting/compliance layer on top of vulnerabilities. Adding a framework means:
 
 1. Mapping existing vulnerabilities to your framework's categories via `framework_mappings` in `VulnerabilityDef`

--- a/docs/custom-evaluators-and-frameworks.md
+++ b/docs/custom-evaluators-and-frameworks.md
@@ -242,7 +242,7 @@ The registry is **in-memory and process-local** — it is not persisted and ther
 ## Adding a new framework
 
 !!! warning "Custom category codes fail at report time, after the run is billed"
-    `Framework` is a fixed enum today — it only accepts `ASI*` and `LLM*` prefixes. A custom framework whose category codes use a different prefix, like `RAI01` or `MAP-1.1` below, runs and scores every attack and then fails when the bundled report is assembled, so the run is fully executed and billed before the failure surfaces. Until that is lifted, either map your custom vulnerability onto an existing `ASI*` or `LLM*` code, or skip the bundled report and consume `report.results` programmatically — each result carries `framework_categories` with every mapped code. Tracked in RES-1479.
+    `infer_framework` derives the framework from the category code's prefix, and today it only recognizes `ASI*` and `LLM*`. A custom framework whose category codes use a different prefix, like `RAI01` or `MAP-1.1` below, runs and scores every attack and then fails when the bundled report is assembled, so the run is fully executed and billed before the failure surfaces. Until that is lifted, map your custom vulnerability onto an existing `ASI*` or `LLM*` code. There is no post-run recovery once a run fails at report assembly: the results are not reachable, and the only way forward is to repeat the run with a mapped code. Tracked in RES-1479.
 
 Frameworks are a reporting/compliance layer on top of vulnerabilities. Adding a framework means:
 
@@ -363,5 +363,6 @@ report = await red_team(
 ## Where to next
 
 - **[Red Teaming](guides/red-teaming.md)** — the red-team workflow these evaluators and frameworks plug into.
+- **[Vulnerabilities & Frameworks](guides/vulnerabilities-and-frameworks.md)** — what the vulnerability/framework mapping is and how to read it off a report.
 - **[LLM as a Jury](llm-as-a-jury.md)** — multi-judge panels for more reliable verdicts.
 - **[CLI Reference](cli-reference/redteam.md)** — run `eq redteam` from the terminal.

--- a/docs/guides/red-teaming.md
+++ b/docs/guides/red-teaming.md
@@ -223,6 +223,8 @@ The two tabs above are the two most common targets. For the full set — includi
 | `LLM08` | Vector and Embedding Weaknesses | generated | ✅ |
 | `LLM09` | Misinformation | 5 | ✅ |
 
+See [Vulnerabilities & Frameworks](vulnerabilities-and-frameworks.md) for how these 19 category codes map onto the 18 vulnerabilities behind them, and how a vulnerability mapped into more than one framework is labelled in reports.
+
 45 curated strategies in total, delivered through 16 delivery methods (`direct-request`, `tool-response`, `role-play`, `crescendo`, `many-shot`, `base64`, `leetspeak`, `multilingual`, `refusal-suppression`, and more). Add your own vulnerabilities, strategies and judges — see [Custom Evaluators & Frameworks](../custom-evaluators-and-frameworks.md).
 
 ## Inspect results in Python

--- a/docs/guides/vulnerabilities-and-frameworks.md
+++ b/docs/guides/vulnerabilities-and-frameworks.md
@@ -1,6 +1,6 @@
 # Vulnerabilities & Frameworks
 
-The red team runs on **vulnerabilities**. OWASP category codes like `ASI01` and `LLM01` are labels attached to those vulnerabilities for reporting, not a second set of things to test. This page explains what the relation is, so the coverage table reads the way it is meant to.
+The red team runs on **vulnerabilities**. OWASP category codes like `ASI01` and `LLM01` are labels attached to those vulnerabilities for reporting, not a second set of things to test. This page explains the relation behind the coverage table.
 
 ## The model
 
@@ -29,7 +29,7 @@ Two frameworks are registered today: `OWASP-ASI` and `OWASP-LLM`.
 
 ## Categories are labels, not the primitive
 
-There are **18 vulnerabilities** and **19 category codes**. The codes are a projection of the vulnerabilities, which is why the counts differ.
+There are 18 vulnerabilities and 19 category codes. The codes are a projection of the vulnerabilities, which is why the counts differ.
 
 The full enumeration — every code, the vulnerability behind it, its curated strategy count, and whether a judge exists — is the [Coverage table](red-teaming.md#coverage) in the red teaming guide. Read that table as 18 things wearing 19 labels.
 
@@ -41,9 +41,9 @@ The full enumeration — every code, the vulnerability behind it, its curated st
 framework_mappings={'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
 ```
 
-`ASI04` and `LLM03` are two names for the same vulnerability. There is one judge rubric and one strategy set behind both codes, not two of each.
+`ASI04` and `LLM03` are two names for the same vulnerability. Both codes share one judge rubric and one strategy set.
 
-`supply_chain` is currently the only multi-mapped vulnerability. The mechanism is general — a `VulnerabilityDef` can list any number of frameworks and codes — but exactly one entry uses it today, which is why the next section catches people out.
+`supply_chain` is currently the only multi-mapped vulnerability. The mechanism is general — a `VulnerabilityDef` can list any number of frameworks and codes — but exactly one entry uses it today.
 
 ## Cross-framework codes report under their primary category
 
@@ -58,7 +58,7 @@ framework_mappings={'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
 
 `VulnerabilityDomain` is `agent`, `model`, or `data`. It says which layer of the stack a fix belongs to — the agent's scaffolding and tools, the model itself, or the data and retrieval it sits on. It does not say which framework the vulnerability belongs to.
 
-`excessive_agency` is the clearest case: its domain is `agent`, and its primary category is `LLM06`, a code from the LLM Top 10. The two axes disagree, and that is fine — neither can be read off the other. Group by domain when you want to know who fixes something; group by category when you want a framework report.
+`excessive_agency` is the clearest case: its domain is `agent`, and its primary category is `LLM06`, a code from the LLM Top 10. The two axes disagree, and neither can be read off the other. Group by domain when you want to know who fixes something; group by category when you want a framework report.
 
 ## Summaries carry every mapped code
 
@@ -69,7 +69,7 @@ report.summary.by_vulnerability['supply_chain'].framework_categories
 # {'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
 ```
 
-So a compliance view keyed on `LLM03` is buildable from a report — read `framework_categories` on the vulnerability summary rather than the primary label.
+So you can build a compliance view keyed on `LLM03` from a report: read `framework_categories` on the vulnerability summary rather than the primary label.
 
 ## Where to next
 

--- a/docs/guides/vulnerabilities-and-frameworks.md
+++ b/docs/guides/vulnerabilities-and-frameworks.md
@@ -1,0 +1,78 @@
+# Vulnerabilities & Frameworks
+
+The red team runs on **vulnerabilities**. OWASP category codes like `ASI01` and `LLM01` are labels attached to those vulnerabilities for reporting, not a second set of things to test. This page explains what the relation is, so the coverage table reads the way it is meant to.
+
+## The model
+
+`Vulnerability` is the atomic primitive. Everything that decides what an attack does binds to it:
+
+- **Attack strategies** are keyed by vulnerability. Pick a vulnerability and you pick the curated strategies. In dynamic and hybrid mode you also pick what the planner generates.
+- **The judge** is keyed by vulnerability. One LLM-as-judge rubric per vulnerability decides RESISTANT or VULNERABLE.
+
+Each vulnerability has a `VulnerabilityDef` in `src/evaluatorq/redteam/vulnerability_registry.py`. Its `framework_mappings` field projects the vulnerability onto framework category codes. That projection is a labelling layer on top of the primitive — it feeds reporting and compliance views, and it lets you name a vulnerability by a code your security team already uses.
+
+```mermaid
+graph TD
+    V["Vulnerability"]
+    S["Attack strategies"]
+    E["Judge rubric"]
+    VD["VulnerabilityDef"]
+    F["Framework categories<br/>OWASP-ASI / OWASP-LLM"]
+
+    V --> S
+    V --> E
+    V --> VD
+    VD --> F
+```
+
+Two frameworks are registered today: `OWASP-ASI` and `OWASP-LLM`.
+
+## Categories are labels, not the primitive
+
+There are **18 vulnerabilities** and **19 category codes**. The codes are a projection of the vulnerabilities, which is why the counts differ.
+
+The full enumeration — every code, the vulnerability behind it, its curated strategy count, and whether a judge exists — is the [Coverage table](red-teaming.md#coverage) in the red teaming guide. Read that table as 18 things wearing 19 labels.
+
+## One vulnerability, two labels
+
+`supply_chain` is mapped into both frameworks:
+
+```python
+framework_mappings={'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
+```
+
+`ASI04` and `LLM03` are two names for the same vulnerability. There is one judge rubric and one strategy set behind both codes, not two of each.
+
+`supply_chain` is currently the only multi-mapped vulnerability. The mechanism is general — a `VulnerabilityDef` can list any number of frameworks and codes — but exactly one entry uses it today, which is why the next section catches people out.
+
+## Cross-framework codes report under their primary category
+
+!!! note "`-c LLM03` reports as `ASI04`"
+    `eq redteam run -c LLM03` runs exactly the attacks `-c ASI04` runs, because both codes resolve to `supply_chain`. The results are reported under **`ASI04`**, the primary category. The run logs the relabel at info level.
+
+    `get_primary_category` returns the first code of the first framework mapping. For `supply_chain` that is `ASI04`, so `ASI04` is the label on every summary row and report heading for that vulnerability, whichever code you asked for.
+
+    If you are assembling an OWASP LLM Top 10 view, filter on the vulnerability id `supply_chain` or on `ASI04`. The top-line label on those rows is `ASI04`, so a filter on the primary category alone will not surface `LLM03`.
+
+## Domain is a different axis from framework
+
+`VulnerabilityDomain` is `agent`, `model`, or `data`. It says which layer of the stack a fix belongs to — the agent's scaffolding and tools, the model itself, or the data and retrieval it sits on. It does not say which framework the vulnerability belongs to.
+
+`excessive_agency` is the clearest case: its domain is `agent`, and its primary category is `LLM06`, a code from the LLM Top 10. The two axes disagree, and that is fine — neither can be read off the other. Group by domain when you want to know who fixes something; group by category when you want a framework report.
+
+## Results carry every mapped code
+
+The top-line label on a result is the primary category, but the complete mapping is on the result too. Each per-vulnerability result has a `framework_categories` field, a `dict[str, list[str]]` of every framework the vulnerability maps into:
+
+```python
+{'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
+```
+
+So a compliance view keyed on `LLM03` is buildable from a report — read `framework_categories` on the vulnerability results rather than the primary label.
+
+## Where to next
+
+- **[Red Teaming](red-teaming.md)** — the workflow, the modes, and the full coverage table.
+- **[Custom Evaluators & Frameworks](../custom-evaluators-and-frameworks.md)** — add your own vulnerabilities, judges, strategies, and framework mappings.
+- **[API Reference › redteam](../reference/evaluatorq/redteam.md)** — the `Vulnerability` enum and the category codes you can pass to `categories=`.
+- **[CLI Reference › Red Teaming](../cli-reference/redteam.md#eq-redteam-run)** — the `--category` and `--vulnerability` flags.

--- a/docs/guides/vulnerabilities-and-frameworks.md
+++ b/docs/guides/vulnerabilities-and-frameworks.md
@@ -60,15 +60,16 @@ framework_mappings={'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
 
 `excessive_agency` is the clearest case: its domain is `agent`, and its primary category is `LLM06`, a code from the LLM Top 10. The two axes disagree, and that is fine — neither can be read off the other. Group by domain when you want to know who fixes something; group by category when you want a framework report.
 
-## Results carry every mapped code
+## Summaries carry every mapped code
 
-The top-line label on a result is the primary category, but the complete mapping is on the result too. Each per-vulnerability result has a `framework_categories` field, a `dict[str, list[str]]` of every framework the vulnerability maps into:
+The top-line label on a result is the primary category, but the complete mapping is available too, on the per-vulnerability summary. `report.summary.by_vulnerability` is a `dict[str, VulnerabilitySummary]` keyed by the vulnerability id string, and each `VulnerabilitySummary` has a `framework_categories` field, a `dict[str, list[str]]` of every framework the vulnerability maps into:
 
 ```python
-{'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
+report.summary.by_vulnerability['supply_chain'].framework_categories
+# {'OWASP-ASI': ['ASI04'], 'OWASP-LLM': ['LLM03']}
 ```
 
-So a compliance view keyed on `LLM03` is buildable from a report — read `framework_categories` on the vulnerability results rather than the primary label.
+So a compliance view keyed on `LLM03` is buildable from a report — read `framework_categories` on the vulnerability summary rather than the primary label.
 
 ## Where to next
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ plugins:
           - guides/targets.md: The system under test — built-in target kinds and how to write your own AgentTarget.
           - guides/agent-simulation.md: Multi-turn, persona-driven conversation testing with an LLM judge.
           - guides/red-teaming.md: Adaptive OWASP-mapped adversarial security testing for agents.
+          - guides/vulnerabilities-and-frameworks.md: How vulnerabilities relate to OWASP category codes, and why they are not the same count.
           - custom-evaluators-and-frameworks.md: Define custom evaluators and frameworks.
           - llm-as-a-jury.md: Multi-judge panel (jury) evaluation.
           - cyclic-judge.md: Round-robin (CyclicJudge) judge assignment at single-judge cost.
@@ -267,6 +268,7 @@ nav:
       - Dashboard: dashboard.md
       - Red Teaming:
           - Overview: guides/red-teaming.md
+          - Vulnerabilities & Frameworks: guides/vulnerabilities-and-frameworks.md
           - Custom Evaluators & Frameworks: custom-evaluators-and-frameworks.md
       - LLM as a Jury:
           - Overview: llm-as-a-jury.md


### PR DESCRIPTION
## What this adds

A concept page, `docs/guides/vulnerabilities-and-frameworks.md`, explaining the relation between the red teamer's `Vulnerability` primitive and the OWASP category codes users actually type into `--category`.

The relation is already correct in `redteam/vulnerability_registry.py`, but the only way to learn it was to read source or infer it from the Coverage table in the red-teaming guide. That table lists 19 category rows, which reads as 19 independent things and hides that categories are a projection of 18 vulnerabilities. Three consequences of the real model were undocumented:

- Attack strategies and judges bind to a `Vulnerability`. `framework_mappings` on each `VulnerabilityDef` is what produces the `ASI01` / `LLM01` labels, so the codes are a derived layer rather than the primitive.
- The mapping is many-to-many, and `supply_chain` is currently the only vulnerability that uses it — it carries both `ASI04` and `LLM03`. The Coverage table shows those as two rows sharing a name, so it looks like two vulnerabilities.
- Because `get_primary_category` returns the first code of the first mapping, `eq redteam run -c LLM03` runs the same attacks as `-c ASI04` and reports them under `ASI04`. The runner logs this at info level; nothing in the docs said it would happen, so an OWASP-LLM-keyed view of the top-line label silently misses those rows.

Domain is also documented as orthogonal to framework, since `excessive_agency` is `domain=agent` while its OWASP code is `LLM06` — neither axis can be read off the other.

## Scope

Documentation only. No behaviour changes, and no `src/` file is touched.

Two known code defects were deliberately left alone and filed as RES-1479: `Framework` is a closed enum, so a custom framework category outside the `ASI*` / `LLM*` prefixes fails report assembly after a fully billed run; and the per-framework report view shows only the primary category. This PR documents the current behaviour instead of changing it.

## Also in here

`docs/custom-evaluators-and-frameworks.md` gains a warning at the top of its "Adding a new framework" section. That section walks a reader through custom category codes like `RAI01`, which currently take the run all the way through execution and scoring before failing — so the warning names the limitation, gives the workaround that exists (map onto an `ASI*` or `LLM*` code), and states that there is no post-run recovery once report assembly fails. It also gains a link back to the new page, which it previously lacked.

`docs/guides/red-teaming.md` gains a two-line pointer near the Coverage table. The table itself is unmoved and unchanged.

The three pages divide the subject deliberately: the new page explains what the relation is, the extension guide owns how to extend it, and the red-teaming guide keeps the workflow and the table. Nothing is duplicated between them.

## Verification

`mkdocs build --strict` and `scripts/validate_mermaid.py` both pass. The full CI set was run before pushing: `ruff check src`, `ruff format --check src`, bare `basedpyright` (0 errors), and `pytest -m 'not integration'` (5147 passed).

A whole-branch review caught one real defect before merge: both pages had claimed `framework_categories` lives on `report.results`. It is on `VulnerabilitySummary`, reached via `report.summary.by_vulnerability`, and the pages now say so with a runnable access path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)