### PR TITLE
feat: export evaluatorq.__version__

### DIFF
--- a/src/evaluatorq/__init__.py
+++ b/src/evaluatorq/__init__.py
@@ -1,5 +1,6 @@
 """EvaluatorQ Python - An evaluation framework for LLM applications."""
 
+import importlib.metadata
 import importlib.util
 import sys
 
@@ -23,6 +24,11 @@ def _require_core_deps() -> None:  # noqa: RUF067
 
 
 _require_core_deps()  # noqa: RUF067
+
+try:  # noqa: RUF067
+    __version__ = importlib.metadata.version('evaluatorq')
+except importlib.metadata.PackageNotFoundError:  # ponytail: source checkout, not installed
+    __version__ = '0.0.0.dev0'
 
 from .contracts import AgentResponse
 from .deployment import (
@@ -112,6 +118,7 @@ __all__ = [
     'Scorer',
     'ScorerParameter',
     'ThreadConfig',
+    '__version__',
     'bt_sigma_aggregation',
     'build_report',
     # Deployment helpers

--- a/src/evaluatorq/cli.py
+++ b/src/evaluatorq/cli.py
@@ -48,9 +48,9 @@ app = typer.Typer(
 
 def _version_callback(value: bool) -> None:  # noqa: FBT001
     if value:
-        from importlib.metadata import version
+        from evaluatorq import __version__
 
-        typer.echo(f'evaluatorq {version("evaluatorq")}')
+        typer.echo(f'evaluatorq {__version__}')
         raise typer.Exit
 
 

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,9 @@
+"""`evaluatorq.__version__` is exported and is a string."""
+
+import evaluatorq
+
+
+def test_version_is_exported_string() -> None:
+    assert isinstance(evaluatorq.__version__, str)
+    assert evaluatorq.__version__
+    assert '__version__' in evaluatorq.__all__


### PR DESCRIPTION
`import evaluatorq; print(evaluatorq.__version__)` works now. It reads installed package metadata (the version is tag-driven via hatch-vcs, so metadata is the only place the real number lives), and falls back to `0.0.0.dev0` when the package is imported from a source checkout that was never installed.

`eq --version` now prints that same attribute instead of calling `importlib.metadata.version('evaluatorq')` itself, so the CLI and the library cannot drift apart.

`__version__` is added to `__all__`. No build-config change, no generated `_version.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)