### PR TITLE
docs: add a docs-writing skill and fix structured-results against it (RES-1495)

### DIFF
--- a/.claude/skills/docs-autofill/SKILL.md
+++ b/.claude/skills/docs-autofill/SKILL.md
@@ -73,6 +73,8 @@ Branch: `docs/autofill-<short-gap-slug>`.
 
 Scope: one page, or one section on an existing page. Not two. If the gap is genuinely too large for one page, write the page that covers the most common half and say in the PR body what you deliberately left out.
 
+**Read the `docs-writing` skill before you draft.** It holds the reader, the three page genres and their shapes, the voice, and the four things every page carries. This routine writes unattended, so a page drafted without it is a page nobody read for voice before it shipped.
+
 Rules that are not negotiable:
 
 - **A new page goes in `mkdocs.yml` twice** — under `nav:` and under `plugins.llmstxt.sections`. The build fails on the mismatch, but fix it at write time rather than discovering it in step 5.

--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -44,7 +44,7 @@ Every page, all three genres, no exceptions.
 
 ## Voice
 
-House voice is already on the page in `guides/targets.md`, `tuning.md` and `guides/getting-started.md`. Read one before drafting. What follows is what those pages do, stated as rules.
+House voice is already on the page in `guides/targets.md`, `tuning.md`, `index.md` and `guides/getting-started.md`. Read one before drafting. What follows is what those pages do, stated as rules.
 
 **Define, then qualify.** State the thing flatly, then add the caveat as its own sentence. Not one sentence carrying both.
 

