### PR TITLE
docs: make the red-team guide the single source for replay mechanics

### DIFF
--- a/.claude/skills/docs-coverage/axes.md
+++ b/.claude/skills/docs-coverage/axes.md
@@ -81,4 +81,6 @@ Marked `N/A` in the matrix, never reported as a gap.
 
 Tier-1 items are **not** matrix cells — there is no `env var` axis, and `surface` has exactly the three values above. Record a Tier-1 gap in the `docs-autofill` ledger as `tier 1: <kind> (<name>, …)` with no second axis, e.g. `tier 1: env var (ORQ_OTEL_MAX_QUEUE_SIZE, ORQ_OTEL_MAX_BATCH_SIZE)`. The ledger dedupe compares that cell as free text, so naming the items is what stops the same gap being re-derived next week; an invented axis pair never matches.
 
+**A symbol whose *output* is documented is not a Tier-1 gap.** A symbol-name grep does not know whether a reader reaches the concept by another name. `bt_sigma_aggregation` is the standing example: it is internal, called only from `build_report(aggregation='bt-sigma')`, and readers meet it as `report.bt_sigma`, documented at `pairwise-judging.md`. Before recording a Tier-1 gap for a symbol, check whether its result is already documented under the name users actually type; if it is, the gap is a false positive, not prose to write.
+
 **Tier 2 — API reference suffices.** Supporting types, contracts, backends, and subpackage `__all__` members. Flag only when there is no docstring at all.

--- a/src/evaluatorq/redteam/README.md
+++ b/src/evaluatorq/redteam/README.md
@@ -105,9 +105,7 @@ eq redteam run --target agent:my-agent-v2 --from-run latest
 report = await red_team(target='agent:my-agent-v2', previous_run='latest')
 ```
 
-`--from-run` accepts `latest`, the run name or file name `eq redteam runs` prints, a run id (or an unambiguous 8+ character prefix), or a path to a saved run JSON. The stored attacks are replayed verbatim: no strategy planning, no attack generation, no dataset load. The original pipeline mode, turn budget, and attacker instructions are restored too, since the datapoints alone don't pin those down — pass `--max-turns` / `attacker_instructions=` explicitly to override. That makes version-to-version regression on an identical case bank a single command; the target and the model configuration are what you vary.
-
-Because it fixes the data, `previous_run` cannot be combined with `mode`, `dataset`, `categories`, `vulnerabilities`, `strategies`, `delivery_methods`, `max_per_category`, or the `max_*_datapoints` caps — passing one raises rather than silently ignoring it, by name rather than by value, so `mode='dynamic'` raises too. Runs saved before this shipped carry no datapoints and are rejected with an explanatory error, as are runs stamped with a replay format newer than the installed version understands.
+See [Replay a previous run](../../../docs/guides/red-teaming.md#replay-a-previous-run) for the reference forms `--from-run` accepts, what replay restores from the stored run, and the arguments it refuses. That guide is the single source for replay mechanics.
 
 ## `red_team()` parameters
 


### PR DESCRIPTION
Closes the last two open items on #167.

**Replay documented in two places (item 2).** `src/evaluatorq/redteam/README.md` and `docs/guides/red-teaming.md` both carried the reference forms `--from-run` accepts, what replay restores from the stored run, and the list of arguments it refuses. The guide has the fuller version, so the README now keeps the two invocations and links out for the mechanics.

**`bt_sigma_aggregation` false positive (item 4).** `.claude/skills/docs-coverage/axes.md` now says that a symbol whose *output* is documented under the name users actually type is not a Tier-1 gap, with `bt_sigma_aggregation` / `report.bt_sigma` as the standing example. Without this the coverage run re-derives it every time.

The other three items on #167 already landed: the `mode` sentinel is fixed in `runner.py` and `cli.py` with a test in `tests/redteam/test_replay.py`, replay is no longer a peer bullet under `## Modes`, and the docs-autofill receipt is a hard gate with the venv-on-`PATH` and fresh-run-store rules spelled out.

`uv run --group docs mkdocs build --strict` passes. No `src/` behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)