--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: docs-writing
+description: How to write a page on the evaluatorq docs site — reader, genre, voice, the four things every page carries, and the reviewer loop that gates it. Use when drafting a new docs page or rewriting an existing one, when a feature PR needs its docs, and when asking how a page should be structured. Invoked deterministically by docs-autofill before it drafts.
+---
+
+# docs-writing
+
+Governs pages under `docs/`. It does not govern PR bodies, commit messages, tickets or code comments — those follow `CLAUDE.md` and `ticket-writing`.
+
+Two rules bind every prose surface, this one included, and live in `CLAUDE.md` because they bind outside it too: **never cut a sentence off**, and **do not hard-wrap prose**. Read them there.
+
+## The reader
+
+An ML or AI engineer already shipping LLM applications. They know Python, async, providers, tokens, and what a prompt is. They do not know evaluatorq.
+
+That sets the jargon budget: a term from the *evaluation* domain — judge, jury, datapoint, vulnerability, target, attack strategy — gets defined on first use on each page, because a reader lands on one page from a search result, not on page one of a book. General Python and LLM terms are free.
+
+Two pages carry a second reader: `docs/index.md` and `docs/guides/getting-started.md` are also read by a backend engineer new to evaluation. On those two, define the eval-domain terms in a sentence rather than a clause, and let the pace slow down.
+
+## Three genres
+
+Every page is one of three. Pick before drafting — the genre decides the opening, the shape, and the length.
+
+| Genre | Answers | Opening | Length | Examples |
+|---|---|---|---|---|
+| **Tutorial** | "get me a working thing" | A promise with a bound: what you will have, how long it takes, what you do not need | ≤ 800 words | `guides/getting-started.md` |
+| **Guide** | "how do I do X" | One line naming X, then the scope line | ≤ 2500 words | `guides/red-teaming.md`, `guides/targets.md` |
+| **Reference** | "what are the knobs" | One line naming the surface, then a table that partitions it | Uncapped — bounded by the surface, not by prose | `tuning.md`, `configuration.md` |
+
+The caps are guidance, not gates. `dashboard.md` runs long because the dashboard is large. A guide running long because it is padded is a different thing, and the cutter reviewer will say so.
+
+**Tutorial pacing.** One path, no choices. Every branch you offer is a place the reader stops to decide, and a tutorial's job is to reach a working result before they have to. Mention the alternatives in one line at the end, or not at all.
+
+**Reference shape.** A reference page's real work is partitioning: the reader has a symptom and needs to know which group of knobs owns it. Lead with the table that splits the surface into groups, then take each group in order. `tuning.md` is the model — three groups, and a note that confusing them is the usual cause of a setting that does nothing.
+
+## Four non-negotiables
+
+Every page, all three genres, no exceptions.
+
+1. **An opening one-line definition.** The first sentence says what the thing is, in one line, without a preamble. `A **target** is the thing evaluatorq attacks or converses with.`
+2. **A scope line.** When to reach for this, and when not. `Every knob on this page has a working default. Reach for it when a run is slow, flaky, or spending more than you want — not before.` A page without one gets read by people it cannot help.
+3. **At least one runnable example.** Runnable means you ran it. Not a fragment, not pseudocode, not a snippet that needs a variable defined three pages away.
+4. **A named failure mode.** What goes wrong, and — where it applies — that it goes wrong *silently*. `Setting the wrong one is silent — the call simply runs at the default.` The reader's next hour is decided by this sentence more than by anything else on the page.
+
+## Voice
+
+House voice is already on the page in `guides/targets.md`, `tuning.md` and `guides/getting-started.md`. Read one before drafting. What follows is what those pages do, stated as rules.
+
+**Define, then qualify.** State the thing flatly, then add the caveat as its own sentence. Not one sentence carrying both.
+
+> ❌ It's important to note that targets, which can be specified either as strings or as objects depending on your use case, are what red teaming and simulation both operate against.
+> ✅ A **target** is the thing evaluatorq attacks or converses with. `red_team()` and `simulate()` both take one.
+
+**Tables partition choices; prose explains one thing.** When the reader is choosing between kinds, modes or backends, a table with a `Use it when` column beats three paragraphs. When there is one thing, prose beats a one-row table.
+
+> ✅ `| Kind | Use it when | Context discovery |`
+
+**Put the gotcha where it bites, not in a section at the bottom.** The install caveat belongs under the install command.
+
+> ✅ ```uv add evaluatorq``` followed immediately by: `uv add` installs into the current project — run `uv init` first if you don't have one.
+
+**Second person for actions, third for facts.** "You pass a target" when the reader does it. "evaluatorq resolves the identifier" when the system does. Mixing these mid-paragraph is the fastest way to lose which side of the API a sentence describes.
+
+**No throat-clearing.** Cut the opening move that says the page is about to begin.
+
+> ❌ In this guide, we will explore the various ways in which you can configure timeouts.
+> ✅ Every knob on this page has a working default.
+
+**Cut the reassurance.** "Simply", "just", "easy", "powerful", "seamlessly", "it's worth noting that", "in today's landscape". They add no information and quietly tell a stuck reader the problem is them.
+
+**Concrete numbers and names over hedges.** "Three groups" not "several groups". "`gpt-5.6-luna`" not "a small model". "Fails after 120 seconds" not "may time out".
+
+**One idea per paragraph, and the idea is in the first sentence.** The reader skims first sentences. A paragraph whose point arrives in the fourth sentence is a paragraph they skip.
+
+## Mechanics
+
+- **Fence every code sample on a page, with a language.** An indented block reaches Pygments with no lexer and renders as grey text. `docs/hooks.py` fails `--strict` on any unhighlighted block, on every page; the two exemptions there are prose diagrams, not an escape hatch. The docstring version of this rule — griffe section indentation, and the backtick width in `examples/*.py` — lives in `CLAUDE.md`, because it binds when you are editing Python and this skill is not loaded.
+- **A new page goes in `mkdocs.yml` twice** — once under `nav:`, once under `plugins.llmstxt.sections`. The llmstxt plugin silently drops any nav page it does not list from `llms.txt` and `llms-full.txt` without failing the build, so `docs/hooks.py` fails `--strict` on the mismatch instead. The check runs one way (nav → sections) and accepts globs, which is why `reference/evaluatorq/*.md` covers every generated API page with one entry.
+- **Name a current model in every example.** `gpt-4o-mini` dates the page the moment a reader sees it, and the reader copies it. The catalog is the source of truth: `orq models list --json` returns a `created` timestamp per entry, so `model_developer == 'openai' and model_type == 'chat'` sorted by `created` descending gives the latest OpenAI family in one command. Prefer the cheap member of that family — it is also the value of `DEFAULT_PIPELINE_MODEL` — unless the sample is specifically about a bigger model. Run the query rather than copying a model name out of a file that does not know today's date.
+
+## Process
+
+1. **Pick the genre and name the reader's task in one sentence.** If you cannot, the page has no scope line yet and drafting it will not find one.
+2. **Draft**, following the genre template and the voice rules.
+3. **Run every code block as written**, in a scratch file. Not "it looks right" — run it. Fix the page, not the snippet's environment.
+4. **Self-check the four non-negotiables.** Missing one is a defect, not a nit.
+5. **Reviewer loop** — below.
+6. **Hand off**: run the `docs-drift` skill scoped to the page (are its claims still true of the code?), confirm both `mkdocs.yml` entries, then `uv run --group docs mkdocs build --strict`.
+
+### Reviewer loop
+
+Four reviewers in parallel on every draft — three narrow sonnet lenses and one broad opus editor:
+
+- **reader** (sonnet) — roleplay the assumed reader. Attempt the task using only this page. Report the first place you got stuck and what you needed that was not there.
+- **conformance** (sonnet) — the four non-negotiables, the genre template, the voice rules. Quote the offending line.
+- **cutter** (sonnet) — filler, reassurance, throat-clearing, paragraphs that delete without loss. Quote what to cut.
+- **`content-evaluator` agent** (opus) — the standing editor agent, unmodified. It reads for argument quality, audience fit and structural problems the three narrow lenses are not looking for. Take its Critical findings as candidate blockers and its rating as a signal, not a gate.
+
+Dispatch all four together. **No reviewer holds the barrier forever**: once the others are in, wait a little longer, then proceed without the missing one and name which lens was skipped wherever you report the result. A review someone knows is partial beats a loop that never ends.
+
+Then: **validate each finding yourself before fixing it.** A reviewer that misread the page produces a finding that makes the page worse. Check the claim against the draft; drop the ones that do not hold.
+
+**Blocking** — fix these, then re-run the loop:
+
+- the reader could not complete the task
+- a non-negotiable is missing
+- a code block does not run
+- a claim is false
+
+Everything else — voice nits, a clunky sentence, a suggested extra example — is **non-blocking**: report it, do not fix it, do not re-run for it. Without that line the loop never ends, because there is always one more sentence to improve.
+
+**Maximum three iterations.** A blocker surviving three rounds means the page has a design problem underneath it — a missing prerequisite, an undocumented feature it stands on — and a fourth round will not find it. Stop; the page is still worth keeping, and the judgement about it is not yours.
+
+**Ship it and make the blockers impossible to miss.** Open the PR, and surface what is unresolved in three places, because each one reaches a reader the others do not:
+
+1. **The PR title** carries the bare tag `[BLOCKED]`. Nothing else — details go in the body. A reviewer scanning the list sees it without opening anything.
+2. **The PR body** opens with a `## Blocking, unresolved` section: each blocker, which lens raised it, what you tried across the three rounds, and what you think it needs. This is what the reviewer reads.
+3. **The session that produced it** gets linked from that section. A blocker's whole context — the drafts, the findings you dropped as invalid, the three rounds of reasoning — lives in the session and nowhere else, and a reviewer who has to reconstruct it will instead just merge or close. In a cloud or scheduled run, paste the session URL. Where there is no shareable URL, say so in that line and name what the reviewer would have to re-derive, so the gap is visible rather than assumed away.
+
+Running unattended (the `docs-autofill` routine), add its fourth channel: DM Bauke on Slack rather than only posting to the channel. A `[BLOCKED]` PR nobody opens is a blocker nobody read.
+
+The aim above all of this is that someone unfamiliar can complete the task from the page alone. That is the goal, not the gate: no agent can certify it, which is why the reader lens exists.
+
+---
+
+*Keeping this file useful: it stays one file while it is under ~250 lines. When the examples push past that, split them into `patterns.md` and point at it from here — a drafting agent needs them, a reviewing one does not.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ This runs 3 personas × 3 scenarios for agent simulation and a small hybrid red-
 
 Reviewers need no flag: `.github/CODEOWNERS` requests them on every PR and skips the author. Change that file, not the `gh` invocation, to change who reviews.
 
+**The ticket is named by its id in the PR title, and by nothing else anywhere.** Put it in trailing parentheses after a conventional-commit subject — `docs: unwrap every hard-wrapped markdown file (RES-1495)`. No Linear URL in the title, the body, a comment or a commit message: the id is what a reader greps, quotes in Slack and types into search, and a pasted URL rots the moment a workspace or slug changes while the id never does. Linear links the two directions on its own from the id plus the PR attachment. The cost to know: dropping the `Closes <id>` line means **merging will not close the ticket** — move it yourself, or say so in the PR.
+
 ## Before pushing to a PR
 
 Run the same checks CI runs, **verbatim**, before every push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,14 +251,11 @@ Releases are **tag-driven**. The package version comes from the latest git tag v
 
 1. `docs-drift` skill, scoped to the diff — finds claims the change made untrue.
 2. `docs-coverage` skill — if the change opens a new usage path (a new mode, backend, surface, entry point), write the prose now rather than deferring it.
+3. `docs-writing` skill — **before drafting or rewriting any page under `docs/`.** It holds the reader, the three page genres, the voice, the four things every page carries, and the reviewer loop that gates a draft. The page-level mechanics live there too: fencing, the two `mkdocs.yml` entries a new page needs, and naming a current model in every example.
 
-The interaction surface those skills reason about — the axes, the tier rules, and the impossible-combination list — is [`.claude/skills/docs-coverage/axes.md`](.claude/skills/docs-coverage/axes.md). Read it when adding anything users choose between; **a new dimension means editing that file in the same PR**, or coverage checking silently stops seeing it.
+The interaction surface `docs-coverage` reasons about — the axes, the tier rules, and the impossible-combination list — is [`.claude/skills/docs-coverage/axes.md`](.claude/skills/docs-coverage/axes.md). Read it when adding anything users choose between; **a new dimension means editing that file in the same PR**, or coverage checking silently stops seeing it.
 
-Rules live in the skills, not here. Both are under `.claude/skills/`.
-
-**Docs examples name a current model.** A sample that says `gpt-4o-mini` dates the page the moment a reader sees it, and the reader copies it. The catalog is the source of truth for what is current: `orq models list --json` returns a `created` timestamp per entry, so `model_developer == 'openai' and model_type == 'chat'`, sorted by `created` descending, gives the latest OpenAI family in one command. As of 2026-08-28 that is **gpt-5.6** — `gpt-5.6-luna` (cheap, and the value of `DEFAULT_PIPELINE_MODEL`), `gpt-5.6-terra` (mid), `gpt-5.6-sol` (premium). Do not write `gpt-4o*`, `gpt-4.1*` or `gpt-5-*` into a new example; prefer `gpt-5.6-luna` unless the sample is specifically about a bigger model. Re-run the query rather than trusting this line — it is a date-stamped fact in a file that does not know today's date.
-
-**A new docs page goes in `mkdocs.yml` twice.** Once under `nav:`, once under `plugins.llmstxt.sections` — the llmstxt plugin silently drops any nav page it does not list from `llms.txt` and `llms-full.txt` without failing the build, so `docs/hooks.py` fails `--strict` on the mismatch instead. The check is one-directional (nav → sections) and accepts globs, which is why `reference/evaluatorq/*.md` covers the generated API pages with one entry.
+Rules live in the skills, not here. All of them are under `.claude/skills/`. The three rules below stay in this file because they bind outside a docs page — in a docstring, a commit message, a PR body — where no docs skill is loaded.
 
 **Never cut a sentence off.** Every sentence you write — in a docs page, a table cell, a docstring, a commit message, a PR title or body — ends. No trailing `…`, no `[...]`, no clause abandoned mid-thought because the line got long. Truncation belongs to *captured output* (a log excerpt, a receipt's first few lines), never to prose you authored. Too long is a signal to write less, not to chop the tail off. This binds humans, agents, and the docs-autofill routine equally.
 

--- a/docs/structured-results.md
+++ b/docs/structured-results.md
@@ -12,7 +12,7 @@ class EvaluationResultCell(BaseModel):
 
 `type` is free-form and uninterpreted — nothing in evaluatorq branches on it. It travels with the result so you can tell cells apart when you read them back.
 
-A sub-score is `str | int | float`, or a `dict` nested one level deeper. **Not `bool`, and not a list.** A list raises a validation error, and `True` is silently coerced to `1` — build a per-category pass map out of booleans and you get integers back with nothing to tell you why. Two more edges of the same type: inside a nested dict an `int` comes back as a `float` (`{"a": {"b": 2}}` reads back `2.0`), and a third level of nesting raises.
+A sub-score is `str | int | float`, or a `dict` — and that dict's values may themselves be dicts of scalars. **Not `bool`, and not a list.** A list raises a validation error, and `True` is silently coerced to `1` — build a per-category pass map out of booleans and you get integers back with nothing to tell you why. Two more edges of the same kind: an `int` below the top level comes back as a `float` (`{"a": {"b": 2}}` reads back `{"a": {"b": 2.0}}`), and nesting a dict deeper than that raises.
 
 ## A complete evaluation
 
@@ -86,7 +86,7 @@ for result in results:
             print(evaluator_score.evaluator_name, cell.type, cell.value["relevance"])
 ```
 
-Both guards are load-bearing, not tidiness. `job_results` and `evaluator_scores` are optional, and a datapoint whose job raised has neither. The `isinstance` check is what keeps this loop alive once you add a second evaluator: a plain float scorer puts a `float` there, and a scorer that *raised* puts an empty string there with the exception on `evaluator_score.error` — both would crash the `cell.type` access.
+Both guards are load-bearing, not tidiness. A datapoint that failed *before* its jobs ran has `job_results=None`, and a job that raised has an empty `evaluator_scores` — the `or []` covers both. The `isinstance` check is what keeps this loop alive once you add a second evaluator: a plain float scorer puts a `float` there, and a scorer that *raised* puts an empty string there with the exception on `evaluator_score.error` — both would crash the `cell.type` access.
 
 ## Sentiment distribution
 
@@ -138,11 +138,11 @@ The keyword checks here keep the examples runnable offline. Real axes usually co
 
 ## What structured results do not do
 
-**Sub-scores are never aggregated.** The summary table renders a structured cell as the literal `[structured]` and stops there: no per-key mean, no per-key trend, no per-datapoint breakdown anywhere in the terminal output. Three float evaluators give you three averages; one cell with three keys gives you a placeholder. The `pass_` flag is the only aggregated signal a structured evaluator contributes, which is why the safety example sets it.
+**Sub-scores are never aggregated.** The summary table renders a structured cell as the literal `[structured]` and stops there: no per-key mean, no per-key trend, no per-datapoint breakdown anywhere in the terminal output. Three float evaluators give you three averages; one cell with three keys gives you a placeholder. The `pass_` flag is the only aggregated signal a structured evaluator contributes to a CI gate, which is why the safety example sets it — the summary table shows `[structured]` either way.
 
 The full value is preserved outside the terminal — in the results object above, and in the payload uploaded to the Orq platform when `ORQ_API_KEY` is set. With no key set, nothing is uploaded and nothing is said about it; the run is otherwise identical.
 
-**On OpenTelemetry spans the cell can disappear, and it is `evaluator_type` that decides.** An evaluator that does not set it — every evaluator on this page — gets exactly one span copy of the score, in the `orq.score` attribute, and Orq ingestion drops that attribute whole past 512 characters rather than truncating it. A rubric with ten keys and long names clears 512 easily, and nothing logs the loss. Declare the kind to get the second copy, which is written to blob storage and is not size-capped:
+**On OpenTelemetry spans the cell can disappear, and it is `evaluator_type` that decides.** An evaluator that does not set it — every evaluator on this page — gets exactly one span copy of the score, in the `orq.score` attribute, and Orq ingestion drops that attribute whole past 512 characters rather than truncating it. A rubric with ten keys and long names clears 512 easily, and nothing logs the loss. Declare the kind to get the second copy, which is routed to blob storage and so is not subject to that 512-character attribute cap:
 
 ```python
 rubric_evaluator: Evaluator = {

--- a/docs/structured-results.md
+++ b/docs/structured-results.md
@@ -1,6 +1,8 @@
 # Structured Results
 
-Some evaluators do not produce one number. A quality rubric has several axes, a safety check has a score per category, a sentiment breakdown is a distribution. `EvaluationResultCell` lets an evaluator return all of them from a single call instead of splitting one judgement across several evaluators.
+`EvaluationResultCell` is an evaluator result that carries several named sub-scores instead of one number. A quality rubric has axes, a safety check has a score per category, a sentiment breakdown is a distribution — a cell returns all of them from a single evaluator.
+
+Reach for it when one judgement genuinely has axes and you want them kept together. Not when you have two independent judgements: separate evaluators each returning a float get a row each in the summary table with an average per job, and a cell does not — see [What structured results do not do](#what-structured-results-do-not-do) before you choose.
 
 ```python
 class EvaluationResultCell(BaseModel):
@@ -8,18 +10,34 @@ class EvaluationResultCell(BaseModel):
     value: dict[str, EvaluationResultCellValue]
 ```
 
-## Multi-criteria rubric
+`type` is free-form and uninterpreted — nothing in evaluatorq branches on it. It travels with the result so you can tell cells apart when you read them back.
+
+A sub-score is `str | int | float`, or a `dict` nested one level deeper. **Not `bool`, and not a list.** A list raises a validation error, and `True` is silently coerced to `1` — build a per-category pass map out of booleans and you get integers back with nothing to tell you why. Two more edges of the same type: inside a nested dict an `int` comes back as a `float` (`{"a": {"b": 2}}` reads back `2.0`), and a third level of nesting raises.
+
+## A complete evaluation
+
+Job, scorer, evaluator, run. This is the whole program — no API key needed, since the scorer here is plain Python rather than an LLM judge.
 
 ```python
-from evaluatorq import DataPoint, EvaluationResult, EvaluationResultCell, evaluatorq, job
+import asyncio
+
+from evaluatorq import (
+    DataPoint,
+    EvaluationResult,
+    EvaluationResultCell,
+    Evaluator,
+    ScorerParameter,
+    evaluatorq,
+    job,
+)
 
 
 @job("echo")
-async def echo_job(data: DataPoint, row: int):
-    return data.inputs["text"]
+async def echo_job(data: DataPoint, _row: int) -> str:
+    return str(data.inputs["text"])
 
 
-async def rubric_scorer(params):
+async def rubric_scorer(params: ScorerParameter) -> EvaluationResult:
     text = str(params["output"])
     return EvaluationResult(
         value=EvaluationResultCell(
@@ -32,12 +50,48 @@ async def rubric_scorer(params):
         ),
         explanation="Multi-criteria quality rubric",
     )
+
+
+rubric_evaluator: Evaluator = {"name": "rubric", "scorer": rubric_scorer}
+
+
+async def run():
+    return await evaluatorq(
+        "structured-rubric",
+        data=[DataPoint(inputs={"text": "The quick brown fox jumps over the lazy dog."})],
+        jobs=[echo_job],
+        evaluators=[rubric_evaluator],
+    )
+
+
+if __name__ == "__main__":
+    results = asyncio.run(run())
 ```
+
+The other two examples on this page are scorers only. Give each one its own `Evaluator` dict and add it to `evaluators=`.
+
+## Reading the sub-scores back
+
+The terminal table will not show you these numbers (see below), so reading them in code is the normal way to get at them. The value is nested twice: `EvaluatorScore.score` is an `EvaluationResult`, its `.value` is the cell, and the cell's `.value` is your dict.
+
+Append this to the script above, after `results = asyncio.run(run())`:
+
+```python
+for result in results:
+    for job_result in result.job_results or []:
+        for evaluator_score in job_result.evaluator_scores or []:
+            cell = evaluator_score.score.value
+            if not isinstance(cell, EvaluationResultCell):
+                continue
+            print(evaluator_score.evaluator_name, cell.type, cell.value["relevance"])
+```
+
+Both guards are load-bearing, not tidiness. `job_results` and `evaluator_scores` are optional, and a datapoint whose job raised has neither. The `isinstance` check is what keeps this loop alive once you add a second evaluator: a plain float scorer puts a `float` there, and a scorer that *raised* puts an empty string there with the exception on `evaluator_score.error` — both would crash the `cell.type` access.
 
 ## Sentiment distribution
 
 ```python
-async def sentiment_scorer(params):
+async def sentiment_scorer(params: ScorerParameter) -> EvaluationResult:
     text = str(params["output"]).lower()
     positive_words = ["good", "great", "excellent", "happy", "love"]
     negative_words = ["bad", "terrible", "awful", "sad", "hate"]
@@ -63,7 +117,7 @@ async def sentiment_scorer(params):
 Structured scores combine with the `pass_` flag, so a run can carry a per-category breakdown *and* gate CI on the worst category:
 
 ```python
-async def safety_scorer(params):
+async def safety_scorer(params: ScorerParameter) -> EvaluationResult:
     text = str(params["output"]).lower()
     categories = {
         "hate_speech": 0.8 if "hate" in text else 0.1,
@@ -80,11 +134,28 @@ async def safety_scorer(params):
 
 See [Evaluation Reference](evaluation-reference.md#passfail-and-ci) for how to inspect `pass_` and add an explicit process exit in a CI script.
 
-!!! note "Display vs. storage"
-    Structured results render as `[structured]` in the terminal table — the breakdown does not fit a cell. The full value is preserved in what is sent to the Orq platform and written to OpenTelemetry spans.
+The keyword checks here keep the examples runnable offline. Real axes usually come from an LLM judge, and you assemble the cell yourself: call the model in your scorer, then put the parsed axes into `EvaluationResultCell`. [LLM as a Jury](llm-as-a-jury.md) does not do this for you — a jury returns one aggregated verdict, not a cell.
+
+## What structured results do not do
+
+**Sub-scores are never aggregated.** The summary table renders a structured cell as the literal `[structured]` and stops there: no per-key mean, no per-key trend, no per-datapoint breakdown anywhere in the terminal output. Three float evaluators give you three averages; one cell with three keys gives you a placeholder. The `pass_` flag is the only aggregated signal a structured evaluator contributes, which is why the safety example sets it.
+
+The full value is preserved outside the terminal — in the results object above, and in the payload uploaded to the Orq platform when `ORQ_API_KEY` is set. With no key set, nothing is uploaded and nothing is said about it; the run is otherwise identical.
+
+**On OpenTelemetry spans the cell can disappear, and it is `evaluator_type` that decides.** An evaluator that does not set it — every evaluator on this page — gets exactly one span copy of the score, in the `orq.score` attribute, and Orq ingestion drops that attribute whole past 512 characters rather than truncating it. A rubric with ten keys and long names clears 512 easily, and nothing logs the loss. Declare the kind to get the second copy, which is written to blob storage and is not size-capped:
+
+```python
+rubric_evaluator: Evaluator = {
+    "name": "rubric",
+    "scorer": rubric_scorer,
+    "evaluator_type": "python_eval",
+}
+```
 
 ## Runnable examples
 
-- [`structured_rubric_eval.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/lib/structured/structured_rubric_eval.py) — multi-criteria quality rubric
-- [`structured_sentiment_eval.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/lib/structured/structured_sentiment_eval.py) — sentiment distribution breakdown
-- [`structured_safety_eval.py`](https://github.com/orq-ai/evaluatorq/blob/main/examples/lib/structured/structured_safety_eval.py) — safety scores with pass/fail tracking
+- [`structured_rubric_eval.py`](examples/lib/structured/structured_rubric_eval.md) — multi-criteria quality rubric
+- [`structured_sentiment_eval.py`](examples/lib/structured/structured_sentiment_eval.md) — sentiment distribution breakdown
+- [`structured_safety_eval.py`](examples/lib/structured/structured_safety_eval.md) — safety scores with pass/fail tracking
+
+Next: [Evaluation Reference](evaluation-reference.md#custom-evaluators) for the scorer contract and the rest of the run mechanics.

--- a/docs/structured-results.md
+++ b/docs/structured-results.md
@@ -12,7 +12,7 @@ class EvaluationResultCell(BaseModel):
 
 `type` is free-form and uninterpreted — nothing in evaluatorq branches on it. It travels with the result so you can tell cells apart when you read them back.
 
-A sub-score is `str | int | float`, or a `dict` — and that dict's values may themselves be dicts of scalars. **Not `bool`, and not a list.** A list raises a validation error, and `True` is silently coerced to `1` — build a per-category pass map out of booleans and you get integers back with nothing to tell you why. Two more edges of the same kind: an `int` below the top level comes back as a `float` (`{"a": {"b": 2}}` reads back `{"a": {"b": 2.0}}`), and nesting a dict deeper than that raises.
+A sub-score is `str | int | float`, or a `dict` — and that dict's values may themselves be dicts of scalars. **Not `bool`, and not a list.** A list raises a validation error, and `True` is silently coerced to `1` — build a per-category pass map out of booleans and you get integers back with nothing to tell you why. Two more edges of the same kind: an `int` below the top level comes back as a `float` (`{"a": {"b": 2}}` reads back `{"a": {"b": 2.0}}`), and one dict layer beyond that raises — `{"a": {"b": {"c": 2}}}` is accepted, `{"a": {"b": {"c": {"d": 2}}}}` is not.
 
 ## A complete evaluation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,8 +26,7 @@ examples/lib/
 │   └── langchain/                   # LangChain / LangGraph
 │       ├── langchain_integration_example.py   # Basic LangChain agent eval
 │       ├── langgraph_integration_example.py   # Basic LangGraph agent eval
-│       ├── langgraph_research_eval.py         # Research agent with dynamic instructions
-│       └── langgraph_dataset_eval.py          # Dataset-based LangGraph eval
+│       └── langgraph_research_eval.py         # Research agent with dynamic instructions
 ├── cli/                             # CLI integration examples
 │   ├── example_using_cli.py
 │   ├── example_using_cli_two.py
@@ -52,7 +51,6 @@ uv run examples/lib/structured/structured_rubric_eval.py
 
 # Integrations (requires OPENAI_API_KEY)
 ORQ_API_KEY=... OPENAI_API_KEY=... uv run examples/lib/integrations/langchain/langgraph_research_eval.py
-ORQ_API_KEY=... OPENAI_API_KEY=... DATASET_ID=... uv run examples/lib/integrations/langchain/langgraph_dataset_eval.py
 
 # CLI
 uv run examples/lib/cli/example_using_cli.py

--- a/examples/lib/datasets/country_unit_test.py
+++ b/examples/lib/datasets/country_unit_test.py
@@ -13,7 +13,7 @@ Prerequisites:
   - Set ORQ_API_KEY environment variable
 
 Usage:
-  ORQ_API_KEY=your-key python examples/country_unit_test.py
+  ORQ_API_KEY=your-key python examples/lib/datasets/country_unit_test.py
 """
 
 import asyncio

--- a/examples/lib/datasets/country_unit_test.py
+++ b/examples/lib/datasets/country_unit_test.py
@@ -13,7 +13,7 @@ Prerequisites:
   - Set ORQ_API_KEY environment variable
 
 Usage:
-  ORQ_API_KEY=your-key python examples/lib/datasets/country_unit_test.py
+  ORQ_API_KEY=your-key uv run python examples/lib/datasets/country_unit_test.py
 """
 
 import asyncio

--- a/examples/lib/structured/path_organization.py
+++ b/examples/lib/structured/path_organization.py
@@ -17,7 +17,7 @@ Prerequisites:
   - Set ORQ_API_KEY environment variable
 
 Usage:
-  ORQ_API_KEY=your-key python examples/path_organization.py
+  ORQ_API_KEY=your-key python examples/lib/structured/path_organization.py
 """
 
 import asyncio

--- a/examples/lib/structured/path_organization.py
+++ b/examples/lib/structured/path_organization.py
@@ -17,7 +17,7 @@ Prerequisites:
   - Set ORQ_API_KEY environment variable
 
 Usage:
-  ORQ_API_KEY=your-key python examples/lib/structured/path_organization.py
+  ORQ_API_KEY=your-key uv run python examples/lib/structured/path_organization.py
 """
 
 import asyncio

--- a/examples/lib/structured/structured_rubric_eval.py
+++ b/examples/lib/structured/structured_rubric_eval.py
@@ -5,7 +5,7 @@ Demonstrates returning structured EvaluationResultCell values with
 multiple sub-scores per evaluator.
 
 Usage:
-    python examples/lib/structured/structured_rubric_eval.py
+    uv run python examples/lib/structured/structured_rubric_eval.py
 """
 
 import asyncio

--- a/examples/lib/structured/structured_rubric_eval.py
+++ b/examples/lib/structured/structured_rubric_eval.py
@@ -5,7 +5,7 @@ Demonstrates returning structured EvaluationResultCell values with
 multiple sub-scores per evaluator.
 
 Usage:
-    python examples/structured_rubric_eval.py
+    python examples/lib/structured/structured_rubric_eval.py
 """
 
 import asyncio

--- a/examples/lib/structured/structured_safety_eval.py
+++ b/examples/lib/structured/structured_safety_eval.py
@@ -5,7 +5,7 @@ Demonstrates returning structured EvaluationResultCell values
 with per-category safety severity scores and pass/fail tracking.
 
 Usage:
-    python examples/structured_safety_eval.py
+    python examples/lib/structured/structured_safety_eval.py
 """
 
 import asyncio

--- a/examples/lib/structured/structured_safety_eval.py
+++ b/examples/lib/structured/structured_safety_eval.py
@@ -5,7 +5,7 @@ Demonstrates returning structured EvaluationResultCell values
 with per-category safety severity scores and pass/fail tracking.
 
 Usage:
-    python examples/lib/structured/structured_safety_eval.py
+    uv run python examples/lib/structured/structured_safety_eval.py
 """
 
 import asyncio

--- a/examples/lib/structured/structured_sentiment_eval.py
+++ b/examples/lib/structured/structured_sentiment_eval.py
@@ -5,7 +5,7 @@ Demonstrates returning structured EvaluationResultCell values
 with sentiment distribution across categories.
 
 Usage:
-    python examples/structured_sentiment_eval.py
+    python examples/lib/structured/structured_sentiment_eval.py
 """
 
 import asyncio

--- a/examples/lib/structured/structured_sentiment_eval.py
+++ b/examples/lib/structured/structured_sentiment_eval.py
@@ -5,7 +5,7 @@ Demonstrates returning structured EvaluationResultCell values
 with sentiment distribution across categories.
 
 Usage:
-    python examples/lib/structured/structured_sentiment_eval.py
+    uv run python examples/lib/structured/structured_sentiment_eval.py
 """
 
 import asyncio

--- a/examples/pairwise/bt_sigma_ranking.py
+++ b/examples/pairwise/bt_sigma_ranking.py
@@ -18,7 +18,7 @@ defaults). Needs ORQ_API_KEY.
 Usage:
 
 ```bash
-python examples/pairwise/bt_sigma_ranking.py [STRONG WEAK_1 WEAK_2]
+uv run python examples/pairwise/bt_sigma_ranking.py [STRONG WEAK_1 WEAK_2]
 ```
 """
 


### PR DESCRIPTION
## Why

The repo has four docs skills and all of them check prose without ever teaching it. `docs-drift` verifies claims, `docs-coverage` finds gaps, `docs-autofill` drafts unattended, `mkdocs-material` handles the build. Nothing said what a good page looks like, so every draft rediscovered the house voice from scratch — and `docs-autofill` in particular writes with no human in the loop and no voice guidance at all.

## The skill

`.claude/skills/docs-writing/SKILL.md` holds:

- The assumed reader — an ML/AI engineer already shipping LLM apps, landing from a search result — and the jargon budget that follows: eval-domain terms defined on first use per page, general Python and LLM terms free.
- Three genres, each with an opening pattern and a length bound: tutorial (≤ 800 words), guide (≤ 2500), reference (uncapped, bounded by the surface).
- Four non-negotiables every page carries: a one-line definition, a scope line, a runnable example, a named failure mode.
- Eight voice rules, each anchored to a real before/after pair taken from `guides/targets.md`, `tuning.md` and `guides/getting-started.md` rather than invented.
- Page-level mechanics: fencing, the two `mkdocs.yml` entries a new page needs, naming a current model.
- A reviewer loop: three narrow sonnet lenses (reader, conformance, cutter) plus the opus `content-evaluator` agent, every finding validated before it is applied, an explicit blocking list so the loop terminates, and a three-iteration cap that ships a `[BLOCKED]` PR rather than looping.

`CLAUDE.md` hands off to it as step 3 of the docs checklist and gives up the two rules the skill now owns. Three rules stay in `CLAUDE.md` deliberately — they bind in a docstring, a commit message or a PR body, where no docs skill is loaded, so moving them would have silently stopped them binding.

## The page

`docs/structured-results.md` was the first page run through the loop, over three rounds. What it found and the page now fixes:

- The page imported `evaluatorq`, defined a job, and called neither. A reader landing from search had three scorer functions and no way to run one. The first example is now a complete program that executes offline with no API key.
- The terminal never shows the sub-scores, and the page did not say how to get them. There is now a read-back section, with both of its guards explained rather than presented as tidiness — a float evaluator and a scorer that raised both put a non-cell in the same slot, so the `isinstance` check is what keeps the loop alive when the reader adds their second evaluator.
- `EvaluationResultCellValue` appeared in a signature and was never defined. It is now spelled out with its silent edges: `bool` coerces to `1`, a list raises, an `int` below the top level reads back as a `float`, and a dict nested deeper than two levels raises.
- Nothing stated the trade. Sub-scores are never aggregated: three float evaluators give three averages, one cell with three keys gives a `[structured]` placeholder. That is now a section, and it is the reason the scope line at the top says what it says.
- The tracing note claimed the full value is preserved. It now names `evaluator_type` as the switch that decides — without it an evaluator gets exactly one span copy of the score, in an attribute Orq ingestion drops whole past 512 characters rather than truncating, with nothing logged.

Every code block on the page was executed in document order. The `evaluator_type` gate, both read-back guards, the `bool`/list/nesting coercions, and the `[structured]` placeholder were each verified against the running library rather than read off the source.

## The example usage lines

Five example docstrings told the reader to run a path that does not exist — the files moved under `examples/lib/` and the usage lines stayed behind. These lines render verbatim onto the generated example pages, so the broken path was published, not merely stale in the repo. The same five also invoked bare `python`, which in a uv project reaches whichever interpreter is first on `PATH` — usually one without evaluatorq installed — so a reader would have hit an `ImportError` immediately after the path was fixed. Both are corrected: real paths, `uv run python`, env-var prefixes kept ahead of the runner.

`examples/README.md` also listed `langgraph_dataset_eval.py` in its tree and gave a command to run it. That file has never existed — PR #54 added four files under `langchain/` and a README describing five — so both references are removed rather than repaired. A dataset-based LangGraph example may still be worth having, but that is one to write, not a reference to fix.

Verified two ways rather than by eye: the documented command was executed for the rubric example, and every `examples/**.py` path referenced in any tracked file now resolves. The first version of that sweep searched only `*.py` files for references, so it could not see a dead link in a README — which is how the README one survived it.

## What the dry run says about the loop itself

Worth recording, since it is the argument for the design:

- The opus editor found every Critical; the three narrow sonnet lenses found the mechanical conformance gaps it did not enumerate. Neither tier was redundant.
- **Each round found a defect introduced by the previous round's fix.** Round 2's rewrite asserted the span value is written twice, which is only true when `evaluator_type` is set and none of the page's evaluators set it. Round 3 then caught two more: the nesting depth was wrong in both directions, and the `or []` explanation described a failure case that does not occur. All three were false statements about behaviour, not matters of taste — a single-pass review ships all three.
- The validation step earned its place immediately. One finding was dropped as not holding (a suggested `Use it when` table that would have partitioned nothing), two were downgraded as overstated, one upgraded. A reviewer-invented `evaluator_type` value was replaced with the codebase's own vocabulary.
- The lenses disagreed twice, and both disagreements were legitimate rather than noise. That is the case for perspective diversity over more reviewers of the same kind.

## Checks

- `uv run --group docs mkdocs build --strict` — clean, exit 0.
- Every Python block on the changed page executed in document order, offline, with `ORQ_API_KEY` unset.
- No changes under `src/`.

## One more CLAUDE.md rule

`CLAUDE.md` gains a rule requiring the ticket to be named by its id in the PR title and by no URL anywhere — `docs: … (RES-1495)`. The id is what a reader greps, quotes in Slack and types into search, and a pasted Linear URL rots the moment a workspace or slug changes while the id never does. Linear links both directions from the id plus the PR attachment, so the URL buys nothing.

It is here rather than in its own PR because this PR is what exposed the problem, and because the rule states a cost that only shows up when you follow it: dropping the `Closes <id>` line is what stops a merge from closing the ticket, so whoever drops it moves the ticket by hand. This PR is the first case — RES-1495 is closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
